### PR TITLE
Check valid status code on ProjectCreateResponder to validate proyect

### DIFF
--- a/vendor/github.com/rundeck/go-rundeck/rundeck/client.go
+++ b/vendor/github.com/rundeck/go-rundeck/rundeck/client.go
@@ -2599,7 +2599,7 @@ func NewWithBaseURI(baseURI string, ) BaseClient {
         err = autorest.Respond(
         resp,
         client.ByInspecting(),
-        azure.WithErrorUnlessStatusCode(http.StatusOK,http.StatusCreated,http.StatusConflict),
+        azure.WithErrorUnlessStatusCode(http.StatusOK,http.StatusCreated),
         autorest.ByUnmarshallingJSON(&result.Value),
         autorest.ByClosing())
         result.Response = autorest.Response{Response: resp}


### PR DESCRIPTION
**Description** 
This change adjusts the HTTP response handling in the Go client for the Rundeck provider by removing the acceptance of HTTP 409 (Conflict) as a valid response code.

**Changes:**
Removed http.StatusConflict from the list of accepted status codes in azure.WithErrorUnlessStatusCode.
Responses with a 409 status code will now result in an error, aligning the behavior with expected operation flows.

**Impact**
Enhances the robustness of the client by treating conflicts as failures instead of proceeding as if they were successes.
Reduces the likelihood of misinterpreting a conflict as an expected outcome.
Testing

**Validated the following scenarios:**
Responses with 200 (OK) and 201 (Created) are still correctly accepted.
Responses  other than 200 and 201 now raise an error, as intended.
The error-handling flow functions as expected.