### PR TITLE
Check project name before creating it

### DIFF
--- a/rundeck/resource_project.go
+++ b/rundeck/resource_project.go
@@ -123,6 +123,13 @@ func CreateProject(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
 	ctx := context.Background()
+
+	project, _ := client.ProjectGet(ctx, name)
+
+	if project.StatusCode != 404 {
+		return fmt.Errorf("project with unique name (%s) already exist", name)
+	}
+
 	_, err := client.ProjectCreate(ctx, rundeck.ProjectCreateRequest{
 		Name: &name,
 	})


### PR DESCRIPTION
**Description**
This change introduces validation in the CreateProject function of the Go client for the Rundeck provider to ensure a project with the same name does not already exist before attempting to create it.

**Changes**
Added a call to client.ProjectGet(ctx, name) to check if a project with the given name already exists.
If the project's status code is not 404 (indicating it exists), the function now returns an error with a descriptive message.

