### PR TITLE
Set nodes_selected_by_default to true

### DIFF
--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -180,6 +180,7 @@ func resourceRundeckJob() *schema.Resource {
 			"nodes_selected_by_default": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 
 			"time_zone": {


### PR DESCRIPTION
Fix for https://github.com/rundeck/terraform-provider-rundeck/issues/153 as intended in PR https://github.com/rundeck/terraform-provider-rundeck/pull/154

Problem:
When creating a new job via Terraform, if the nodes_selected_by_default option was not set to true, the job would fail to execute locally, as it could not find any nodes.

Solution:
To align with the behavior of the GUI, the nodes_selected_by_default option was modified to have a default value of true.