### PR TITLE
Remove website-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
 script:
 - make test
 - make vet
-- make website-test
 
 branches:
   only:


### PR DESCRIPTION
This is no longer the way to test per this commit at Hashicorp: https://github.com/hashicorp/terraform-website/commit/6d41be434cf85392bc9de773d8a5a8d571a195ad