### PR TITLE
Fix log filter plugins

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -276,6 +276,9 @@ type JobCommand struct {
 	Job *JobCommandJobRef `xml:"jobref"`
 
 	// Configuration for a step plugin to run as this command.
+	StepPlugin *JobPlugin `xml:"step-plugin"`
+
+	// Configuration for log filter plugins to run for this command.
 	Plugins *JobPlugins `xml:"plugins"`
 
 	// Configuration for a node step plugin to run as this command.
@@ -307,10 +310,10 @@ type JobCommandJobRefArguments string
 type JobPlugin struct {
 	XMLName xml.Name
 	Type    string          `xml:"type,attr"`
-	Config  JobPluginConfig `xml:"config"`
+	Config  JobPluginConfig `xml:"configuration"`
 }
 
-// Plugins is a configuration for a list of LogFilter plugins to run within a job.
+// Plugin is a configuration for a filter plugin to run for a step
 type JobPlugins struct {
 	XMLName          xml.Name
 	LogFilterPlugins []JobLogFilter `xml:"LogFilter"`

--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -276,7 +276,7 @@ type JobCommand struct {
 	Job *JobCommandJobRef `xml:"jobref"`
 
 	// Configuration for a step plugin to run as this command.
-	StepPlugin *JobPlugin `xml:"step-plugin"`
+	Plugins *JobPlugins `xml:"plugins"`
 
 	// Configuration for a node step plugin to run as this command.
 	NodeStepPlugin *JobPlugin `xml:"node-step-plugin"`
@@ -307,7 +307,13 @@ type JobCommandJobRefArguments string
 type JobPlugin struct {
 	XMLName xml.Name
 	Type    string          `xml:"type,attr"`
-	Config  JobPluginConfig `xml:"configuration"`
+	Config  JobPluginConfig `xml:"config"`
+}
+
+// Plugins is a configuration for a list of LogFilter plugins to run within a job.
+type JobPlugins struct {
+	XMLName          xml.Name
+	LogFilterPlugins []JobLogFilter `xml:"LogFilter"`
 }
 
 // JobPluginConfig is a specialization of map[string]string for job plugin configuration.

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -375,7 +375,11 @@ func resourceRundeckJobCommand() *schema.Resource {
 				Optional: true,
 				Elem:     resourceRundeckJobCommandJob(),
 			},
-
+			"step_plugin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobPluginResource(),
+			},
 			"plugins": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -439,6 +443,11 @@ func resourceRundeckJobCommandErrorHandler() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     resourceRundeckJobCommandJob(),
+			},
+			"step_plugin": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceRundeckJobPluginResource(),
 			},
 
 			"plugins": {
@@ -1199,6 +1208,9 @@ func commandFromResourceData(commandI interface{}) (*JobCommand, error) {
 	if command.Job, err = jobCommandJobRefFromResourceData("job", commandMap); err != nil {
 		return nil, err
 	}
+	if command.StepPlugin, err = singlePluginFromResourceData("step_plugin", commandMap); err != nil {
+		return nil, err
+	}
 	if command.Plugins, err = pluginsFromResourceData("plugins", commandMap); err != nil {
 		return nil, err
 	}
@@ -1331,6 +1343,14 @@ func commandToResourceData(command *JobCommand) (map[string]interface{}, error) 
 			jobRefConfigI["node_filters"] = append([]interface{}{}, nodeFilterConfigI)
 		}
 		commandConfigI["job"] = append([]interface{}{}, jobRefConfigI)
+	}
+	if command.StepPlugin != nil {
+		commandConfigI["step_plugin"] = []interface{}{
+			map[string]interface{}{
+				"type":   command.StepPlugin.Type,
+				"config": map[string]string(command.StepPlugin.Config),
+			},
+		}
 	}
 
 	if command.Plugins != nil {

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -244,6 +244,7 @@ The following arguments are supported:
 
 * A `job` block, described below, causes another job within the same project to be executed as
   a command.
+* A `step_plugin` block, described below, causes a step plugin to be executed as a command.
 
 * A `plugins` block, described below, contains a list of plugins to add to the command. At the moment, only [Log Filters](https://docs.rundeck.com/docs/manual/log-filters/) are supported
 
@@ -285,7 +286,7 @@ A command's `plugins` block has the following structure:
 
 * `log_filter_plugin`: A log filter plugin to add to the command. Can be repeated to add multiple log filters. See below for the structure.
 
-A command's `log_filter_plugin` or `node_step_plugin` block both have the following structure, as does the job's
+A command's `log_filter_plugin`, `step_plugin`  or `node_step_plugin` block both have the following structure, as does the job's
   `global_log_filter` blocks:
 
 * `type`: (Required) The name of the plugin to execute.

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -18,21 +18,58 @@ Each job belongs to a project. A project can be created with the `rundeck_projec
 
 ```hcl
   resource "rundeck_job" "bounceweb" {
-    name              = "Bounce All Web Servers"
-    project_name      = "${rundeck_project.terraform.name}"
-    node_filter_query = "tags: web"
-    description       = "Restart the service daemons on all the web servers"
+      name              = "Bounce All Web Servers"
+      project_name      = "${rundeck_project.terraform.name}"
+      node_filter_query = "tags: web"
+      description       = "Restart the service daemons on all the web servers"
 
-    command {
-        shell_command = "sudo service anvils restart"
-    }
-    notification {
-        type = "on_success"
-        email {
-            recipients = ["example@foo.bar"]
+      command {
+          shell_command = "sudo service anvils restart"
+      }
+      notification {
+          type = "on_success"
+          email {
+              recipients = ["example@foo.bar"]
+          }
+      }
+  }
+```
+
+## Example Usage (Key-Value Data Log filter to pass data between jobs)
+
+```hcl
+  resource "rundeck_job" "update_review_environments" {
+      name              = "Update review environments"
+      project_name      = "${rundeck_project.terraform.name}"
+      node_filter_query = "tags: dev_server"
+      description       = "Update the code in review environments checking out the given branch"
+      command {
+        description           = null
+        inline_script         = "#!/bin/sh\nenvironment_numbers=$(find /var/review_environments -mindepth 3 -maxdepth 4 -name '$1' | awk -F/ -vORS=, '{ print $3 }' | sed 's/.$//')\necho \"RUNDECK:DATA:environment_numbers=\"$environment_numbers\""
+        script_file_args      = "$${option.git_branch}"
+        plugins {
+          log_filter_plugin {
+            config = {
+              invalidKeyPattern = "\\s|\\$|\\{|\\}|\\\\"
+              logData           = "true"
+              regex             = "^RUNDECK:DATA:\\s*([^\\s]+?)\\s*=\\s*(.+)$"
+            }
+            type = "key-value-data"
+          }
         }
+      }
+    command {
+      job {
+        args              = "-environment_numbers $${data.environment_numbers}"
+        name              = "git_pull_review_environments"
+      }
     }
-}
+    option {
+      name                      = "git_branch"
+      required                  = true
+    }
+  }
+
 ```
 
 ## Argument Reference
@@ -208,7 +245,7 @@ The following arguments are supported:
 * A `job` block, described below, causes another job within the same project to be executed as
   a command.
 
-* A `step_plugin` block, described below, causes a step plugin to be executed as a command.
+* A `plugins` block, described below, contains a list of plugins to add to the command. At the moment, only [Log Filters](https://docs.rundeck.com/docs/manual/log-filters/) are supported
 
 * A `node_step_plugin` block, described below, causes a node step plugin to be executed once for
   each node.
@@ -244,7 +281,11 @@ A command's `node_filters` block has the following structure:
 
 * `exclude_filter`: (Optional) The query string for nodes ***not to use***.
 
-A command's `step_plugin` or `node_step_plugin` block both have the following structure, as does the job's
+A command's `plugins` block has the following structure:
+
+* `log_filter_plugin`: A log filter plugin to add to the command. Can be repeated to add multiple log filters. See below for the structure.
+
+A command's `log_filter_plugin` or `node_step_plugin` block both have the following structure, as does the job's
   `global_log_filter` blocks:
 
 * `type`: (Required) The name of the plugin to execute.


### PR DESCRIPTION
Log filter plugins are defined under a `plugins` element in the `command` element in the XML definition of a job. This contains a list of `LogFilter` elements that defined Log Filter plugins to add to the step. This MR adds support for them and allows one to create Rundeck jobs with Log Filter plugins applied to its workflow steps. It also includes an acceptance test and documentation showing a typical use case for it.