### PR TITLE
chore(docker): update dockerfile to use rundeck version 5.11.1

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,3 +1,3 @@
-FROM rundeck/rundeck:3.3.6
+FROM rundeck/rundeck:5.11.1
 
 COPY --chown=rundeck:root remco /etc/remco

--- a/test/remco/resources.d/xmlLegacy.toml
+++ b/test/remco/resources.d/xmlLegacy.toml
@@ -1,0 +1,4 @@
+[[template]]
+    src         = "${REMCO_TEMPLATE_DIR}/xmlLegacy.properties"
+    dst         = "${REMCO_TMP_DIR}/rundeck-config/rundeck-config-xmlLegacy.properties"
+    mode        = "0644"

--- a/test/remco/templates/xmlLegacy.properties
+++ b/test/remco/templates/xmlLegacy.properties
@@ -1,0 +1,2 @@
+# To enable xml legacy api usage and working with terraform provider
+rundeck.feature.legacyXml.enabled=true


### PR DESCRIPTION
This pull request updates the Rundeck base image to a newer version and adds support for enabling the legacy XML API, which is useful for compatibility with certain tools like Terraform. Below are the key changes:

### Base Image Update:
* Updated the Rundeck base image in `test/Dockerfile` from version `3.3.6` to `5.11.1` to use the latest features and improvements.

### Legacy XML API Support:
* Added a new template configuration in `test/remco/resources.d/xmlLegacy.toml` to generate properties for enabling the legacy XML API.
* Introduced a new template file `test/remco/templates/xmlLegacy.properties` with the setting `rundeck.feature.legacyXml.enabled=true` to enable the legacy XML API for compatibility with Terraform.