### PR TITLE
Orchestrator Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.4.6
 - Added Retry Delay setting to Job definition.
+- Added ability to set Secure Options in Job Definition.
 - Typos in provider descriptions.
 - Minor fixes
 

--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -320,8 +320,10 @@ type JobNodeFilter struct {
 
 // JobOrchestratorConfig Contains the options for the Job Orchestrators
 type JobOrchestratorConfig struct {
-	Count   int `xml:"count,omitempty"`
-	Percent int `xml:"percent,omitempty"`
+	Count     int    `xml:"count,omitempty"`
+	Percent   int    `xml:"percent,omitempty"`
+	Attribute string `xml:"attribute,omitempty"`
+	Sort      string `xml:"sort,omitempty"`
 }
 
 // JobOrchestrator describes how to schedule the jobs, in what order, and on how many nodes

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -69,7 +69,8 @@ func TestAccJob_cmd_nodefilter(t *testing.T) {
 		},
 	})
 }
-func TestAccJob_cmd_orchestrator(t *testing.T) {
+
+func TestOchestrator_high_low(t *testing.T) {
 	var job JobDetail
 
 	resource.Test(t, resource.TestCase{
@@ -78,18 +79,70 @@ func TestAccJob_cmd_orchestrator(t *testing.T) {
 		CheckDestroy: testAccJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_cmd_nodefilter,
+				Config: testOchestration_high_low,
 				Check: resource.ComposeTestCheckFunc(
 					testAccJobCheckExists("rundeck_job.test", &job),
 					func(s *terraform.State) error {
-						if expected := "subset"; job.Orchestrator.Type != expected {
-							return fmt.Errorf("wrong subset; expected %v, got %v", expected, job.Orchestrator.Type)
+						if expected := "basic-job-with-node-filter"; job.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, job.Name)
 						}
-
-						if expected := 1; job.Orchestrator.Config.Count != expected {
-							return fmt.Errorf("wrong subset count; expected %v, got %v", expected, job.Orchestrator.Config.Count)
+						if expected := "name: tacobell"; job.CommandSequence.Commands[0].Job.NodeFilter.Query != expected {
+							return fmt.Errorf("failed to set job node filter; expected %v, got %v", expected, job.CommandSequence.Commands[0].Job.NodeFilter.Query)
 						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
 
+func TestOchestrator_max_percent(t *testing.T) {
+	var job JobDetail
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccJobCheckDestroy(&job),
+		Steps: []resource.TestStep{
+			{
+				Config: testOchestration_maxperecent,
+				Check: resource.ComposeTestCheckFunc(
+					testAccJobCheckExists("rundeck_job.test", &job),
+					func(s *terraform.State) error {
+						if expected := "basic-job-with-node-filter"; job.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, job.Name)
+						}
+						if expected := "name: tacobell"; job.CommandSequence.Commands[0].Job.NodeFilter.Query != expected {
+							return fmt.Errorf("failed to set job node filter; expected %v, got %v", expected, job.CommandSequence.Commands[0].Job.NodeFilter.Query)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestOchestrator_rankTiered(t *testing.T) {
+	var job JobDetail
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccJobCheckDestroy(&job),
+		Steps: []resource.TestStep{
+			{
+				Config: testOchestration_rank_tiered,
+				Check: resource.ComposeTestCheckFunc(
+					testAccJobCheckExists("rundeck_job.test", &job),
+					func(s *terraform.State) error {
+						if expected := "basic-job-with-node-filter"; job.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, job.Name)
+						}
+						if expected := "name: tacobell"; job.CommandSequence.Commands[0].Job.NodeFilter.Query != expected {
+							return fmt.Errorf("failed to set job node filter; expected %v, got %v", expected, job.CommandSequence.Commands[0].Job.NodeFilter.Query)
+						}
 						return nil
 					},
 				),
@@ -499,3 +552,159 @@ resource "rundeck_job" "test" {
   }
 }
 `
+
+const testOchestration_maxperecent = `
+resource "rundeck_project" "test" {
+	name = "terraform-acc-test-job"
+	description = "parent project for job acceptance tests"
+  
+	resource_model_source {
+	  type = "file"
+	  config = {
+		  format = "resourcexml"
+		  file = "/tmp/terraform-acc-tests.xml"
+	  }
+	}
+  }
+  resource "rundeck_job" "test" {
+	project_name = "${rundeck_project.test.name}"
+	name = "orchestrator-MaxPercent"
+	description = "A basic job"
+	execution_enabled = true
+	node_filter_query = "example"
+	allow_concurrent_executions = true
+	  nodes_selected_by_default = false
+	max_thread_count = 1
+	rank_order = "ascending"
+	  schedule = "0 0 12 * * * *"
+	  schedule_enabled = true
+	option {
+	  name = "foo"
+	  default_value = "bar"
+	} 
+	orchestrator {
+	  type = "maxPercentage"
+	  percent = 10
+	}
+	command {
+	  job {
+		name = "Other Job Name"
+		run_for_each_node = true
+		node_filters {
+		  filter = "name: tacobell"
+		}
+	  }
+	  description = "Prints Hello World"
+	}
+	notification {
+		type = "on_success"
+		email {
+			recipients = ["foo@foo.bar"]
+		}
+	}
+  }
+  `
+
+const testOchestration_high_low = `
+resource "rundeck_project" "test" {
+	name = "terraform-acc-test-job"
+	description = "parent project for job acceptance tests"
+  
+	resource_model_source {
+	  type = "file"
+	  config = {
+		  format = "resourcexml"
+		  file = "/tmp/terraform-acc-tests.xml"
+	  }
+	}
+  }
+  resource "rundeck_job" "test" {
+	project_name = "${rundeck_project.test.name}"
+	name = "orchestrator-High-Low"
+	description = "A basic job"
+	execution_enabled = true
+	node_filter_query = "example"
+	allow_concurrent_executions = true
+	  nodes_selected_by_default = false
+	max_thread_count = 1
+	rank_order = "ascending"
+	  schedule = "0 0 12 * * * *"
+	  schedule_enabled = true
+	option {
+	  name = "foo"
+	  default_value = "bar"
+	} 
+	orchestrator {
+	  type = "orchestrator-highest-lowest-attribute"
+	  sort = "highest"
+	  attribute = "my-attribute"
+	}
+	command {
+	  job {
+		name = "Other Job Name"
+		run_for_each_node = true
+		node_filters {
+		  filter = "name: tacobell"
+		}
+	  }
+	  description = "Prints Hello World"
+	}
+	notification {
+		type = "on_success"
+		email {
+			recipients = ["foo@foo.bar"]
+		}
+	}
+  }
+  `
+
+const testOchestration_rank_tiered = `
+resource "rundeck_project" "test" {
+	name = "terraform-acc-test-job"
+	description = "parent project for job acceptance tests"
+  
+	resource_model_source {
+	  type = "file"
+	  config = {
+		  format = "resourcexml"
+		  file = "/tmp/terraform-acc-tests.xml"
+	  }
+	}
+  }
+  resource "rundeck_job" "test" {
+	project_name = "${rundeck_project.test.name}"
+	name = "basic-job-with-node-filter"
+	description = "A basic job"
+	execution_enabled = true
+	node_filter_query = "example"
+	allow_concurrent_executions = true
+	  nodes_selected_by_default = false
+	max_thread_count = 1
+	rank_order = "ascending"
+	  schedule = "0 0 12 * * * *"
+	  schedule_enabled = true
+	option {
+	  name = "foo"
+	  default_value = "bar"
+	} 
+	orchestrator {
+	  type = "rankTiered"
+	}
+	command {
+	  job {
+		name = "Other Job Name"
+		run_for_each_node = true
+		node_filters {
+		  filter = "name: tacobell"
+		}
+	  }
+	  description = "Prints Hello World"
+	}
+	notification {
+		type = "on_success"
+		email {
+			recipients = ["foo@foo.bar"]
+		}
+	}
+  }
+  `

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -56,7 +56,12 @@ The following arguments are supported:
 
 * `schedule` - (Optional) The job's schedule in Quartz schedule cron format. Similar to unix crontab, but with seven fields instead of five: Second Minute Hour Day-of-Month Month Day-of-Week Year
 
-* `orchestrator` - (Optional) The orchestrator for the job, described below.
+* `orchestrator` - (Optional) The orchestrator for the job, described below and [here](https://docs.rundeck.com/docs/manual/orchestrator-plugins/bundled.html)
+    - `type`: Must be one of `subset`, `rankTiered`, `maxPercentage`, `orchestrator-highest-lowest-attribute`
+    - `count`: Required when types is `subset`. Selects that max number of the target nodes at random to process.
+    - `percent`: Required when type is `maxPercentage`. Used to determine max percentage of the nodes to process at once.
+    - `attribute`: Required when type is `orchestrator-highest-lowest-attribute`.  The node attribute to use for sorting.
+    - `sort`:Required when type is `orchestrator-highest-lowest-attribute`.  Values accepted are `highest` or `lowest`.
 
 * `schedule_enabled` - (Optional) Sets the job schedule to be enabled or disabled. Defaults to `true`.
 


### PR DESCRIPTION
This PR is a collection of work from @tebriel and @sorenmat adding Orchestrator options. (PR #58 and #29)

There was remaining work to merge fully:
[ ] Add the following Orchestrator options missing from this PR: 

<img width="650" alt="Screen Shot 2022-02-02 at 2 33 52 PM" src="https://user-images.githubusercontent.com/9272445/152248970-9afb880e-963a-4fa2-9a3a-680884bb2408.png">

[ ] Update Documentation to ensure the features are fully covered. (some was lost in merging this feature to a local branch due to conflicts.)