### PR TITLE
Job configuration feature additions and bug fixes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,8 +5,9 @@ PKG_NAME=rundeck
 
 default: build
 
-build: fmtcheck
-	go install
+build: fmt fmtcheck
+	env go install
+	env GOOS=linux GOARCH=amd64 go install
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -2,10 +2,11 @@ package rundeck
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/rundeck/go-rundeck/rundeck"
 )
 
@@ -57,6 +58,11 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"retry": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"max_thread_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -64,6 +70,11 @@ func resourceRundeckJob() *schema.Resource {
 			},
 
 			"continue_on_error": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"continue_next_node_on_error": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
@@ -101,6 +112,11 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"node_filter_exclude_query": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"node_filter_exclude_precedence": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -115,6 +131,11 @@ func resourceRundeckJob() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+
+			"time_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"notification": {
@@ -179,6 +200,11 @@ func resourceRundeckJob() *schema.Resource {
 							Required: true,
 						},
 
+						"label": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"default_value": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -240,86 +266,197 @@ func resourceRundeckJob() *schema.Resource {
 				},
 			},
 
+			"global_log_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobFilter(),
+			},
+
 			"command": {
 				Type:     schema.TypeList,
 				Required: true,
+				Elem:     resourceRundeckJobCommand(),
+			},
+		},
+	}
+}
+
+// Attention - Changes made to this function should be repeated in resourceRundeckJobCommandErrorHandler below!
+func resourceRundeckJobCommand() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"shell_command": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"inline_script": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"script_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"script_file_args": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"script_interpreter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobCommandScriptInterpreter(),
+			},
+
+			"job": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobCommandJob(),
+			},
+
+			"step_plugin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobPluginResource(),
+			},
+			"node_step_plugin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobPluginResource(),
+			},
+			"keep_going_on_success": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"error_handler": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobCommandErrorHandler(),
+			},
+		},
+	}
+}
+
+// Terraform schemas do not support recursion. The Error Handler is a command within a command, but we're breaking it
+// out and repeating it verbatim except for an inner errorHandler field.
+func resourceRundeckJobCommandErrorHandler() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"shell_command": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"inline_script": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"script_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"script_file_args": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"script_interpreter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobCommandScriptInterpreter(),
+			},
+
+			"job": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobCommandJob(),
+			},
+
+			"step_plugin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobPluginResource(),
+			},
+
+			"node_step_plugin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobPluginResource(),
+			},
+
+			"keep_going_on_success": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceRundeckJobCommandScriptInterpreter() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"invocation_string": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"args_quoted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceRundeckJobCommandJob() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"run_for_each_node": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"args": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"nodefilters": {
+				Type:     schema.TypeMap,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"description": {
+						"excludeprecedence": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"shell_command": {
+						"filter": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-
-						"inline_script": {
+						"excludeFilter": {
 							Type:     schema.TypeString,
 							Optional: true,
-						},
-
-						"script_file": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"script_file_args": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"job": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"group_name": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"run_for_each_node": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"args": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"nodefilters": {
-										Type:     schema.TypeMap,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"excludeprecedence": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"filter": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-
-						"step_plugin": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     resourceRundeckJobPluginResource(),
-						},
-
-						"node_step_plugin": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     resourceRundeckJobPluginResource(),
 						},
 					},
 				},
