### PR TITLE
Ability to import projects

### DIFF
--- a/rundeck/import_resource_project_test.go
+++ b/rundeck/import_resource_project_test.go
@@ -1,0 +1,32 @@
+package rundeck
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/rundeck/go-rundeck/rundeck"
+)
+
+func TestAccProject_Import(t *testing.T) {
+	name := "rundeck_project.main"
+	project_name := "terraform-acc-test-basic"
+	var project rundeck.Project
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccProjectCheckDestroy(&project),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectConfig_basic,
+				Check:  testAccProjectCheckExists(name, &project),
+			},
+			{
+				ResourceName:      name,
+				ImportStateId:     project_name,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/rundeck/import_resource_project_test.go
+++ b/rundeck/import_resource_project_test.go
@@ -3,7 +3,7 @@ package rundeck
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/rundeck/go-rundeck/rundeck"
 )
 

--- a/rundeck/resource_project.go
+++ b/rundeck/resource_project.go
@@ -29,6 +29,9 @@ func resourceRundeckProject() *schema.Resource {
 		Delete: DeleteProject,
 		Exists: ProjectExists,
 		Read:   ReadProject,
+		Importer: &schema.ResourceImporter{
+			State: resourceProjectImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -306,4 +309,24 @@ func DeleteProject(d *schema.ResourceData, meta interface{}) error {
 	_, err := client.ProjectDelete(ctx, name)
 
 	return err
+}
+
+func resourceProjectImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	name := d.Id()
+
+	ok, err := ProjectExists(d, meta)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("Project doesn't exist. Please try again.")
+	}
+	d.SetId(name)
+
+	err = ReadProject(d, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/project.html.md
+++ b/website/docs/r/project.html.md
@@ -90,3 +90,11 @@ The following attributes are exported:
 
 * `name` - The unique name that identifies the project, as set in the arguments.
 * `ui_url` - The URL of the index page for this project in the Rundeck UI.
+
+## Import
+
+Rundeck Project can be imported using the `name`, e.g.
+
+```
+$ terraform import rundeck_project.main project-name
+```


### PR DESCRIPTION
Based on https://github.com/rundeck/terraform-provider-rundeck/pull/50 with a small update (last commit)

This allows to import already existing projects from running Rundeck instances which makes migration to Terraform management easier.

Validate if that works:
- create a project in Rundeck via Terraform e.g. `my-test-project`
- create a backup of your `terraform.tfstate` (e.g. via `cp` or a local git)
- delete the `terraform.tfstate` file
- import the project via `terraform import rundeck_project.my_test_project my-test-project` 
- compare the diffirence between the new `terraform.tfstate` and the previous one - no actual configuration should change

It was requested in the other PR that documentation is provided. Please elaborate as that PR already contains addition to the documentation.