### PR TITLE
Support job runner selector

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -71,6 +71,7 @@ type JobDetail struct {
 	Timeout                   string              `xml:"timeout,omitempty"`
 	Retry                     *Retry              `xml:"retry,omitempty"`
 	NodeFilter                *JobNodeFilter      `xml:"nodefilters,omitempty"`
+	RunnerSelector            *RunnerSelector     `xml:"runnerSelector,omitempty"`
 	Orchestrator              *JobOrchestrator    `xml:"orchestrator,omitempty"`
 
 	/* If Dispatch is enabled, nodesSelectedByDefault is always present with true/false.
@@ -354,6 +355,13 @@ type JobNodeFilter struct {
 	Query             string `xml:"filter,omitempty"`
 	ExcludeQuery      string `xml:"filterExclude,omitempty"`
 	ExcludePrecedence bool   `xml:"excludeprecedence,omitempty"`
+}
+
+// RunnerSelector describes which runner will be used.
+type RunnerSelector struct {
+	Filter     string `xml:"filter,omitempty"`
+	FilterMode string `xml:"runnerFilterMode,omitempty"`
+	FilterType string `xml:"runnerFilterType,omitempty"`
 }
 
 // JobOrchestratorConfig Contains the options for the Job Orchestrators

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -158,6 +158,24 @@ func resourceRundeckJob() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+
+			"runner_selector_filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"runner_selector_filter_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "TAGS",
+			},
+
+			"runner_selector_filter_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "TAG_FILTER_AND",
+			},
+
 			"timeout": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -938,6 +956,14 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 		job.NodeFilter.ExcludeQuery = nodeFilterExcludeQuery
 	}
 
+	if runnerSelectorFilter := d.Get("runner_selector_filter").(string); runnerSelectorFilter != "" {
+		job.RunnerSelector = &RunnerSelector{
+			Filter:     runnerSelectorFilter,
+			FilterMode: d.Get("runner_selector_filter_mode").(string),
+			FilterType: d.Get("runner_selector_filter_type").(string),
+		}
+	}
+
 	if err := JobScheduleFromResourceData(d, job); err != nil {
 		return nil, err
 	}
@@ -1149,6 +1175,18 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 			return err
 		}
 		if err := d.Set("node_filter_exclude_precedence", nil); err != nil {
+			return err
+		}
+	}
+
+	if job.RunnerSelector != nil {
+		if err := d.Set("runner_selector_filter", job.RunnerSelector.Filter); err != nil {
+			return err
+		}
+		if err := d.Set("runner_selector_filter_mode", job.RunnerSelector.FilterMode); err != nil {
+			return err
+		}
+		if err := d.Set("runner_selector_filter_type", job.RunnerSelector.FilterType); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #167.

We need to choose on which runner the job will be run and this is not supported by this plugin, it seems only the node choice is supported.

I suggest adding these fields :
```
runner_selector_filter
runner_selector_filter_mode
runner_selector_filter_type
```

Which correspond to the XML field `runnerSelector`:
```xml
<runnerSelector>
  <filter>my_filter</filter>
  <runnerFilterMode>TAGS</runnerFilterMode>
  <runnerFilterType>TAG_FILTER_AND</runnerFilterType>
</runnerSelector>
```