### PR TITLE
Add support for setting options types (file or text)

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -211,6 +211,9 @@ type JobOption struct {
 
 	// Option should be hidden from job run page
 	Hidden bool `xml:"hidden,omitempty"`
+
+	// Type of the option. One of: text, file
+	Type string `xml:"type,attr,omitempty"`
 }
 
 // JobValueChoices is a specialization of []string representing a sequence of predefined values

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -319,6 +319,11 @@ func resourceRundeckJob() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "text",
+						},
 					},
 				},
 			},
@@ -820,6 +825,7 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 				ValueIsExposedToScripts: optionMap["exposed_to_scripts"].(bool),
 				StoragePath:             optionMap["storage_path"].(string),
 				Hidden:                  optionMap["hidden"].(bool),
+				Type:                    optionMap["type"].(string),
 			}
 			if option.StoragePath != "" && !option.ObscureInput {
 				return nil, fmt.Errorf("argument \"obscure_input\" must be set to `true` when \"storage_path\" is not empty")
@@ -835,6 +841,9 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 				option.ValueChoices = append(option.ValueChoices, iv.(string))
 			}
 
+			if option.Type != "" && option.Type != "text" && option.Type != "file" {
+				return nil, fmt.Errorf("argument \"type\" cannot have \"%s\" as a value; allowed values: \"text\", \"file\"", option.Type)
+			}
 			optionsConfig.Options = append(optionsConfig.Options, option)
 		}
 		job.OptionsConfig = optionsConfig
@@ -1065,6 +1074,10 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 				"exposed_to_scripts":        option.ValueIsExposedToScripts,
 				"storage_path":              option.StoragePath,
 				"hidden":                    option.Hidden,
+				"type":                      option.Type,
+			}
+			if optionConfigI["type"] == "" {
+				optionConfigI["type"] = "text"
 			}
 			optionConfigsI = append(optionConfigsI, optionConfigI)
 		}

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -228,6 +228,8 @@ The following arguments are supported:
 * `hidden`: (Optional) Boolean controlling whether this option should be hidden from the UI on the job run page.
   Defaults to `false`.
 
+* `type`: (Optional) Option type. One of: `file`, `text`. Defaults to `text`.
+
 `command` blocks must have any one of the following combinations of arguments as contents:
 
 * `description`: (Optional) gives a description to the command block.


### PR DESCRIPTION
Right now, there is no support for setting the option type as shown in the docs: https://docs.rundeck.com/docs/manual/jobs/job-options.html#file-option-type. The option type is thus forced to `text` for all options. This MR adds a type field to the JobOption definition and adds support to allow the user to specify the option type, defaulting to `text`