### PR TITLE
Add orchestrator options

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -67,6 +67,7 @@ type JobDetail struct {
 	Timeout                   string              `xml:"timeout,omitempty"`
 	Retry                     string              `xml:"retry,omitempty"`
 	NodeFilter                *JobNodeFilter      `xml:"nodefilters,omitempty"`
+	Orchestrator              *JobOrchestrator    `xml:"orchestrator,omitempty"`
 
 	/* If Dispatch is enabled, nodesSelectedByDefault is always present with true/false.
 	 * by this reason omitempty cannot be present.
@@ -305,6 +306,18 @@ type JobPluginConfig map[string]string
 type JobNodeFilter struct {
 	ExcludePrecedence bool   `xml:"excludeprecedence"`
 	Query             string `xml:"filter,omitempty"`
+}
+
+// JobOrchestratorConfig Contains the options for the Job Orchestrators
+type JobOrchestratorConfig struct {
+	Count   int `xml:"count,omitempty"`
+	Percent int `xml:"percent,omitempty"`
+}
+
+// JobOrchestrator describes how to schedule the jobs, in what order, and on how many nodes
+type JobOrchestrator struct {
+	Config JobOrchestratorConfig `xml:"configuration"`
+	Type   string                `xml:"type"`
 }
 
 type jobImportResults struct {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -101,6 +101,30 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"orchestrator": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Option of `subset`, `tiered`, `percentage`",
+						},
+						"count": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Value for the subset orchestrator",
+						},
+						"percent": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Value for the maxPercentage orchestrator",
+						},
+					},
+				},
+			},
+
 			"schedule": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -421,6 +445,26 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 			RankAttribute:   d.Get("rank_attribute").(string),
 			RankOrder:       d.Get("rank_order").(string),
 		},
+	}
+
+	orchList := d.Get("orchestrator").([]interface{})
+	if len(orchList) > 1 {
+		return nil, fmt.Errorf("rundeck command may have no more than one orchestrator")
+	}
+	for _, orch := range orchList {
+		orchMap := orch.(map[string]interface{})
+		job.Orchestrator = &JobOrchestrator{
+			Type:   orchMap["type"].(string),
+			Config: JobOrchestratorConfig{},
+		}
+		orchCount := orchMap["count"]
+		if orchCount != nil {
+			job.Orchestrator.Config.Count = orchCount.(int)
+		}
+		orchPct := orchMap["percent"]
+		if orchPct != nil {
+			job.Orchestrator.Config.Percent = orchPct.(int)
+		}
 	}
 
 	sequence := &JobCommandSequence{

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -149,6 +149,10 @@ resource "rundeck_job" "test" {
   option {
     name = "foo"
     default_value = "bar"
+  } 
+  orchestrator {
+    type = "subset"
+    count = 1
   }
   command {
     description = "Prints Hello World"

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -54,6 +54,8 @@ The following arguments are supported:
 
 * `schedule` - (Optional) The jobs schedule in Unix crontab format
 
+* `orchestrator` - (Optional) The orchestrator for the job, described below.
+
 * `schedule_enabled` - (Optional) Sets the job schedule to be enabled or disabled. Defaults to `true`.
 
 * `allow_concurrent_executions` - (Optional) Boolean defining whether two or more executions of
@@ -61,7 +63,7 @@ The following arguments are supported:
   sequentially.
 
 * `max_thread_count` - (Optional) The maximum number of threads to use to execute this job, which
-  controls on how many nodes the commands can be run simulateneously. Defaults to 1, meaning that
+  controls on how many nodes the commands can be run simultaneously. Defaults to 1, meaning that
   the nodes will be visited sequentially.
 
 * `continue_on_error` - (Optional) Boolean defining whether Rundeck will continue to run
@@ -97,6 +99,12 @@ The following arguments are supported:
   more commands. The structure of this nested block is described below.
 
 * `notification`: (Optional) Nested block defining notifications on the job workflow. The structure of this nested block is described below.
+
+`orchestrator` blocks have the following structure:
+
+* `type`: (Required) The type of orchestrator to use (subset, tiered, maxPercentage)
+
+* `value`: (Optional) The value for the orchestrator (not used in tiered)
 
 `option` blocks have the following structure:
 


### PR DESCRIPTION
This is a work in progress, to address:

feedback from @ProTip 

> For orchestrator config I'm a little concerned that the Terraform schema may stray from the API schema in a way that reduces the flexibility. Unlike notification which has "built in" notifications, email and webhook_urls, separate from a "plugin" config the orchestrator block is itself a "plugin" config. So its schema is pretty much the same as for the notification plugin block: https://github.com/terraform-providers/terraform-provider-rundeck/blob/master/rundeck/resource_job.go#L310-L323 .

> The builtin orchestrator plugins happen to have one configuration key, however others could in theory have arbitrary configuration elements. It would reduce or make "validation" more tricky, but I'm wondering if it would be better to model the orchestrator schema after the notification plugin block?