### PR TITLE
Add retry delay option

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -68,8 +68,7 @@ type JobDetail struct {
 	CommandSequence           *JobCommandSequence `xml:"sequence,omitempty"`
 	Notification              *JobNotification    `xml:"notification,omitempty"`
 	Timeout                   string              `xml:"timeout,omitempty"`
-	Retry                     string              `xml:"retry,omitempty"`
-	RetryDelay                string              `xml:"retry_delay,omitempty"`
+	Retry                     *Retry              `xml:"retry,omitempty"`
 	NodeFilter                *JobNodeFilter      `xml:"nodefilters,omitempty"`
 
 	/* If Dispatch is enabled, nodesSelectedByDefault is always present with true/false.
@@ -84,6 +83,11 @@ type JobDetail struct {
 
 type Boolean struct {
 	Value bool `xml:",chardata"`
+}
+
+type Retry struct {
+	Delay string `xml:"delay,attr"`
+	Value string `xml:",chardata"`
 }
 
 type JobNotification struct {

--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -69,6 +69,7 @@ type JobDetail struct {
 	Notification              *JobNotification    `xml:"notification,omitempty"`
 	Timeout                   string              `xml:"timeout,omitempty"`
 	Retry                     string              `xml:"retry,omitempty"`
+	RetryDelay                string              `xml:"retry_delay,omitempty"`
 	NodeFilter                *JobNodeFilter      `xml:"nodefilters,omitempty"`
 
 	/* If Dispatch is enabled, nodesSelectedByDefault is always present with true/false.

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -62,6 +62,11 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"retry_delay": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"max_thread_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -596,6 +601,7 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		LogLevel:                  d.Get("log_level").(string),
 		AllowConcurrentExecutions: d.Get("allow_concurrent_executions").(bool),
 		Retry:                     d.Get("retry").(string),
+		RetryDelay:                d.Get("retry_delay").(string),
 		Dispatch: &JobDispatch{
 			MaxThreadCount:          d.Get("max_thread_count").(int),
 			ContinueNextNodeOnError: d.Get("continue_next_node_on_error").(bool),
@@ -818,6 +824,9 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 		return err
 	}
 	if err := d.Set("retry", job.Retry); err != nil {
+		return err
+	}
+	if err := d.Set("retry_delay", job.RetryDelay); err != nil {
 		return err
 	}
 

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -600,8 +600,10 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		TimeZone:                  d.Get("time_zone").(string),
 		LogLevel:                  d.Get("log_level").(string),
 		AllowConcurrentExecutions: d.Get("allow_concurrent_executions").(bool),
-		Retry:                     d.Get("retry").(string),
-		RetryDelay:                d.Get("retry_delay").(string),
+		Retry: &Retry{
+			Value: d.Get("retry").(string),
+			Delay: d.Get("retry_delay").(string),
+		},
 		Dispatch: &JobDispatch{
 			MaxThreadCount:          d.Get("max_thread_count").(int),
 			ContinueNextNodeOnError: d.Get("continue_next_node_on_error").(bool),
@@ -823,13 +825,14 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 	if err := d.Set("allow_concurrent_executions", job.AllowConcurrentExecutions); err != nil {
 		return err
 	}
-	if err := d.Set("retry", job.Retry); err != nil {
-		return err
+	if job.Retry != nil {
+		if err := d.Set("retry", job.Retry.Value); err != nil {
+			return err
+		}
+		if err := d.Set("retry_delay", job.Retry.Delay); err != nil {
+			return err
+		}
 	}
-	if err := d.Set("retry_delay", job.RetryDelay); err != nil {
-		return err
-	}
-
 	if job.Dispatch != nil {
 		if err := d.Set("max_thread_count", job.Dispatch.MaxThreadCount); err != nil {
 			return err

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -70,6 +70,10 @@ The following arguments are supported:
   value reference like "${option.retry}". The default is `0`, meaning that jobs will only run
   once.
 
+* `retry_delay` - (Optional) The time between the failed execution and the retry. Time in seconds or
+  specify time units: "120m", "2h", "3d". Use 0 to indicate no delay. Can include option value
+  references like "${option.delay}". The default is 0.
+
 * `max_thread_count` - (Optional) The maximum number of threads to use to execute this job, which
   controls on how many nodes the commands can be run simulateneously. Defaults to 1, meaning that
   the nodes will be visited sequentially.


### PR DESCRIPTION
This is a continuation of #77 which I can not modify, unfortunately.

This PR adds the `retry_delay` option to the `rundeck_job` resource and documents it using the description found in the Rundeck UI.