### PR TITLE
Nodes selected by default

### DIFF
--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -538,7 +538,9 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 		d.Set("node_filter_exclude_precedence", job.NodeFilter.ExcludePrecedence)
 	}
 
-	d.Set("nodes_selected_by_default", job.NodesSelectedByDefault)
+	if job.NodesSelectedByDefault {
+		d.Set("nodes_selected_by_default", job.NodesSelectedByDefault)
+	}
 
 	optionConfigsI := []interface{}{}
 	if job.OptionsConfig != nil {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -109,6 +109,7 @@ func resourceRundeckJob() *schema.Resource {
 			"nodes_selected_by_default": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 
 			"schedule": &schema.Schema{
@@ -483,10 +484,7 @@ func jobFromResourceData(d *schema.ResourceData) (*rundeck.JobDetail, error) {
 		}
 	}
 
-	// By default rundeck will set this option to false
-	if d.Get("nodes_selected_by_default").(bool) {
-		job.NodesSelectedByDefault = true
-	}
+	job.NodesSelectedByDefault = d.Get("nodes_selected_by_default")
 
 	if d.Get("schedule").(string) != "" {
 		job.ScheduleEnabled = d.Get("schedule_enabled").(bool)
@@ -552,9 +550,7 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 		d.Set("node_filter_query", nil)
 	}
 
-	if job.NodesSelectedByDefault {
-		d.Set("nodes_selected_by_default", job.NodesSelectedByDefault)
-	}
+	d.Set("nodes_selected_by_default", job.NodesSelectedByDefault)
 
 	optionConfigsI := []interface{}{}
 	if job.OptionsConfig != nil {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -484,7 +484,7 @@ func jobFromResourceData(d *schema.ResourceData) (*rundeck.JobDetail, error) {
 		}
 	}
 
-	job.NodesSelectedByDefault = d.Get("nodes_selected_by_default")
+	job.NodesSelectedByDefault = d.Get("nodes_selected_by_default").(bool)
 
 	if d.Get("schedule").(string) != "" {
 		job.ScheduleEnabled = d.Get("schedule_enabled").(bool)

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -466,11 +466,11 @@ func jobFromResourceData(d *schema.ResourceData) (*rundeck.JobDetail, error) {
 
 	if d.Get("node_filter_query").(string) != "" {
 		job.NodeFilter = &rundeck.JobNodeFilter{
-			ExcludePrecedence: d.Get("node_filter_exclude_precedence").(bool),
-			Query:             d.Get("node_filter_query").(string),
+			Query: d.Get("node_filter_query").(string),
 		}
 	}
 
+	// By default rundeck will set this option to false
 	if d.Get("nodes_selected_by_default").(bool) {
 		job.NodesSelectedByDefault = true
 	}
@@ -531,11 +531,10 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 		d.Set("rank_order", nil)
 	}
 
-	d.Set("node_filter_query", nil)
-	d.Set("node_filter_exclude_precedence", nil)
 	if job.NodeFilter != nil {
 		d.Set("node_filter_query", job.NodeFilter.Query)
-		d.Set("node_filter_exclude_precedence", job.NodeFilter.ExcludePrecedence)
+	} else {
+		d.Set("node_filter_query", nil)
 	}
 
 	if job.NodesSelectedByDefault {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -100,6 +100,11 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"nodes_selected_by_default": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"schedule": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -466,6 +471,10 @@ func jobFromResourceData(d *schema.ResourceData) (*rundeck.JobDetail, error) {
 		}
 	}
 
+	if d.Get("nodes_selected_by_default").(bool) {
+		job.NodesSelectedByDefault = true
+	}
+
 	if d.Get("schedule").(string) != "" {
 		schedule := strings.Split(d.Get("schedule").(string), " ")
 		if len(schedule) != 7 {
@@ -528,6 +537,8 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 		d.Set("node_filter_query", job.NodeFilter.Query)
 		d.Set("node_filter_exclude_precedence", job.NodeFilter.ExcludePrecedence)
 	}
+
+	d.Set("nodes_selected_by_default", job.NodesSelectedByDefault)
 
 	optionConfigsI := []interface{}{}
 	if job.OptionsConfig != nil {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -56,6 +56,12 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"execution_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"max_thread_count": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -108,6 +114,12 @@ func resourceRundeckJob() *schema.Resource {
 			"schedule": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+
+			"schedule_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
 			},
 
 			"option": &schema.Schema{
@@ -355,6 +367,7 @@ func jobFromResourceData(d *schema.ResourceData) (*rundeck.JobDetail, error) {
 		Description:               d.Get("description").(string),
 		LogLevel:                  d.Get("log_level").(string),
 		AllowConcurrentExecutions: d.Get("allow_concurrent_executions").(bool),
+		ExecutionEnabled:          d.Get("execution_enabled").(bool),
 		Dispatch: &rundeck.JobDispatch{
 			MaxThreadCount:  d.Get("max_thread_count").(int),
 			ContinueOnError: d.Get("continue_on_error").(bool),
@@ -476,6 +489,7 @@ func jobFromResourceData(d *schema.ResourceData) (*rundeck.JobDetail, error) {
 	}
 
 	if d.Get("schedule").(string) != "" {
+		job.ScheduleEnabled = d.Get("schedule_enabled").(bool)
 		schedule := strings.Split(d.Get("schedule").(string), " ")
 		if len(schedule) != 7 {
 			return nil, fmt.Errorf("Rundeck schedule must be formated like a cron expression, as defined here: http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html")
@@ -519,6 +533,7 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 	d.Set("description", job.Description)
 	d.Set("log_level", job.LogLevel)
 	d.Set("allow_concurrent_executions", job.AllowConcurrentExecutions)
+	d.Set("execution_enabled", job.ExecutionEnabled)
 	if job.Dispatch != nil {
 		d.Set("max_thread_count", job.Dispatch.MaxThreadCount)
 		d.Set("continue_on_error", job.Dispatch.ContinueOnError)
@@ -625,6 +640,7 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 		schedule = append(schedule, job.Schedule.Year.Year)
 
 		d.Set("schedule", strings.Join(schedule, " "))
+		d.Set("schedule_enabled", job.ScheduleEnabled)
 	}
 
 	return nil

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -28,6 +28,9 @@ func TestAccJob_basic(t *testing.T) {
 						if expected := "Prints Hello World"; job.CommandSequence.Commands[0].Description != expected {
 							return fmt.Errorf("failed to set command description; expected %v, got %v", expected, job.CommandSequence.Commands[0].Description)
 						}
+						if expected := true; job.NodesSelectedByDefault != expected {
+							return fmt.Errorf("failed to set node selected by default; expected %v, got %v", expected, job.NodesSelectedByDefault)
+						}
 						return nil
 					},
 				),
@@ -91,6 +94,7 @@ resource "rundeck_job" "test" {
   name = "basic-job"
   description = "A basic job"
   node_filter_query = "example"
+  nodes_selected_by_default = true
   allow_concurrent_executions = 1
   max_thread_count = 1
   rank_order = "ascending"

--- a/vendor/github.com/apparentlymart/go-rundeck-api/rundeck/job.go
+++ b/vendor/github.com/apparentlymart/go-rundeck-api/rundeck/job.go
@@ -31,10 +31,12 @@ type JobDetail struct {
 	ProjectName               string              `xml:"context>project,omitempty"`
 	OptionsConfig             *JobOptions         `xml:"context>options,omitempty"`
 	Description               string              `xml:"description"`
+	ExecutionEnabled          bool                `xml:"executionEnabled"`
 	LogLevel                  string              `xml:"loglevel,omitempty"`
 	AllowConcurrentExecutions bool                `xml:"multipleExecutions,omitempty"`
 	Dispatch                  *JobDispatch        `xml:"dispatch,omitempty"`
 	CommandSequence           *JobCommandSequence `xml:"sequence,omitempty"`
+	Notification              *JobNotification    `xml:"notification,omitempty"`
 	Timeout                   string              `xml:"timeout,omitempty"`
 	Retry                     string              `xml:"retry,omitempty"`
 	NodeFilter                *JobNodeFilter      `xml:"nodefilters,omitempty"`
@@ -43,21 +45,52 @@ type JobDetail struct {
 	 * by this reason omitempty cannot be present.
 	 * This has to be handle by the user.
 	 */
-	NodesSelectedByDefault    bool                `xml:"nodesSelectedByDefault"`
-	Schedule                  *JobSchedule        `xml:"schedule"`
+	NodesSelectedByDefault bool         `xml:"nodesSelectedByDefault"`
+	Schedule               *JobSchedule `xml:"schedule,omitempty"`
+	ScheduleEnabled        bool         `xml:"scheduleEnabled"`
 }
 
+type Boolean struct {
+	Value bool `xml:",chardata"`
+}
+
+type JobNotification struct {
+	OnFailure *Notification `xml:"onfailure,omitempty"`
+	OnStart   *Notification `xml:"onstart,omitempty"`
+	OnSuccess *Notification `xml:"onsuccess,omitempty"`
+}
+
+type Notification struct {
+	Email   *EmailNotification   `xml:"email,omitempty"`
+	WebHook *WebHookNotification `xml:"webhook,omitempty"`
+	Plugin  *JobPlugin           `xml:"plugin"`
+}
+
+type EmailNotification struct {
+	AttachLog  bool               `xml:"attachLog,attr,omitempty"`
+	Recipients NotificationEmails `xml:"recipients,attr"`
+	Subject    string             `xml:"subject,attr"`
+}
+
+type NotificationEmails []string
+
+type WebHookNotification struct {
+	Urls NotificationUrls `xml:"urls,attr"`
+}
+
+type NotificationUrls []string
+
 type JobSchedule struct {
-	XMLName         xml.Name               `xml:"schedule"`
-	DayOfMonth      *JobScheduleDayOfMonth `xml:"dayofmonth,omitempty"`
-	Time            JobScheduleTime        `xml:"time"`
-	Month           JobScheduleMonth       `xml:"month"`
-	WeekDay         *JobScheduleWeekDay    `xml:"weekday,omitempty"`
-	Year            JobScheduleYear        `xml:"year"`
+	XMLName    xml.Name               `xml:"schedule"`
+	DayOfMonth *JobScheduleDayOfMonth `xml:"dayofmonth,omitempty"`
+	Time       JobScheduleTime        `xml:"time"`
+	Month      JobScheduleMonth       `xml:"month"`
+	WeekDay    *JobScheduleWeekDay    `xml:"weekday,omitempty"`
+	Year       JobScheduleYear        `xml:"year"`
 }
 
 type JobScheduleDayOfMonth struct {
-	XMLName      xml.Name `xml:"dayofmonth"`
+	XMLName xml.Name `xml:"dayofmonth"`
 }
 
 type JobScheduleMonth struct {
@@ -73,14 +106,14 @@ type JobScheduleYear struct {
 
 type JobScheduleWeekDay struct {
 	XMLName xml.Name `xml:"weekday"`
-	Day string   `xml:"day,attr"`
+	Day     string   `xml:"day,attr"`
 }
 
 type JobScheduleTime struct {
-	XMLName  xml.Name `xml:"time"`
-	Hour     string   `xml:"hour,attr"`
-	Minute   string   `xml:"minute,attr"`
-	Seconds  string   `xml:"seconds,attr"`
+	XMLName xml.Name `xml:"time"`
+	Hour    string   `xml:"hour,attr"`
+	Minute  string   `xml:"minute,attr"`
+	Seconds string   `xml:"seconds,attr"`
 }
 
 type jobDetailList struct {
@@ -143,7 +176,6 @@ type JobOption struct {
 	Description string `xml:"description,omitempty"`
 }
 
-
 // JobValueChoices is a specialization of []string representing a sequence of predefined values
 // for a job option.
 type JobValueChoices []string
@@ -173,7 +205,7 @@ type JobCommand struct {
 	XMLName xml.Name
 
 	// If the Workflow keepgoing is false, this allows the Workflow to continue when the Error Handler is successful.
-	ContinueOnError bool     `xml:"keepgoingOnSuccess,attr,omitempty"`
+	ContinueOnError bool `xml:"keepgoingOnSuccess,attr,omitempty"`
 
 	// Description
 	Description string `xml:"description,omitempty"`
@@ -223,6 +255,7 @@ type JobCommandJobRef struct {
 	Name           string                    `xml:"name,attr"`
 	GroupName      string                    `xml:"group,attr"`
 	RunForEachNode bool                      `xml:"nodeStep,attr"`
+	Dispatch       *JobDispatch              `xml:"dispatch,omitempty"`
 	NodeFilter     *JobNodeFilter            `xml:"nodefilters,omitempty"`
 	Arguments      JobCommandJobRefArguments `xml:"arg"`
 }
@@ -230,7 +263,7 @@ type JobCommandJobRef struct {
 // JobCommandJobRefArguments is a string representing the arguments in a JobCommandJobRef.
 type JobCommandJobRefArguments string
 
-// JobPlugin is a configuration for a plugin to run within a job.
+// Plugin is a configuration for a plugin to run within a job or notification.
 type JobPlugin struct {
 	XMLName xml.Name
 	Type    string          `xml:"type,attr"`
@@ -243,8 +276,7 @@ type JobPluginConfig map[string]string
 // JobNodeFilter describes which nodes from the project's resource list will run the configured
 // commands.
 type JobNodeFilter struct {
-	ExcludePrecedence bool   `xml:"excludeprecedence"`
-	Query             string `xml:"filter,omitempty"`
+	Query string `xml:"filter,omitempty"`
 }
 
 type jobImportResults struct {
@@ -267,10 +299,11 @@ type jobImportResult struct {
 }
 
 type JobDispatch struct {
-	MaxThreadCount  int    `xml:"threadcount,omitempty"`
-	ContinueOnError bool   `xml:"keepgoing"`
-	RankAttribute   string `xml:"rankAttribute,omitempty"`
-	RankOrder       string `xml:"rankOrder,omitempty"`
+	ExcludePrecedence *Boolean `xml:"excludePrecedence"`
+	MaxThreadCount    int      `xml:"threadcount,omitempty"`
+	ContinueOnError   bool     `xml:"keepgoing"`
+	RankAttribute     string   `xml:"rankAttribute,omitempty"`
+	RankOrder         string   `xml:"rankOrder,omitempty"`
 }
 
 // GetJobSummariesForProject returns summaries of the jobs belonging to the named project.
@@ -343,6 +376,34 @@ func (c *Client) importJob(job *JobDetail, dupeOption string) (*JobSummary, erro
 // DeleteJob deletes the job with the given id.
 func (c *Client) DeleteJob(id string) error {
 	return c.delete([]string{"job", id})
+}
+
+func (c NotificationEmails) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	if len(c) > 0 {
+		return xml.Attr{name, strings.Join(c, ",")}, nil
+	} else {
+		return xml.Attr{}, nil
+	}
+}
+
+func (c *NotificationEmails) UnmarshalXMLAttr(attr xml.Attr) error {
+	values := strings.Split(attr.Value, ",")
+	*c = values
+	return nil
+}
+
+func (c NotificationUrls) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	if len(c) > 0 {
+		return xml.Attr{name, strings.Join(c, ",")}, nil
+	} else {
+		return xml.Attr{}, nil
+	}
+}
+
+func (c *NotificationUrls) UnmarshalXMLAttr(attr xml.Attr) error {
+	values := strings.Split(attr.Value, ",")
+	*c = values
+	return nil
 }
 
 func (c JobValueChoices) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {

--- a/vendor/github.com/apparentlymart/go-rundeck-api/rundeck/key.go
+++ b/vendor/github.com/apparentlymart/go-rundeck-api/rundeck/key.go
@@ -61,6 +61,14 @@ func (c *Client) ReplacePrivateKey(path string, content string) error {
 	return c.createOrReplacePublicKey("PUT", path, "application/octet-stream", content)
 }
 
+func (c *Client) CreatePassword(path string, content string) error {
+	return c.createOrReplacePublicKey("POST", path, "application/x-rundeck-data-password", content)
+}
+
+func (c *Client) ReplacePassword(path string, content string) error {
+	return c.createOrReplacePublicKey("PUT", path, "application/x-rundeck-data-password", content)
+}
+
 func (c *Client) createOrReplacePublicKey(method string, path string, contentType string, content string) error {
 	req := &request{
 		Method: method,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -11,15 +11,15 @@
 		{
 			"checksumSHA1": "+2yCNqbcf7VcavAptooQReTGiHY=",
 			"path": "github.com/apparentlymart/go-rundeck-api",
-			"revision": "f6af74d34d1ef69a511c59173876fc1174c11f0d",
-			"revisionTime": "2016-08-26T14:30:32Z"
+			"revision": "2c962acae81080a937c350a5bea054c239f27a81",
+			"revisionTime": "2017-07-05T17:22:45Z"
 		},
 		{
-			"checksumSHA1": "Z1MQQMA4d9pKVHeoC3H+DdK583s=",
+			"checksumSHA1": "uZt5wSURm4Iz1mdLuauSE8RhCeA=",
 			"comment": "v0.0.1-1-g43fcd8f",
 			"path": "github.com/apparentlymart/go-rundeck-api/rundeck",
-			"revision": "f6af74d34d1ef69a511c59173876fc1174c11f0d",
-			"revisionTime": "2016-08-26T14:30:32Z"
+			"revision": "2c962acae81080a937c350a5bea054c239f27a81",
+			"revisionTime": "2017-07-05T17:22:45Z"
 		},
 		{
 			"checksumSHA1": "fFU9OeM0pKWGL3D+Fa3PmHSjjLg=",

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -46,9 +46,13 @@ The following arguments are supported:
 
 * `schedule` - (Optional) The jobs schedule in Unix crontab format
 
+* `schedule_enabled` - (Optional) Set to false if you don't want the schedule to be active.
+
 * `allow_concurrent_executions` - (Optional) Boolean defining whether two or more executions of
   this job can run concurrently. The default is `false`, meaning that jobs will only run
   sequentially.
+
+* `execution_enabled` - (Optional) Set to false if you don't want the job to be active. No execution will be possible. The default is `true`.
 
 * `max_thread_count` - (Optional) The maximum number of threads to use to execute this job, which
   controls on how many nodes the commands can be run simulateneously. Defaults to 1, meaning that
@@ -79,6 +83,8 @@ The following arguments are supported:
 
 * `node_filter_exclude_precedence`: (Optional) Boolean controlling a deprecated Rundeck feature that controls
   whether node exclusions take priority over inclusions.
+
+* `nodes_selected_by_default`: (Optional) Boolean selecting or not nodes by default. The default is true. 
 
 * `option`: (Optional) Nested block defining an option a user may set when executing this job. A
   job may have any number of options. The structure of this nested block is described below.


### PR DESCRIPTION
I've updated `go-rundeck-api` to the latest [master](https://github.com/apparentlymart/go-rundeck-api) and have adapted a few bits to work with the changes.
This PR is mainly adding support for the following options:
- nodes_selected_by_default
- execution_enabled (coming from the latest `apparentlymart/go-rundeck-api`)
- schedule_enabled (coming from the latest `apparentlymart/go-rundeck-api`)

Documentation is also updated.
It is already running on a few instances of rundeck in production already with no side effects.
  