### PR TITLE
Add manual, publish triggers for updating in TF registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
+  workflow_dispatch:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a quick tweak to our `release` workflow for releasing to Terraform. As it is, it will only trigger publishing a new version if a new tag is _pushed_ to the repo. This change adds triggers so that it can be done both manually, and if a release is cut via the GH UI.