### PR TITLE
feat(rundeck_job): add file_extension & expand_token_in_script_file options

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -288,6 +288,10 @@ type JobCommand struct {
 	// A pre-existing file (on the target nodes) that will be executed.
 	ScriptFile string `xml:"scriptfile,omitempty"`
 
+	// Whether to expand variables in the script file.
+	// If set, the script file will be expanded before being executed.
+	ExpandTokenInScriptFile bool `xml:"expandTokenInScriptFile,omitempty"`
+
 	// When ScriptFile is set, the arguments to provide to the script when executing it.
 	ScriptFileArgs string `xml:"scriptargs,omitempty"`
 

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -436,6 +436,16 @@ func resourceRundeckJobCommand() *schema.Resource {
 				Optional: true,
 			},
 
+			"expand_token_in_script_file": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"file_extension": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"script_interpreter": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -506,6 +516,16 @@ func resourceRundeckJobCommandErrorHandler() *schema.Resource {
 			},
 
 			"script_file_args": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"expand_token_in_script_file": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"file_extension": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -1360,13 +1380,15 @@ func scheduleToCronSpec(schedule *JobSchedule) (string, error) {
 func commandFromResourceData(commandI interface{}) (*JobCommand, error) {
 	commandMap := commandI.(map[string]interface{})
 	command := &JobCommand{
-		Description:        commandMap["description"].(string),
-		ShellCommand:       commandMap["shell_command"].(string),
-		Script:             commandMap["inline_script"].(string),
-		ScriptUrl:          commandMap["script_url"].(string),
-		ScriptFile:         commandMap["script_file"].(string),
-		ScriptFileArgs:     commandMap["script_file_args"].(string),
-		KeepGoingOnSuccess: commandMap["keep_going_on_success"].(bool),
+		Description:             commandMap["description"].(string),
+		ShellCommand:            commandMap["shell_command"].(string),
+		Script:                  commandMap["inline_script"].(string),
+		ScriptUrl:               commandMap["script_url"].(string),
+		ScriptFile:              commandMap["script_file"].(string),
+		ScriptFileArgs:          commandMap["script_file_args"].(string),
+		ExpandTokenInScriptFile: commandMap["expand_token_in_script_file"].(bool),
+		FileExtension:           commandMap["file_extension"].(string),
+		KeepGoingOnSuccess:      commandMap["keep_going_on_success"].(bool),
 	}
 
 	// Because of the lack of schema recursion, the inner command has a separate schema without an error_handler
@@ -1499,13 +1521,15 @@ func singlePluginFromResourceData(key string, commandMap map[string]interface{})
 
 func commandToResourceData(command *JobCommand) (map[string]interface{}, error) {
 	commandConfigI := map[string]interface{}{
-		"description":           command.Description,
-		"shell_command":         command.ShellCommand,
-		"inline_script":         command.Script,
-		"script_url":            command.ScriptUrl,
-		"script_file":           command.ScriptFile,
-		"script_file_args":      command.ScriptFileArgs,
-		"keep_going_on_success": command.KeepGoingOnSuccess,
+		"description":                 command.Description,
+		"shell_command":               command.ShellCommand,
+		"inline_script":               command.Script,
+		"script_url":                  command.ScriptUrl,
+		"script_file":                 command.ScriptFile,
+		"script_file_args":            command.ScriptFileArgs,
+		"expand_token_in_script_file": command.ExpandTokenInScriptFile,
+		"file_extension":              command.FileExtension,
+		"keep_going_on_success":       command.KeepGoingOnSuccess,
 	}
 
 	if command.ErrorHandler != nil {

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -467,6 +467,44 @@ resource "rundeck_job" "test" {
 }
 `
 
+const testAccJobConfig_script = `
+resource "rundeck_project" "test" {
+  name = "terraform-acc-test-job"
+  description = "parent project for job acceptance tests"
+
+  resource_model_source {
+    type = "file"
+    config = {
+        format = "resourcexml"
+        file = "/tmp/terraform-acc-tests.xml"
+    }
+  }
+}
+resource "rundeck_job" "test" {
+  project_name = "${rundeck_project.test.name}"
+  name = "script-job"
+  description = "A job using script"
+
+  option {
+    name = "foo"
+	default_value = "bar"
+	value_choices = ["", "foo"]
+  }
+
+  command {
+    description = "runs a script from a URL"
+    script_url = "https://raw.githubusercontent.com/fleschutz/PowerShell/refs/heads/main/scripts/check-xml-file.ps1"
+    script_file_args = "/tmp/terraform-acc-tests.xml"
+    file_extension = ".ps1"
+    expand_token_in_script_file = true
+    script_interpreter {
+      args_quoted       = false
+      invocation_string = "pwsh -f $${scriptfile}"
+    }
+  }
+}
+`
+
 const testAccJobConfig_withLogLimit = `
 resource "rundeck_project" "test" {
   name = "terraform-acc-test-job"


### PR DESCRIPTION
Simply adds the Job Command options for `file_extension`, and `expand_token_in_script_file` which pertains to the job node step type "Script" within Rundeck.

This allows setting:

```hcl
command {
 file_extension              = ".ps1"
 expand_token_in_script_file = true
 script_file                 = "/path/to/some/powershell_script.ps1"
 script_interpreter {
   args_quoted       = false
   invocation_string = "pwsh -f $${scriptfile}"
 }
}
```

Requested in Issue: #169

- `file_extension`: determines the file extension of the temporary script that gets copied to the node. It seems to try to interpret based on the shebang line if there is one as far as I can tell. but this ensures the temp script gets the proper extension for when it matters.

- `expand_token_in_script_file`: allows putting Rundeck specific tokens within an external script the same way you could in the inline script area, where you could use @option.value@ inside your external script, this tells rundeck to first expand those tokens to their values before running the script.

I have tested these after building the provider locally, and it does function as intended for both options.

I don't personally like how it is in the top level of command, but that is where script_file and script_file_args also sits.

Let me know if there is anything I should do to improve this.
