### PR TITLE
Fix: Resolve log_limit and nodes_selected_by_default update issues in Terraform Rundeck provider

### DIFF
--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -73,12 +73,12 @@ func resourceRundeckJob() *schema.Resource {
 						},
 						"action": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 							Description: "Enter either \"halt\" or \"truncate\" to specify the action to take when the log limit is reached.",
 						},
 						"status": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Required:    true,
 							Description: "Enter either \"failed\" or \"canceled\" or any custom status.",
 						},
 					},
@@ -1068,10 +1068,12 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 		return err
 	}
 	if job.LoggingLimit != nil {
-		logLimit := map[string]interface{}{
-			"output": job.LoggingLimit.Output,
-			"action": job.LoggingLimit.Action,
-			"status": job.LoggingLimit.Status,
+		logLimit := []map[string]interface{}{
+			{
+				"output": job.LoggingLimit.Output,
+				"action": job.LoggingLimit.Action,
+				"status": job.LoggingLimit.Status,
+			},
 		}
 		if err := d.Set("log_limit", logLimit); err != nil {
 			return err

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -1109,6 +1109,9 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 		if err := d.Set("success_on_empty_node_filter", job.Dispatch.SuccessOnEmptyNodeFilter); err != nil {
 			return err
 		}
+		if err := d.Set("nodes_selected_by_default", job.NodesSelectedByDefault); err != nil {
+			return err
+		}
 	} else {
 		if err := d.Set("max_thread_count", 1); err != nil {
 			return err
@@ -1120,6 +1123,10 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 			return err
 		}
 		if err := d.Set("rank_order", "ascending"); err != nil {
+			return err
+		}
+		// if not dispatch, nodes_selected_by_default is always empty and default to be true
+		if err := d.Set("nodes_selected_by_default", true); err != nil {
 			return err
 		}
 	}

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -115,8 +115,8 @@ The following arguments are supported:
   The `log_limit` block has the following structure:
 
   * `output` - (Required) Enter either maximum total line-count (e.g. "100"), maximum per-node line-count ("100/node"), or maximum log file size ("100MB", "100KB", etc.), using "GB","MB","KB","B" as Giga- Mega- Kilo- and bytes.
-  * `action` - (Optional) Enter either "halt" or "truncate" to specify the action to take when the log limit is reached.
-  * `status` - (Optional) Enter either "failed" or "aborted" or any custom status.
+  * `action` - (Required) Enter either "halt" or "truncate" to specify the action to take when the log limit is reached.
+  * `status` - (Required) Enter either "failed" or "aborted" or any custom status.
 
 * `timeout` - (Optional) The maximum time for an execution to run. Time in seconds, or specify time units: "120m", "2h", "3d". Use blank or 0 to indicate no timeout.
 


### PR DESCRIPTION
**This PR addresses two issues introduced in**
[PR #159](https://github.com/rundeck/terraform-provider-rundeck/pull/159)
[PR #160](https://github.com/rundeck/terraform-provider-rundeck/pull/160)

**log_limit Block Behavior**
Previously, the log_limit block was updated to allow optional fields (output, action, status). However, when any of these fields were omitted, their values defaulted to null. This caused Terraform to consistently detect pending updates for the resource, even if there were no actual changes. As a result, unnecessary updates were repeatedly applied.

**Resolution**
log_limit remains optional, but all fields within it (output, action, status) are now required.
This change ensures that the values in the Terraform configuration always match those in Rundeck, resolving the issue of constant updates.

**nodes_selected_by_default Default Value**
An issue was identified where nodes_selected_by_default was not set to true by default if not explicitly declared. Instead, it defaulted to false, causing Terraform to incorrectly detect and attempt updates on the job.

**Resolution**
Added a missing validation to ensure nodes_selected_by_default defaults to true when not declared, aligning with the expected provider behavior.