### PR TITLE
NodeFilterEditable property on a Job

### DIFF
--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -82,6 +82,7 @@ type JobDetail struct {
 	Schedule               *JobSchedule `xml:"schedule,omitempty"`
 	ScheduleEnabled        bool         `xml:"scheduleEnabled"`
 	TimeZone               string       `xml:"timeZone,omitempty"`
+	NodeFilterEditable     bool         `xml:"nodeFilterEditable"`
 }
 
 type Boolean struct {

--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -90,6 +90,12 @@ func resourceRundeckJob() *schema.Resource {
 				Optional: true,
 			},
 
+			"node_filter_editable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"retry": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -805,6 +811,7 @@ func jobFromResourceData(d *schema.ResourceData) (*JobDetail, error) {
 			RankAttribute:           d.Get("rank_attribute").(string),
 			RankOrder:               d.Get("rank_order").(string),
 		},
+		NodeFilterEditable: d.Get("node_filter_editable").(bool),
 	}
 	if !(job.DefaultTab == "nodes" || job.DefaultTab == "output" || job.DefaultTab == "html") {
 		return nil, fmt.Errorf("Argument \"default_tab\" must be set to one of `nodes`, `output`, `html`.")
@@ -1129,6 +1136,9 @@ func jobToResourceData(job *JobDetail, d *schema.ResourceData) error {
 		return err
 	}
 	if err := d.Set("log_level", job.LogLevel); err != nil {
+		return err
+	}
+	if err := d.Set("node_filter_editable", job.NodeFilterEditable); err != nil {
 		return err
 	}
 	if job.LoggingLimit != nil {

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -214,6 +214,8 @@ The following arguments are supported:
 * `nodes_selected_by_default`: (Optional) Boolean controlling whether nodes that match the node_query_filter are
   selected by default or not.
 
+* `node_filter_editable` - (Optional) Boolean that controls whether the node filter is editable at job run time in the Rundeck UI. The default is `true` if not set.
+
 * `runner_selector_filter`: (Optional) When using the [**Manual** Dispatch Settings](https://docs.rundeck.com/docs/administration/runner/runner-management/project-dispatch-configuration.html#manual-runner-selection) in a Project, this is the Runner Selector filter for a Job definition.
 
 * `runner_selector_filter_mode`: (Optional) When using the [**Manual** Dispatch Settings](https://docs.rundeck.com/docs/administration/runner/runner-management/project-dispatch-configuration.html#manual-runner-selection) in a Project, this defines the _mode_ of the Runner Selector. Accepts the following values:


### PR DESCRIPTION
This adds support for setting the NodeFilterEditable property on a Job.
Fixes https://github.com/rundeck/terraform-provider-rundeck/issues/90