@@ -329,6 +466,21 @@ func resourceRundeckJob() *schema.Resource {
 }
 
 func resourceRundeckJobPluginResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceRundeckJobFilter() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"type": {
@@ -399,7 +551,8 @@ func JobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 
 	resp, err := client.JobGet(ctx, d.Id(), "")
 	if err != nil {
-		if _, ok := err.(*NotFoundError); ok == true {
+		var notFound *NotFoundError
+		if errors.Is(err, notFound) {
 			return false, nil
 		}
 		return false, err
@@ -411,7 +564,7 @@ func JobExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 		return false, nil
 	}
 
-	return false, fmt.Errorf("Error checking if job exists: (%v)", err)
+	return false, fmt.Errorf("error checking if job exists: (%w)", err)
 }
 
 func ReadJob(d *schema.ResourceData, meta interface{}) error {
@@ -434,15 +587,18 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		Description:               d.Get("description").(string),
 		ExecutionEnabled:          d.Get("execution_enabled").(bool),
 		ScheduleEnabled:           d.Get("schedule_enabled").(bool),
+		TimeZone:                  d.Get("time_zone").(string),
 		LogLevel:                  d.Get("log_level").(string),
 		AllowConcurrentExecutions: d.Get("allow_concurrent_executions").(bool),
+		Retry:                     d.Get("retry").(string),
 		Dispatch: &JobDispatch{
-			MaxThreadCount:  d.Get("max_thread_count").(int),
-			ContinueOnError: d.Get("continue_on_error").(bool),
-			RankAttribute:   d.Get("rank_attribute").(string),
-			RankOrder:       d.Get("rank_order").(string),
+			MaxThreadCount:          d.Get("max_thread_count").(int),
+			ContinueNextNodeOnError: d.Get("continue_next_node_on_error").(bool),
+			RankAttribute:           d.Get("rank_attribute").(string),
+			RankOrder:               d.Get("rank_order").(string),
 		},
 	}
+
 	successOnEmpty := d.Get("success_on_empty_node_filter")
 	if successOnEmpty != nil {
 		job.Dispatch.SuccessOnEmptyNodeFilter = successOnEmpty.(bool)
@@ -454,74 +610,33 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		Commands:         []JobCommand{},
 	}
 
+	logFilterConfigs := d.Get("global_log_filter").([]interface{})
+	if len(logFilterConfigs) > 0 {
+		globalLogFilters := &[]JobLogFilter{}
+		for _, logFilterI := range logFilterConfigs {
+			logFilterMap := logFilterI.(map[string]interface{})
+			configI := logFilterMap["config"].(map[string]interface{})
+			config := &JobLogFilterConfig{}
+			for key, value := range configI {
+				(*config)[key] = value.(string)
+			}
+			logFilter := &JobLogFilter{
+				Type:   logFilterMap["type"].(string),
+				Config: config,
+			}
+
+			*globalLogFilters =
+				append(*globalLogFilters, *logFilter)
+		}
+		sequence.GlobalLogFilters = globalLogFilters
+	}
 	commandConfigs := d.Get("command").([]interface{})
 	for _, commandI := range commandConfigs {
-		commandMap := commandI.(map[string]interface{})
-		command := JobCommand{
-			Description:    commandMap["description"].(string),
-			ShellCommand:   commandMap["shell_command"].(string),
-			Script:         commandMap["inline_script"].(string),
-			ScriptFile:     commandMap["script_file"].(string),
-			ScriptFileArgs: commandMap["script_file_args"].(string),
+		command, err := commandFromResourceData(commandI)
+		if err != nil {
+			return nil, err
 		}
-
-		jobRefsI := commandMap["job"].([]interface{})
-		if len(jobRefsI) > 1 {
-			return nil, fmt.Errorf("rundeck command may have no more than one job")
-		}
-		if len(jobRefsI) > 0 {
-			jobRefMap := jobRefsI[0].(map[string]interface{})
-			command.Job = &JobCommandJobRef{
-				Name:           jobRefMap["name"].(string),
-				GroupName:      jobRefMap["group_name"].(string),
-				RunForEachNode: jobRefMap["run_for_each_node"].(bool),
-				Arguments:      JobCommandJobRefArguments(jobRefMap["args"].(string)),
-				NodeFilter:     &JobNodeFilter{},
-			}
-			nodeFilterMap := jobRefMap["nodefilters"].(map[string]interface{})
-			if nodeFilterMap["filter"] != nil {
-				command.Job.NodeFilter.Query = nodeFilterMap["filter"].(string)
-			}
-			if nodeFilterMap["excludeprecedence"] != nil {
-				command.Job.NodeFilter.ExcludePrecedence = nodeFilterMap["excludeprecedence"].(bool)
-			}
-		}
-
-		stepPluginsI := commandMap["step_plugin"].([]interface{})
-		if len(stepPluginsI) > 1 {
-			return nil, fmt.Errorf("rundeck command may have no more than one step plugin")
-		}
-		if len(stepPluginsI) > 0 {
-			stepPluginMap := stepPluginsI[0].(map[string]interface{})
-			configI := stepPluginMap["config"].(map[string]interface{})
-			config := map[string]string{}
-			for k, v := range configI {
-				config[k] = v.(string)
-			}
-			command.StepPlugin = &JobPlugin{
-				Type:   stepPluginMap["type"].(string),
-				Config: config,
-			}
-		}
-
-		stepPluginsI = commandMap["node_step_plugin"].([]interface{})
-		if len(stepPluginsI) > 1 {
-			return nil, fmt.Errorf("rundeck command may have no more than one node step plugin")
-		}
-		if len(stepPluginsI) > 0 {
-			stepPluginMap := stepPluginsI[0].(map[string]interface{})
-			configI := stepPluginMap["config"].(map[string]interface{})
-			config := map[string]string{}
-			for k, v := range configI {
-				config[k] = v.(string)
-			}
-			command.NodeStepPlugin = &JobPlugin{
-				Type:   stepPluginMap["type"].(string),
-				Config: config,
-			}
-		}
-
-		sequence.Commands = append(sequence.Commands, command)
+		sequence.Commands = append(sequence.Commands, *command)
 	}
 	job.CommandSequence = sequence
 
@@ -535,6 +650,7 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 			optionMap := optionI.(map[string]interface{})
 			option := JobOption{
 				Name:                    optionMap["name"].(string),
+				Label:                   optionMap["label"].(string),
 				DefaultValue:            optionMap["default_value"].(string),
 				ValueChoices:            JobValueChoices([]string{}),
 				ValueChoicesURL:         optionMap["value_choices_url"].(string),
@@ -550,7 +666,7 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 
 			for _, iv := range optionMap["value_choices"].([]interface{}) {
 				if iv == nil {
-					return nil, fmt.Errorf("Argument \"value_choices\" can not have empty values; try \"required\"")
+					return nil, fmt.Errorf("argument \"value_choices\" can not have empty values; try \"required\"")
 				}
 				option.ValueChoices = append(option.ValueChoices, iv.(string))
 			}
@@ -560,48 +676,20 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		job.OptionsConfig = optionsConfig
 	}
 
-	if d.Get("node_filter_query").(string) != "" {
-		job.NodeFilter = &JobNodeFilter{
-			ExcludePrecedence: d.Get("node_filter_exclude_precedence").(bool),
-			Query:             d.Get("node_filter_query").(string),
-		}
-
-		job.Dispatch = &JobDispatch{
-			MaxThreadCount:  d.Get("max_thread_count").(int),
-			ContinueOnError: d.Get("continue_on_error").(bool),
-			RankAttribute:   d.Get("rank_attribute").(string),
-			RankOrder:       d.Get("rank_order").(string),
-		}
-
-		successOnEmpty := d.Get("success_on_empty_node_filter")
-		if successOnEmpty != nil {
-			job.Dispatch.SuccessOnEmptyNodeFilter = successOnEmpty.(bool)
-		}
+	job.NodeFilter = &JobNodeFilter{
+		ExcludePrecedence: d.Get("node_filter_exclude_precedence").(bool),
+	}
+	if nodeFilterQuery := d.Get("node_filter_query").(string); nodeFilterQuery != "" {
+		job.NodeFilter.Query = nodeFilterQuery
+	}
+	if nodeFilterExcludeQuery := d.Get("node_filter_exclude_query").(string); nodeFilterExcludeQuery != "" {
+		job.NodeFilter.ExcludeQuery = nodeFilterExcludeQuery
 	}
 
-	if d.Get("schedule").(string) != "" {
-		schedule := strings.Split(d.Get("schedule").(string), " ")
-		if len(schedule) != 7 {
-			return nil, fmt.Errorf("Rundeck schedule must be formated like a cron expression, as defined here: http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html")
-		}
-		job.Schedule = &JobSchedule{
-			Time: JobScheduleTime{
-				Seconds: schedule[0],
-				Minute:  schedule[1],
-				Hour:    schedule[2],
-			},
-			Month: JobScheduleMonth{
-				Day:   schedule[3],
-				Month: schedule[4],
-			},
-			WeekDay: &JobScheduleWeekDay{
-				Day: schedule[5],
-			},
-			Year: JobScheduleYear{
-				Year: schedule[6],
-			},
-		}
+	if err := JobScheduleFromResourceData(d, job); err != nil {
+		return nil, err
 	}
+
 	notificationsConfigI := d.Get("notification").([]interface{})
 	if len(notificationsConfigI) > 0 {
 		if len(notificationsConfigI) <= 3 {
@@ -660,84 +748,139 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 				switch jobType {
 				case "on_success":
 					if jobNotification.OnSuccess != nil {
-						return nil, fmt.Errorf("A block with %s already exists", jobType)
+						return nil, fmt.Errorf("a block with %s already exists", jobType)
 					}
 					jobNotification.OnSuccess = &notification
 					job.Notification = &jobNotification
 				case "on_failure":
 					if jobNotification.OnFailure != nil {
-						return nil, fmt.Errorf("A block with %s already exists", jobType)
+						return nil, fmt.Errorf("a block with %s already exists", jobType)
 					}
 					jobNotification.OnFailure = &notification
 					job.Notification = &jobNotification
 				case "on_start":
 					if jobNotification.OnStart != nil {
-						return nil, fmt.Errorf("A block with %s already exists", jobType)
+						return nil, fmt.Errorf("a block with %s already exists", jobType)
 					}
 					jobNotification.OnStart = &notification
 					job.Notification = &jobNotification
 				default:
-					return nil, fmt.Errorf("The notification type is not one of `on_success`, `on_failure`, `on_start`")
+					return nil, fmt.Errorf("the notification type is not one of `on_success`, `on_failure`, `on_start`")
 				}
 			}
 		} else {
-			return nil, fmt.Errorf("Can only have up to three notfication blocks, `on_success`, `on_failure`, `on_start`")
+			return nil, fmt.Errorf("can only have up to three notfication blocks, `on_success`, `on_failure`, `on_start`")
 		}
 	}
-
 	return job, nil
 }
 
 func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 
 	d.SetId(job.ID)
-	d.Set("name", job.Name)
-	d.Set("group_name", job.GroupName)
+	if err := d.Set("name", job.Name); err != nil {
+		return err
+	}
+	if err := d.Set("group_name", job.GroupName); err != nil {
+		return err
+	}
 
 	// The project name is not consistently returned in all rundeck versions,
 	// so we'll only update it if it's set. Jobs can't move between projects
 	// anyway, so this is harmless.
 	if job.ProjectName != "" {
-		d.Set("project_name", job.ProjectName)
+		if err := d.Set("project_name", job.ProjectName); err != nil {
+			return err
+		}
 	}
 
-	d.Set("description", job.Description)
-	d.Set("execution_enabled", job.ExecutionEnabled)
-	d.Set("schedule_enabled", job.ScheduleEnabled)
-	d.Set("log_level", job.LogLevel)
-	d.Set("allow_concurrent_executions", job.AllowConcurrentExecutions)
+	if err := d.Set("description", job.Description); err != nil {
+		return err
+	}
+	if err := d.Set("execution_enabled", job.ExecutionEnabled); err != nil {
+		return err
+	}
+	if err := d.Set("schedule_enabled", job.ScheduleEnabled); err != nil {
+		return err
+	}
+	if err := d.Set("time_zone", job.TimeZone); err != nil {
+		return err
+	}
+	if err := d.Set("log_level", job.LogLevel); err != nil {
+		return err
+	}
+	if err := d.Set("allow_concurrent_executions", job.AllowConcurrentExecutions); err != nil {
+		return err
+	}
+	if err := d.Set("retry", job.Retry); err != nil {
+		return err
+	}
 
 	if job.Dispatch != nil {
-		d.Set("max_thread_count", job.Dispatch.MaxThreadCount)
-		d.Set("continue_on_error", job.Dispatch.ContinueOnError)
-		d.Set("rank_attribute", job.Dispatch.RankAttribute)
-		d.Set("rank_order", job.Dispatch.RankOrder)
+		if err := d.Set("max_thread_count", job.Dispatch.MaxThreadCount); err != nil {
+			return err
+		}
+		if err := d.Set("continue_next_node_on_error", job.Dispatch.ContinueNextNodeOnError); err != nil {
+			return err
+		}
+		if err := d.Set("rank_attribute", job.Dispatch.RankAttribute); err != nil {
+			return err
+		}
+		if err := d.Set("rank_order", job.Dispatch.RankOrder); err != nil {
+			return err
+		}
 	} else {
-		d.Set("max_thread_count", 1)
-		d.Set("continue_on_error", nil)
-		d.Set("rank_attribute", nil)
-		d.Set("rank_order", "ascending")
+		if err := d.Set("max_thread_count", 1); err != nil {
+			return err
+		}
+		if err := d.Set("continue_next_node_on_error", false); err != nil {
+			return err
+		}
+		if err := d.Set("rank_attribute", nil); err != nil {
+			return err
+		}
+		if err := d.Set("rank_order", "ascending"); err != nil {
+			return err
+		}
 	}
 
-	d.Set("node_filter_query", nil)
-	d.Set("node_filter_exclude_precedence", nil)
 	if job.NodeFilter != nil {
-		d.Set("node_filter_query", job.NodeFilter.Query)
-		d.Set("node_filter_exclude_precedence", job.NodeFilter.ExcludePrecedence)
+		if err := d.Set("node_filter_query", job.NodeFilter.Query); err != nil {
+			return err
+		}
+		if err := d.Set("node_filter_exclude_query", job.NodeFilter.ExcludeQuery); err != nil {
+			return err
+		}
+		if err := d.Set("node_filter_exclude_precedence", job.NodeFilter.ExcludePrecedence); err != nil {
+			return err
+		}
+	} else {
+		if err := d.Set("node_filter_query", nil); err != nil {
+			return err
+		}
+		if err := d.Set("node_filter_exclude_query", nil); err != nil {
+			return err
+		}
+		if err := d.Set("node_filter_exclude_precedence", nil); err != nil {
+			return err
+		}
 	}
 
-	optionConfigsI := []interface{}{}
+	optionConfigsI := make([]interface{}, 0)
 	if job.OptionsConfig != nil {
-		d.Set("preserve_options_order", job.OptionsConfig.PreserveOrder)
+		if err := d.Set("preserve_options_order", job.OptionsConfig.PreserveOrder); err != nil {
+			return err
+		}
 		for _, option := range job.OptionsConfig.Options {
 			optionConfigI := map[string]interface{}{
 				"name":                      option.Name,
+				"label":                     option.Label,
 				"default_value":             option.DefaultValue,
 				"value_choices":             option.ValueChoices,
 				"value_choices_url":         option.ValueChoicesURL,
 				"require_predefined_choice": option.RequirePredefinedChoice,
 				"validation_regex":          option.ValidationRegex,
-				"decription":                option.Description,
+				"description":               option.Description,
 				"required":                  option.IsRequired,
 				"allow_multiple_values":     option.AllowsMultipleValues,
 				"multi_value_delimiter":     option.MultiValueDelimiter,
@@ -747,72 +890,55 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 			optionConfigsI = append(optionConfigsI, optionConfigI)
 		}
 	}
-	d.Set("option", optionConfigsI)
+	if err := d.Set("option", optionConfigsI); err != nil {
+		return err
+	}
 
-	commandConfigsI := []interface{}{}
 	if job.CommandSequence != nil {
-		d.Set("command_ordering_strategy", job.CommandSequence.OrderingStrategy)
-		for _, command := range job.CommandSequence.Commands {
-			commandConfigI := map[string]interface{}{
-				"description":      command.Description,
-				"shell_command":    command.ShellCommand,
-				"inline_script":    command.Script,
-				"script_file":      command.ScriptFile,
-				"script_file_args": command.ScriptFileArgs,
-			}
+		if err := d.Set("command_ordering_strategy", job.CommandSequence.OrderingStrategy); err != nil {
+			return err
+		}
+		if err := d.Set("continue_on_error", job.CommandSequence.ContinueOnError); err != nil {
+			return err
+		}
 
-			if command.Job != nil {
-				commandConfigI["job"] = []interface{}{
-					map[string]interface{}{
-						"name":              command.Job.Name,
-						"group_name":        command.Job.GroupName,
-						"run_for_each_node": command.Job.RunForEachNode,
-						"args":              command.Job.Arguments,
-						"nodefilters":       command.Job.NodeFilter,
-					},
+		if job.CommandSequence.GlobalLogFilters != nil && len(*job.CommandSequence.GlobalLogFilters) > 0 {
+			globalLogFilterConfigsI := make([]interface{}, 0)
+			for _, logFilter := range *job.CommandSequence.GlobalLogFilters {
+				logFilterI := map[string]interface{}{
+					"type":   logFilter.Type,
+					"config": map[string]string(*logFilter.Config),
 				}
+				globalLogFilterConfigsI = append(globalLogFilterConfigsI, logFilterI)
 			}
-
-			if command.StepPlugin != nil {
-				commandConfigI["step_plugin"] = []interface{}{
-					map[string]interface{}{
-						"type":   command.StepPlugin.Type,
-						"config": map[string]string(command.StepPlugin.Config),
-					},
-				}
+			if err := d.Set("global_log_filter", globalLogFilterConfigsI); err != nil {
+				return err
 			}
+		}
 
-			if command.NodeStepPlugin != nil {
-				commandConfigI["node_step_plugin"] = []interface{}{
-					map[string]interface{}{
-						"type":   command.NodeStepPlugin.Type,
-						"config": map[string]string(command.NodeStepPlugin.Config),
-					},
-				}
+		commandConfigsI := make([]interface{}, 0)
+		for i := range job.CommandSequence.Commands {
+			commandConfigI, err := commandToResourceData(&job.CommandSequence.Commands[i])
+			if err != nil {
+				return err
 			}
-
 			commandConfigsI = append(commandConfigsI, commandConfigI)
 		}
+		if err := d.Set("command", commandConfigsI); err != nil {
+			return err
+		}
 	}
-	d.Set("command", commandConfigsI)
 
 	if job.Schedule != nil {
-		schedule := []string{}
-		schedule = append(schedule, job.Schedule.Time.Seconds)
-		schedule = append(schedule, job.Schedule.Time.Minute)
-		schedule = append(schedule, job.Schedule.Time.Hour)
-		schedule = append(schedule, job.Schedule.Month.Day)
-		schedule = append(schedule, job.Schedule.Month.Month)
-		if job.Schedule.WeekDay != nil {
-			schedule = append(schedule, job.Schedule.WeekDay.Day)
-		} else {
-			schedule = append(schedule, "*")
+		cronSpec, err := scheduleToCronSpec(job.Schedule)
+		if err != nil {
+			return err
 		}
-		schedule = append(schedule, job.Schedule.Year.Year)
-
-		d.Set("schedule", strings.Join(schedule, " "))
+		if err := d.Set("schedule", cronSpec); err != nil {
+			return err
+		}
 	}
-	notificationConfigsI := []interface{}{}
+	notificationConfigsI := make([]interface{}, 0)
 	if job.Notification != nil {
 		if job.Notification.OnSuccess != nil {
 			notificationConfigI := readNotification(job.Notification.OnSuccess, "on_success")
@@ -828,9 +954,239 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 		}
 	}
 
-	d.Set("notification", notificationConfigsI)
+	if err := d.Set("notification", notificationConfigsI); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+func JobScheduleFromResourceData(d *schema.ResourceData, job *JobDetail) error {
+	const scheduleKey = "schedule"
+	cronSpec := d.Get(scheduleKey).(string)
+	if cronSpec != "" {
+		schedule := strings.Split(cronSpec, " ")
+		if len(schedule) != 7 {
+			return fmt.Errorf("the Rundeck schedule must be formatted like a cron expression, as defined here: http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html")
+		}
+		job.Schedule = &JobSchedule{
+			Time: JobScheduleTime{
+				Seconds: schedule[0],
+				Minute:  schedule[1],
+				Hour:    schedule[2],
+			},
+			Month: JobScheduleMonth{
+				Day:   schedule[3],
+				Month: schedule[4],
+			},
+			WeekDay: JobScheduleWeekDay{
+				Day: schedule[5],
+			},
+			Year: JobScheduleYear{
+				Year: schedule[6],
+			},
+		}
+		// Day-of-month and Day-of-week can both be asterisks, but otherwise one, and only one, must be a '?'
+		if job.Schedule.Month.Day == job.Schedule.WeekDay.Day {
+			if job.Schedule.Month.Day != "*" {
+				return fmt.Errorf("invalid '%s' specification %s - one of day-of-month (4th item) or day-of-week (6th) must be '?'", scheduleKey, cronSpec)
+			}
+		} else if job.Schedule.Month.Day != "?" && job.Schedule.WeekDay.Day != "?" {
+			return fmt.Errorf("invalid '%s' specification %s - one of day-of-month (4th item) or day-of-week (6th) must be '?'", scheduleKey, cronSpec)
+		}
+	}
+	return nil
+}
+
+func scheduleToCronSpec(schedule *JobSchedule) (string, error) {
+	if schedule.Month.Day == "" {
+		if schedule.WeekDay.Day == "*" || schedule.WeekDay.Day == "" {
+			schedule.Month.Day = "*"
+		} else {
+			schedule.Month.Day = "?"
+		}
+	}
+	if schedule.WeekDay.Day == "" {
+		if schedule.Month.Day == "*" {
+			schedule.WeekDay.Day = "*"
+		} else {
+			schedule.WeekDay.Day = "?"
+		}
+	}
+	cronSpec := make([]string, 0)
+	cronSpec = append(cronSpec, schedule.Time.Seconds)
+	cronSpec = append(cronSpec, schedule.Time.Minute)
+	cronSpec = append(cronSpec, schedule.Time.Hour)
+	cronSpec = append(cronSpec, schedule.Month.Day)
+	cronSpec = append(cronSpec, schedule.Month.Month)
+	cronSpec = append(cronSpec, schedule.WeekDay.Day)
+	cronSpec = append(cronSpec, schedule.Year.Year)
+	return strings.Join(cronSpec, " "), nil
+}
+
+func commandFromResourceData(commandI interface{}) (*JobCommand, error) {
+	commandMap := commandI.(map[string]interface{})
+	command := &JobCommand{
+		Description:        commandMap["description"].(string),
+		ShellCommand:       commandMap["shell_command"].(string),
+		Script:             commandMap["inline_script"].(string),
+		ScriptFile:         commandMap["script_file"].(string),
+		ScriptFileArgs:     commandMap["script_file_args"].(string),
+		KeepGoingOnSuccess: commandMap["keep_going_on_success"].(bool),
+	}
+
+	// Because of the lack of schema recursion, the inner command has a separate schema without an error_handler
+	// field, but is otherwise identical. The 'exists' checks allow this function to apply to both 'command' and
+	// 'errorHandler' schemas.
+	if errorHandlersI, exists := commandMap["error_handler"].([]interface{}); exists {
+		if len(errorHandlersI) > 1 {
+			return nil, fmt.Errorf("rundeck command may have no more than one error handler")
+		}
+		if len(errorHandlersI) > 0 {
+			errorHandlerMap := errorHandlersI[0].(map[string]interface{})
+			errorHandler, err := commandFromResourceData(errorHandlerMap)
+			if err != nil {
+				return nil, err
+			}
+			command.ErrorHandler = errorHandler
+		}
+	}
+
+	scriptInterpretersI := commandMap["script_interpreter"].([]interface{})
+	if len(scriptInterpretersI) > 1 {
+		return nil, fmt.Errorf("rundeck command may have no more than one script interpreter")
+	}
+	if len(scriptInterpretersI) > 0 {
+		scriptInterpreterMap := scriptInterpretersI[0].(map[string]interface{})
+		command.ScriptInterpreter = &JobCommandScriptInterpreter{
+			InvocationString: scriptInterpreterMap["invocation_string"].(string),
+			ArgsQuoted:       scriptInterpreterMap["args_quoted"].(bool),
+		}
+	}
+
+	var err error
+	if command.Job, err = jobCommandJobRefFromResourceData("job", commandMap); err != nil {
+		return nil, err
+	}
+	if command.StepPlugin, err = singlePluginFromResourceData("step_plugin", commandMap); err != nil {
+		return nil, err
+	}
+	if command.NodeStepPlugin, err = singlePluginFromResourceData("node_step_plugin", commandMap); err != nil {
+		return nil, err
+	}
+
+	return command, nil
+}
+
+func jobCommandJobRefFromResourceData(key string, commandMap map[string]interface{}) (*JobCommandJobRef, error) {
+	jobRefsI := commandMap[key].([]interface{})
+	if len(jobRefsI) > 1 {
+		return nil, fmt.Errorf("rundeck command may have no more than one %s", key)
+	}
+	if len(jobRefsI) == 0 {
+		return nil, nil
+	}
+	jobRefMap := jobRefsI[0].(map[string]interface{})
+	jobRef := &JobCommandJobRef{
+		Name:           jobRefMap["name"].(string),
+		GroupName:      jobRefMap["group_name"].(string),
+		RunForEachNode: jobRefMap["run_for_each_node"].(bool),
+		Arguments:      JobCommandJobRefArguments(jobRefMap["args"].(string)),
+		NodeFilter:     &JobNodeFilter{},
+	}
+	nodeFilterMap := jobRefMap["nodefilters"].(map[string]interface{})
+	if nodeFilterMap["filter"] != nil {
+		jobRef.NodeFilter.Query = nodeFilterMap["filter"].(string)
+	}
+	if nodeFilterMap["exclude_filter"] != nil {
+		jobRef.NodeFilter.ExcludeQuery = nodeFilterMap["exclude_filter"].(string)
+	}
+	if nodeFilterMap["excludeprecedence"] != nil {
+		jobRef.NodeFilter.ExcludePrecedence = nodeFilterMap["excludeprecedence"].(bool)
+	}
+	return jobRef, nil
+}
+
+func singlePluginFromResourceData(key string, commandMap map[string]interface{}) (*JobPlugin, error) {
+	stepPluginsI := commandMap[key].([]interface{})
+	if len(stepPluginsI) > 1 {
+		return nil, fmt.Errorf("rundeck command may have no more than one %s", key)
+	}
+	if len(stepPluginsI) == 0 {
+		return nil, nil
+	}
+	stepPluginMap := stepPluginsI[0].(map[string]interface{})
+	configI := stepPluginMap["config"].(map[string]interface{})
+	config := map[string]string{}
+	for key, value := range configI {
+		config[key] = value.(string)
+	}
+	result := &JobPlugin{
+		Type:   stepPluginMap["type"].(string),
+		Config: config,
+	}
+	return result, nil
+}
+
+func commandToResourceData(command *JobCommand) (map[string]interface{}, error) {
+	commandConfigI := map[string]interface{}{
+		"description":           command.Description,
+		"shell_command":         command.ShellCommand,
+		"inline_script":         command.Script,
+		"script_file":           command.ScriptFile,
+		"script_file_args":      command.ScriptFileArgs,
+		"keep_going_on_success": command.KeepGoingOnSuccess,
+	}
+
+	if command.ErrorHandler != nil {
+		errorHandlerI, err := commandToResourceData(command.ErrorHandler)
+		if err != nil {
+			return nil, err
+		}
+		commandConfigI["error_handler"] = []interface{}{
+			errorHandlerI,
+		}
+	}
+
+	if command.ScriptInterpreter != nil {
+		commandConfigI["script_interpreter"] = []interface{}{
+			map[string]interface{}{
+				"invocation_string": command.ScriptInterpreter.InvocationString,
+				"args_quoted":       command.ScriptInterpreter.ArgsQuoted,
+			},
+		}
+	}
+
+	if command.Job != nil {
+		commandConfigI["job"] = []interface{}{
+			map[string]interface{}{
+				"name":              command.Job.Name,
+				"group_name":        command.Job.GroupName,
+				"run_for_each_node": command.Job.RunForEachNode,
+				"args":              command.Job.Arguments,
+				"nodefilters":       command.Job.NodeFilter,
+			},
+		}
+	}
+
+	if command.StepPlugin != nil {
+		commandConfigI["step_plugin"] = []interface{}{
+			map[string]interface{}{
+				"type":   command.StepPlugin.Type,
+				"config": map[string]string(command.StepPlugin.Config),
+			},
+		}
+	}
+
+	if command.NodeStepPlugin != nil {
+		commandConfigI["node_step_plugin"] = []interface{}{
+			map[string]interface{}{
+				"type":   command.NodeStepPlugin.Type,
+				"config": map[string]string(command.NodeStepPlugin.Config),
+			},
+		}
+	}
+	return commandConfigI, nil
 }
 
 // Helper function for three different notifications
@@ -839,7 +1195,7 @@ func readNotification(notification *Notification, notificationType string) map[s
 		"type": notificationType,
 	}
 	if notification.WebHook != nil {
-		notificationConfigI["webhok_urls"] = notification.WebHook.Urls
+		notificationConfigI["webhook_urls"] = notification.WebHook.Urls
 	}
 	if notification.Email != nil {
 		notificationConfigI["email"] = []interface{}{

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -56,9 +56,17 @@ The following arguments are supported:
 
 * `schedule_enabled` - (Optional) Sets the job schedule to be enabled or disabled. Defaults to `true`.
 
+* `time_zone` - (Optional) A valid Time Zone, either an abbreviation such as "PST", a full name such as 
+  "America/Los_Angeles",or a custom ID such as "GMT-8:00".
+  
 * `allow_concurrent_executions` - (Optional) Boolean defining whether two or more executions of
   this job can run concurrently. The default is `false`, meaning that jobs will only run
   sequentially.
+
+* `retry` - (Optional) Maximum number of times to retry execution when this job is directly invoked. 
+  Retry will occur if the job fails or times out, but not if it is manually killed. Can use an option 
+  value reference like "${option.retry}". The default is `0`, meaning that jobs will only run
+  once.
 
 * `max_thread_count` - (Optional) The maximum number of threads to use to execute this job, which
   controls on how many nodes the commands can be run simulateneously. Defaults to 1, meaning that
@@ -84,11 +92,20 @@ The following arguments are supported:
 * `command_ordering_strategy`: (Optional) The name of the strategy used to describe how to
   traverse the matrix of nodes and commands. The default is "node-first", meaning that all commands
   will be executed on a single node before moving on to the next. May also be set to "step-first",
-  meaning that a single step will be executed across all nodes before moving on to the next step.
+  meaning that a single step will be executed across all nodes before moving on to the next step, or
+  "parallel", meaning that all nodes can execute the script simultaneously.
+
+* `continue_next_node_on_error` - (Optional) Boolean defining whether Rundeck will continue to run
+  on subsequent nodes if a node fails when the `command_ordering_strategy` is set to either "node-first"
+  or "step-first". Defaults to `false`, meaning that the job execution will not proceed to the next node.
 
 * `node_filter_query` - (Optional) A query string using
   [Rundeck's node filter language](http://rundeck.org/docs/manual/node-filters.html#node-filter-syntax)
-  that defines which subset of the project's nodes will be used to execute this job.
+  that defines which subset of the project's nodes ***will*** be used to execute this job.
+
+* `node_filter_exclude_query` - (Optional) A query string using
+  [Rundeck's node filter language](http://rundeck.org/docs/manual/node-filters.html#node-filter-syntax)
+  that defines which subset of the project's nodes ***will not*** be used to execute this job.
 
 * `node_filter_exclude_precedence`: (Optional) Boolean controlling a deprecated Rundeck feature that controls
   whether node exclusions take priority over inclusions.
@@ -99,12 +116,19 @@ The following arguments are supported:
 * `command`: (Required) Nested block defining one step in the job workflow. A job must have one or
   more commands. The structure of this nested block is described below.
 
-* `notification`: (Optional) Nested block defining notifications on the job workflow. The structure of this nested block is described below.
+* `global_log_filter`: (Optional) Nested block defining a global log filter plugin available to provide communication
+  between all workflow steps. A job may have multiple global log filters.  The structure of this nested block is 
+  described below.
+   
+* `notification`: (Optional) Nested block defining notifications on the job workflow. The structure of this nested block
+  is described below.
 
 `option` blocks have the following structure:
 
 * `name`: (Required) Unique name that will be shown in the UI when entering values and used as
   a variable name for template substitutions.
+
+* `label`: (Optional) Display label that will be shown in the UI instead of the name.
 
 * `default_value`: (Optional) A default value for the option.
 
@@ -150,6 +174,9 @@ The following arguments are supported:
 
 * `script_file` and `script_file_args` together describe a script that is already pre-installed
   on the nodes which is to be executed.
+  
+* A `script_interpreter` block (Optional), described below, is an advanced feature specifying how
+  to invoke the script file.
 
 * A `job` block, described below, causes another job within the same project to be executed as
   a command.
@@ -158,6 +185,14 @@ The following arguments are supported:
 
 * A `node_step_plugin` block, described below, causes a node step plugin to be executed once for
   each node.
+
+A command's `script_interpreter` block has the following structure:
+
+* `invocation_string`: (Optional) The string describing how to invoke the script file. By
+  default the temporary script file path will be appended to this string, followed by any
+  arguments. Include `${scriptfile}` anywhere to change the file path argument location.
+  
+* `args_quoted`: (Optional) Quote arguments to script invocation string?
 
 A command's `job` block has the following structure:
 
@@ -176,11 +211,14 @@ A command's `job` block has the following structure:
 
 A command's `nodefilters` block has the following structure:
 
-* `excludeprecedence`: (Optional) Whether to exclude precedence or not.
+* `excludeprecedence`: (Optional, Deprecated) Whether to give precedence to the exclusion filter or not.
 
-* `filter`: (Optional) The node filter query string to use.
+* `filter`: (Optional) The query string for nodes ***to use***.
 
-A command's `step_plugin` or `node_step_plugin` block both have the following structure:
+* `exclude_filter`: (Optional) The query string for nodes ***not to use***.
+
+A command's `step_plugin` or `node_step_plugin` block both have the following structure, as does the job's 
+  `global_log_filter` blocks:
 
 * `type`: (Required) The name of the plugin to execute.
 


### PR DESCRIPTION
Added 8 missing features to the Job Configuration:
* time_zone
* retry
* continue_next_node_on_error
* global_log_filter
* label
* script_interpreter
* exclude_filter
* node_filter/exclude_query

Fixed several bugs:
* Now catches problems with malformed cron spec in "schedule", rather than silently failing
* Disambiguated "continue_on_error" between steps and nodes execution
* Deprecated feature, "exclude_precedence", had been required in xml, causing spurious updates - now optional
* Corrected misspelled HCL tags, "decription" and "webhok_urls"
* Cleaned up compiler warnings
* Added missing error handling