### PR TITLE
feat(jobs): add format and http_method to notification

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -106,9 +106,11 @@ type JobNotification struct {
 }
 
 type Notification struct {
-	Email   *EmailNotification   `xml:"email,omitempty"`
-	WebHook *WebHookNotification `xml:"webhook,omitempty"`
-	Plugin  *JobPlugin           `xml:"plugin"`
+	Email      *EmailNotification   `xml:"email,omitempty"`
+	WebHook    *WebHookNotification `xml:"webhook,omitempty"`
+	Plugin     *JobPlugin           `xml:"plugin"`
+	Format     string               `xml:"format,omitempty"`
+	HttpMethod string               `xml:"httpMethod,omitempty"`
 }
 
 type EmailNotification struct {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -228,6 +228,16 @@ func resourceRundeckJob() *schema.Resource {
 							Required:    true,
 							Description: "Option of `on_success`, `on_failure`, `on_start`",
 						},
+						"format": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The webhook payload format (`json` or `xml`)",
+						},
+						"http_method": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "HTTP method to use for webhook delivery (`post` or `get`)",
+						},
 						"email": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -967,6 +977,14 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 					notification.Email = &email
 				}
 
+				if format, ok := notificationMap["format"].(string); ok && format != "" {
+					notification.Format = format
+				}
+
+				if httpMethod, ok := notificationMap["http_method"].(string); ok && httpMethod != "" {
+					notification.HttpMethod = httpMethod
+				}
+
 				// Webhook notification
 				webHookUrls := notificationMap["webhook_urls"].([]interface{})
 				if len(webHookUrls) > 0 {
@@ -1569,6 +1587,14 @@ func readNotification(notification *Notification, notificationType string) map[s
 			},
 		}
 	}
+
+	if notification.Format != "" {
+		notificationConfigI["format"] = notification.Format
+	}
+	if notification.HttpMethod != "" {
+		notificationConfigI["http_method"] = notification.HttpMethod
+	}
+
 	return notificationConfigI
 }
 

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -91,6 +91,26 @@ resource "rundeck_job" "example_with_log_limit" {
 }
 ```
 
+## Example Usage (Webhook Notification Configuration)
+```hcl
+resource "rundeck_job" "example_with_webhook" {
+    name              = "Example Job with Webhook Settings"
+    project_name      = rundeck_project.terraform.name
+    description       = "An example job with webhook notification settings"
+
+    command {
+        shell_command = "echo 'Hello, World!'"
+    }
+
+    notification {
+        type = "on_success"
+        format = "json"
+        http_method = "post"
+        webhook_urls = ["https://example.com/webhook"]
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -346,6 +366,10 @@ A command's `log_filter_plugin`, `step_plugin`  or `node_step_plugin` block both
 * `email`: (Optional) block listed below to send emails as notificiation.
 
 * `webhook_urls`: (Optional) A list of urls to send a webhook notification.
+
+* `format` - (Optional) The webhook payload format. Values can be `json` or `xml`. (Usefull only with `webhook_urls`)
+
+* `http_method` - (Optional) HTTP method to use for webhook delivery. Values can be `post` or `get`. (Usefull only with `webhook_urls`)
 
 * `plugin`: (Optional) A block listed below to send notifications using a plugin.
 

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -367,9 +367,9 @@ A command's `log_filter_plugin`, `step_plugin`  or `node_step_plugin` block both
 
 * `webhook_urls`: (Optional) A list of urls to send a webhook notification.
 
-* `format` - (Optional) The webhook payload format. Values can be `json` or `xml`. (Usefull only with `webhook_urls`)
+* `format` - (Optional) The webhook payload format. Values can be `json` or `xml`. (Useful only with `webhook_urls`)
 
-* `http_method` - (Optional) HTTP method to use for webhook delivery. Values can be `post` or `get`. (Usefull only with `webhook_urls`)
+* `http_method` - (Optional) HTTP method to use for webhook delivery. Values can be `post` or `get`. (Useful only with `webhook_urls`)
 
 * `plugin`: (Optional) A block listed below to send notifications using a plugin.
 


### PR DESCRIPTION
This pull request introduces support for configuring webhook notifications in Rundeck jobs, including specifying payload formats and HTTP methods. Key changes include updates to the `Notification` struct, enhancements to the Terraform provider schema, and the addition of new tests and documentation.

### Enhancements to webhook notification configuration:

* **`rundeck/job.go`**: Added `Format` and `HttpMethod` fields to the `Notification` struct to allow specifying the webhook payload format (`json` or `xml`) and the HTTP method (`post` or `get`).

* **`rundeck/resource_job.go`**:
  - Updated the Terraform provider schema to include `format` and `http_method` fields under the `notification` block.
  - Modified the `jobFromResourceData` function to map `format` and `http_method` values from resource data to the `Notification` struct.
  - Enhanced the `readNotification` function to include `format` and `http_method` in the returned configuration map.

### Testing improvements:

* **`rundeck/resource_job_test.go`**: Added a new acceptance test, `TestAccJobWebhookNotification`, to validate webhook notification configurations, including `format` and `http_method` values for `on_success`, `on_failure`, and `on_start` notifications.

### Documentation updates:

* **`website/docs/r/job.html.md`**:
  - Added an example usage section demonstrating webhook notification configuration.
  - Documented the new `format` and `http_method` arguments under the notification block.