### PR TITLE
feat(job): add logging limits

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -62,6 +62,7 @@ type JobDetail struct {
 	Description               string              `xml:"description"`
 	ExecutionEnabled          bool                `xml:"executionEnabled"`
 	LogLevel                  string              `xml:"loglevel,omitempty"`
+	LoggingLimit              *JobLoggingLimit    `xml:"logging,omitempty"`
 	AllowConcurrentExecutions bool                `xml:"multipleExecutions,omitempty"`
 	Dispatch                  *JobDispatch        `xml:"dispatch,omitempty"`
 	CommandSequence           *JobCommandSequence `xml:"sequence,omitempty"`
@@ -83,6 +84,13 @@ type JobDetail struct {
 
 type Boolean struct {
 	Value bool `xml:",chardata"`
+}
+
+// JobLoggingLimit represents the logging limit options for a job.
+type JobLoggingLimit struct {
+	Output string `xml:"limit,attr"`
+	Action string `xml:"limitAction,attr"`
+	Status string `xml:"status,attr"`
 }
 
 type Retry struct {

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -72,6 +72,25 @@ Each job belongs to a project. A project can be created with the `rundeck_projec
 
 ```
 
+## Example Usage (Specify Log Limit)
+```hcl
+resource "rundeck_job" "example_with_log_limit" {
+    name              = "Example Job with Log Limit"
+    project_name      = rundeck_project.terraform.name
+    description       = "An example job with log limit settings"
+
+    log_limit {
+        output = "100MB"
+        action = "halt"
+        status = "failed"
+    }
+
+    command {
+        shell_command = "echo 'Hello, World!'"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -88,6 +107,14 @@ The following arguments are supported:
   Setting this creates collapsable subcategories within the Rundeck UI's project job index.
 
 * `log_level` - (Optional) The log level that Rundeck should use for this job. Defaults to "INFO".
+
+* `log_limit` - (Optional) A block defining the log limit settings for the job. The structure of this nested block is described below.
+
+  The `log_limit` block has the following structure:
+
+  * `output` - (Required) Enter either maximum total line-count (e.g. "100"), maximum per-node line-count ("100/node"), or maximum log file size ("100MB", "100KB", etc.), using "GB","MB","KB","B" as Giga- Mega- Kilo- and bytes.
+  * `action` - (Required) Enter either "halt" or "truncate" to specify the action to take when the log limit is reached.
+  * `status` - (Required) Enter either "failed" or "aborted" or any custom status.
 
 * `timeout` - (Optional) The maximum time for an execution to run. Time in seconds, or specify time units: "120m", "2h", "3d". Use blank or 0 to indicate no timeout.
 
@@ -279,9 +306,9 @@ A command's `job` block has the following structure:
 
 * `skip_notifications` (Optional) If the referenced job has notifications, they will be skipped.
 
-* `fail_on_disable` (Optional) If the referenced job has disabled execution, it will be considered a failure 
+* `fail_on_disable` (Optional) If the referenced job has disabled execution, it will be considered a failure
 
-* `child_nodes`: (Optional) If the referenced job is from another project, you can use referenced job node list instead of the parent's nodes. 
+* `child_nodes`: (Optional) If the referenced job is from another project, you can use referenced job node list instead of the parent's nodes.
 
 * `node_filters`: (Optional) A map for overriding the referenced job's node filters.
 


### PR DESCRIPTION
### Description

This PR adds support for setting log limits on Rundeck jobs in the Terraform provider. The new attribute `log_limit` allows users to configure log output limits, define actions to take when these limits are reached, and specify custom status.

#### Added Features:
- `log_limit` attribute for Rundeck jobs to manage logging behavior.
  - **output**: Maximum total line-count or size of the log.
  - **action**: The action to take when the log limit is reached (`halt` or `truncate`).
  - **status**: Custom status for halted jobs due to log limits.

### Example Usage

```hcl
resource "rundeck_job" "example_with_log_limit" {
    name              = "Example Job with Log Limit"
    project_name      = rundeck_project.terraform.name
    description       = "An example job with log limit settings"

    log_limit {
        output = "100MB"
        action = "halt"
        status = "failed"
    }

    command {
        shell_command = "echo 'Hello, World!'"
    }
}
```

### Testing

- Added new acceptance tests to validate log limit behavior.
- I was unable to fully test the acceptance tests. Could someone please validate them?

### Notes

- This change is backward compatible.
- The properties **action** and **status** have been made required along with **output** to avoid a bug where setting these properties to `null` in the resource declaration caused a cyclic drift. Specifically, the state file would show `null` for these properties while the `ReadJob` function would return default values (`failed` for `status` and `halt` for `action`). This discrepancy led to unnecessary resource updates.
- Please review the new schema and provide feedback regarding additional validations or edge cases.