### PR TITLE
Adding option url parameters

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -207,7 +207,7 @@ type JobOption struct {
 	ValueChoicesURL string `xml:"valuesUrl,attr,omitempty"`
 
 	// URL value choices can be configured
-	JobValueChoicesURL JobValueChoicesURL `xml:"valuesUrlConfig,omitempty"`
+	JobValueChoicesURL JobValueChoicesURL `xml:"configRemoteUrl,omitempty"`
 
 	// Description of the value to be shown in the Rundeck UI.
 	Description string `xml:"description,omitempty"`

--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -206,11 +206,38 @@ type JobOption struct {
 	// Mutually exclusive with ValueChoices
 	ValueChoicesURL string `xml:"valuesUrl,attr,omitempty"`
 
+	// URL value choices can be configured
+	JobValueChoicesURL JobValueChoicesURL `xml:"valuesUrlConfig,omitempty"`
+
 	// Description of the value to be shown in the Rundeck UI.
 	Description string `xml:"description,omitempty"`
 
 	// Option should be hidden from job run page
 	Hidden bool `xml:"hidden,omitempty"`
+}
+
+type JobValueChoicesURL struct {
+	XMLName xml.Name `xml:"configRemoteUrl"`
+
+	JsonFilter string `xml:"jsonFilter,omitempty"`
+
+	// Can be BASIC, API_KEY or BEARER_TOKEN
+	AuthenticationType string `xml:"authenticationType,omitempty"`
+
+	// Only used by BASIC auth
+	PasswordStoragePath string `xml:"passwordStoragePath,omitempty"`
+
+	// Only used by BASIC auth
+	Username string `xml:"username,omitempty"`
+
+	// Only used by API_KEY. Can be QUERY_PARAM or HEADER
+	ApiTokenReporter string `xml:"apiTokenReporter,omitempty"`
+
+	// Only used by API_KEY
+	KeyName string `xml:"keyName,omitempty"`
+
+	// Only used by API_KEY and BEARER_TOKEN
+	TokenStoragePath string `xml:"tokenStoragePath,omitempty"`
 }
 
 // JobValueChoices is a specialization of []string representing a sequence of predefined values
@@ -314,14 +341,14 @@ type JobCommandJobRef struct {
 // JobCommandJobRefArguments is a string representing the arguments in a JobCommandJobRef.
 type JobCommandJobRefArguments string
 
-// Plugin is a configuration for a plugin to run within a job or notification.
+// JobPlugin is a configuration for a plugin to run within a job or notification.
 type JobPlugin struct {
 	XMLName xml.Name
 	Type    string          `xml:"type,attr"`
 	Config  JobPluginConfig `xml:"configuration"`
 }
 
-// Plugin is a configuration for a filter plugin to run for a step
+// JobPlugins is a configuration for a filter plugin to run for a step
 type JobPlugins struct {
 	XMLName          xml.Name
 	LogFilterPlugins []JobLogFilter `xml:"LogFilter"`

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -844,7 +844,8 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 				ValueChoices:    JobValueChoices([]string{}),
 				ValueChoicesURL: optionMap["value_choices_url"].(string),
 				// Mark: This should be a map[string]string of sorts to be able to parse the subset of URL options
-				// and should reference
+				// and should reference. Right now this compiles, but fails on runtime because the schema
+				// expects this to be a map, not an object (I think)
 				JobValueChoicesURL:      JobValueChoicesURL{},
 				RequirePredefinedChoice: optionMap["require_predefined_choice"].(bool),
 				ValidationRegex:         optionMap["validation_regex"].(string),

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -272,6 +272,12 @@ func resourceRundeckJob() *schema.Resource {
 							Optional: true,
 						},
 
+						"value_choices_url_options": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     resourceRundeckValuesUrlOptions(),
+						},
+
 						"require_predefined_choice": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -333,6 +339,33 @@ func resourceRundeckJob() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				Elem:     resourceRundeckJobCommand(),
+			},
+		},
+	}
+}
+
+func resourceRundeckValuesUrlOptions() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"json_filter": {
+				Type:     schema.TypeString,
+				Required: false,
+			},
+			"authentication_type": {
+				Type:     schema.TypeString,
+				Required: false,
+			},
+			"password_storage_path": {
+				Type:     schema.TypeString,
+				Required: false,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Required: false,
+			},
+			"api_token_reporter": {
+				Type:     schema.TypeString,
+				Required: false,
 			},
 		},
 	}
