### PR TITLE
Add support for importing jobs into the Terraform state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.4.6
 - Added Retry Delay setting to Job definition.
+- Added ability to set Secure Options in Job Definition.
 - Typos in provider descriptions.
 - Minor fixes
 

--- a/rundeck/import_resource_job_test.go
+++ b/rundeck/import_resource_job_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccRundeckJob_Import(t *testing.T) {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -928,6 +928,9 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 	if err := d.Set("allow_concurrent_executions", job.AllowConcurrentExecutions); err != nil {
 		return err
 	}
+	if err := d.Set("timeout", job.Timeout); err != nil {
+		return err
+	}
 	if job.Retry != nil {
 		if err := d.Set("retry", job.Retry.Value); err != nil {
 			return err
@@ -947,6 +950,9 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 			return err
 		}
 		if err := d.Set("rank_order", job.Dispatch.RankOrder); err != nil {
+			return err
+		}
+		if err := d.Set("success_on_empty_node_filter", job.Dispatch.SuccessOnEmptyNodeFilter); err != nil {
 			return err
 		}
 	} else {

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -83,7 +83,7 @@ func TestOchestrator_high_low(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccJobCheckExists("rundeck_job.test", &job),
 					func(s *terraform.State) error {
-						if expected := "basic-job-with-node-filter"; job.Name != expected {
+						if expected := "orchestrator-High-Low"; job.Name != expected {
 							return fmt.Errorf("wrong name; expected %v, got %v", expected, job.Name)
 						}
 						if expected := "name: tacobell"; job.CommandSequence.Commands[0].Job.NodeFilter.Query != expected {
@@ -110,7 +110,7 @@ func TestOchestrator_max_percent(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccJobCheckExists("rundeck_job.test", &job),
 					func(s *terraform.State) error {
-						if expected := "basic-job-with-node-filter"; job.Name != expected {
+						if expected := "orchestrator-MaxPercent"; job.Name != expected {
 							return fmt.Errorf("wrong name; expected %v, got %v", expected, job.Name)
 						}
 						if expected := "name: tacobell"; job.CommandSequence.Commands[0].Job.NodeFilter.Query != expected {
@@ -261,8 +261,23 @@ func TestAccJobOptions_secure_choice(t *testing.T) {
 		CheckDestroy: testAccJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccJobOptions_secure_options,
-				ExpectError: regexp.MustCompile("argument \"value_choices\" can not have empty values; try \"required\""),
+				Config: testAccJobOptions_secure_options,
+				Check: resource.ComposeTestCheckFunc(
+					testAccJobCheckExists("rundeck_job.test", &job),
+					func(s *terraform.State) error {
+						secureOption := job.OptionsConfig.Options[0]
+						if expected := "foo_secure"; secureOption.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, secureOption.Name)
+						}
+						if expected := "/keys/test/path/"; secureOption.StoragePath != expected {
+							return fmt.Errorf("wrong storage_path; expected %v, got %v", expected, secureOption.Name)
+						}
+						if expected := true; secureOption.ObscureInput != expected {
+							return fmt.Errorf("failed to set the input as obscure; expected %v, got %v", expected, secureOption.ObscureInput)
+						}
+						return nil
+					},
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Trying to revive https://github.com/rundeck/terraform-provider-rundeck/pull/44, by fixing the conflicts, testing it, and fixing the acceptance tests.

A use case for this would be transitioning from an existing manual Rundeck configuration into a Terraform-driven one using importing and automatic config generation (useful links: https://opentofu.org/docs/language/import/ and https://opentofu.org/docs/language/import/generating-configuration/)