@@ -805,11 +838,14 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		for _, optionI := range optionConfigsI {
 			optionMap := optionI.(map[string]interface{})
 			option := JobOption{
-				Name:                    optionMap["name"].(string),
-				Label:                   optionMap["label"].(string),
-				DefaultValue:            optionMap["default_value"].(string),
-				ValueChoices:            JobValueChoices([]string{}),
-				ValueChoicesURL:         optionMap["value_choices_url"].(string),
+				Name:            optionMap["name"].(string),
+				Label:           optionMap["label"].(string),
+				DefaultValue:    optionMap["default_value"].(string),
+				ValueChoices:    JobValueChoices([]string{}),
+				ValueChoicesURL: optionMap["value_choices_url"].(string),
+				// Mark: This should be a map[string]string of sorts to be able to parse the subset of URL options
+				// and should reference
+				JobValueChoicesURL:      JobValueChoicesURL{},
 				RequirePredefinedChoice: optionMap["require_predefined_choice"].(bool),
 				ValidationRegex:         optionMap["validation_regex"].(string),
 				Description:             optionMap["description"].(string),
@@ -1055,6 +1091,7 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 				"default_value":             option.DefaultValue,
 				"value_choices":             option.ValueChoices,
 				"value_choices_url":         option.ValueChoicesURL,
+				"value_choices_url_options": option.JobValueChoicesURL,
 				"require_predefined_choice": option.RequirePredefinedChoice,
 				"validation_regex":          option.ValidationRegex,
 				"description":               option.Description,

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -193,6 +193,9 @@ The following arguments are supported:
 * `value_choices_url`: (Optional) Can be used instead of `value_choices` to cause Rundeck to
   obtain a list of choices dynamically by fetching this URL.
 
+* `value_choices_url_options` : (Optional) A map of options to pass to the URL when fetching the
+  list of choices. The map keys are the option names and the values are the option values. 
+
 * `require_predefined_choice`: (Optional) Boolean controlling whether the user is allowed to
   enter values not included in the predefined set of choices (`false`, the default) or whether
   a predefined choice is required (`true`).
@@ -227,6 +230,22 @@ The following arguments are supported:
 
 * `hidden`: (Optional) Boolean controlling whether this option should be hidden from the UI on the job run page.
   Defaults to `false`.
+
+The "value_choices_url_options" block to parameterize using a URL to fill a list of options has the following structure:
+
+* `json_filter`: (Optional) A [JSON path](https://en.wikipedia.org/wiki/JSONPath) filter to apply to the response from the URL. The filter should be an expression that selects a list of keys or key-values from the response.
+
+* `authentication_type`: (Optional) The type of authentication to use when fetching the URL. Can be `BASIC`, `API_KEY` or `BEARER_TOKEN`.
+
+* `username`: (Optional) The username to use for basic authentication. Only used if the authentication type is `BASIC`.
+
+* `password_storage_path`: (Optional) The path to the password in the Rundeck key storage. Only used if the authentication type is `BASIC`.
+
+* `api_token_reporter`: (Optional) Only used if the authentication type is `API_KEY`. The location where the API key can be located. This should be either `QUERY_PARAM` or `HEADER`.
+
+* `key_name`: (Optional) The name of the key in the query parameter or header. Only used if the authentication type is `API_KEY`.
+
+* `token_storage_path`: (Optional) The path to the API key in the Rundeck key storage. This is required if the authentication type is `API_KEY` or `BEARER_TOKEN`.
 
 `command` blocks must have any one of the following combinations of arguments as contents:
 


### PR DESCRIPTION
This is a PR to add the new parameters for URL based options (basic auth, regex, bearer token etcetera) and solve #144. I suggest using a second level block to group these parameters and prevent clutter in the docs and code. There is no additional validation, ie. you could select basic authentication and add a bearer token at the moment. 

@fdevans This code is not working at this time. I think the issue is in jobFromResourceData(:846) with the JobValueChoicesURL object not being a map of strings. My knowledge of Go is very limited and I could find another component with a similar setup. I hope my groundwork is enough to finish this with little extra effort. If not, feel free to delete this pull request. 