### PR TITLE
feat(project-acls): add support for project acl

### DIFF
--- a/rundeck/resource_acl_policy_framework.go
+++ b/rundeck/resource_acl_policy_framework.go
@@ -36,6 +36,7 @@ type aclPolicyResourceModel struct {
 	ID     types.String `tfsdk:"id"`
 	Name   types.String `tfsdk:"name"`
 	Policy types.String `tfsdk:"policy"`
+	Project types.String `tfsdk:"project"`
 }
 
 // Metadata returns the resource type name.
@@ -65,6 +66,13 @@ func (r *aclPolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"policy": schema.StringAttribute{
 				Description: "YAML formatted ACL Policy string.",
 				Required:    true,
+			},
+			"project": schema.StringAttribute{
+				Description: "Project name for project-level ACL. If not specified, creates a system-level ACL.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}
@@ -102,12 +110,25 @@ func (r *aclPolicyResource) Create(ctx context.Context, req resource.CreateReque
 	client := r.clients.V1
 	name := plan.Name.ValueString()
 	policy := plan.Policy.ValueString()
+	project := plan.Project.ValueStringPointer()
 
 	request := &rundeck.SystemACLPolicyCreateRequest{
 		Contents: &policy,
 	}
 
-	response, err := client.SystemACLPolicyCreate(ctx, name, request)
+	var response *rundeck.SetObject
+	var err error
+	if project != nil {
+		// Project-level ACL
+		projectResponse, projectErr := client.ProjectACLPolicyCreate(ctx, *project, name, request)
+		response = &projectResponse
+		err = projectErr
+	} else {
+		// System-level ACL
+		systemResponse, systemErr := client.SystemACLPolicyCreate(ctx, name, request)
+		response = &systemResponse
+		err = systemErr
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating ACL policy",
@@ -144,8 +165,21 @@ func (r *aclPolicyResource) Read(ctx context.Context, req resource.ReadRequest, 
 	// Get ACL policy from Rundeck
 	client := r.clients.V1
 	name := state.ID.ValueString()
+	project := state.Project.ValueStringPointer()
 
-	response, err := client.SystemACLPolicyGet(ctx, name)
+	var response *rundeck.ACLPolicyResponse
+	var err error
+	if project != nil {
+		// Project-level ACL
+		projectResponse, projectErr := client.ProjectACLPolicyGet(ctx, *project, name)
+		response = &projectResponse
+		err = projectErr
+	} else {
+		// System-level ACL
+		systemResponse, systemErr := client.SystemACLPolicyGet(ctx, name)
+		response = &systemResponse
+		err = systemErr
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading ACL policy",
@@ -183,12 +217,20 @@ func (r *aclPolicyResource) Update(ctx context.Context, req resource.UpdateReque
 	client := r.clients.V1
 	name := plan.Name.ValueString()
 	policy := plan.Policy.ValueString()
+	project := plan.Project.ValueStringPointer()
 
 	request := &rundeck.SystemACLPolicyUpdateRequest{
 		Contents: &policy,
 	}
 
-	_, err := client.SystemACLPolicyUpdate(ctx, name, request)
+	var err error
+	if project != nil {
+		// Project-level ACL
+		_, err = client.ProjectACLPolicyUpdate(ctx, *project, name, request)
+	} else {
+		// System-level ACL
+		_, err = client.SystemACLPolicyUpdate(ctx, name, request)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating ACL policy",
@@ -217,8 +259,16 @@ func (r *aclPolicyResource) Delete(ctx context.Context, req resource.DeleteReque
 	// Delete ACL policy
 	client := r.clients.V1
 	name := state.ID.ValueString()
+	project := state.Project.ValueStringPointer()
 
-	_, err := client.SystemACLPolicyDelete(ctx, name)
+	var err error
+	if project != nil {
+		// Project-level ACL
+		_, err = client.ProjectACLPolicyDelete(ctx, *project, name)
+	} else {
+		// System-level ACL
+		_, err = client.SystemACLPolicyDelete(ctx, name)
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting ACL policy",

--- a/website/docs/r/acl_policy.md
+++ b/website/docs/r/acl_policy.md
@@ -8,23 +8,34 @@ description: |-
 
 # rundeck\_acl_policy
 
-Control access to your automation infrastructure. ACL policies define fine-grained permissions for users and groups across projects, jobs, nodes, and key storage. Managing policies as code ensures security is reviewed, versioned, and consistently applied.
+Control access to your automation infrastructure. ACL policies define fine-grained permissions for users and groups across projects, jobs, nodes, and key storage. Managing policies as code ensures security is reviewed, versioned, and consistently applied. The resource supports both System ACLs and Project ACLs.
 
-## Example Usage
+## Example Usage (System ACL)
 
 ```hcl
 data "local_file" "acl" {
   filename = "${path.module}/acl.yaml"
 }
 
-resource "rundeck_acl_policy" "example" {
+resource "rundeck_acl_policy" "system_acl_example" {
   name = "ExampleAcl.aclpolicy"
 
   policy = "${data.local_file.acl.content}"
 }
 ```
 
-Note that the above configuration assumes the existence of an ``acl.yaml`` file in the
+## Example Usage (Project ACL)
+```hcl
+data "local_file" "acl" {
+  filename = "${path.module}/acl.yaml"
+}
+resource "rundeck_acl_policy" "project_acl_example" {
+  name    = "ExampleAcl.aclpolicy"
+  project = "example-project"
+  policy = "${data.local_file.acl.content}"
+}
+```
+Note that the above examples assumes the existence of an ``acl.yaml`` file in the
 project directory. This resource passes the raw YAML policy string to Rundeck which stores
 and returns it as-is. A future ``acl_policy_document`` data source is planned to allow defining
 the policy in terraform configuration.
@@ -37,9 +48,10 @@ The following arguments are supported:
 
 * `policy` - (Required) The name of the job, used to describe the job in the Rundeck UI.
 
-> Note: This example uses an ACL Policy file stored at the current working directory named `acl.yaml`.  Valid contents for that file are shown below.
+* `project` - (Optional) The name of the project to define the project ACL under. If this is not provided the ACL will be a system level ACL policy.
+> Note: These examples use an ACL Policy file stored at the current working directory named `acl.yaml`.  Valid contents for that file are shown below.
 
-```
+```yaml
 by:
   group: terraform
 description: Allow terraform Key Storage Access


### PR DESCRIPTION
This extends the existing ACL Policy support to include project level ACL's by simply providing a project value. 

If project is provided it will be a project ACL.  It not its a standard default System ACL. 


This depends on the extension I have put a PR in here first for this to function:

https://github.com/rundeck/go-rundeck/pull/4


I have built the provider and have tested that System ACL and Project ACL functionality all works as intended. 


## Initial Creation

```
Mar-04 15:53:07 ~\GitHub\terraform-provider-rundeck\test-project-acl
> terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - rundeck/rundeck in c:\Users\codydiehl\GitHub\terraform-provider-rundeck
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to    
│ become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the    
following symbols:
  + create

Terraform will perform the following actions:

  # rundeck_acl_policy.project_test will be created
  + resource "rundeck_acl_policy" "project_test" {
      + id      = (known after apply)
      + name    = "test-project.aclpolicy"
      + policy  = <<-EOT
            description: Test Project ACL
            for:
              resource:
                - allow: [read, run]
              job:
                - allow: [read, run]
              node:
                - allow: [read]
            by:
              group: [users]
        EOT
      + project = "project-testing"
    }

  # rundeck_acl_policy.system_test will be created
  + resource "rundeck_acl_policy" "system_test" {
      + id     = (known after apply)
      + name   = "test-system.aclpolicy"
      + policy = <<-EOT
            description: Test System ACL
            context:
              project: "project-testing"
            for:
              resource:
                - allow: [read, run]
              job:
                - allow: [read, run]
              node:
                - allow: [read]
            by:
              group: [users]
        EOT
    }

Plan: 2 to add, 0 to change, 0 to destroy.
rundeck_acl_policy.system_test: Creating...
rundeck_acl_policy.project_test: Creating...
rundeck_acl_policy.system_test: Creation complete after 1s [id=test-system.aclpolicy]
rundeck_acl_policy.project_test: Creation complete after 1s [id=test-project.aclpolicy]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```


## Update to ACL Policy

```
Mar-04 15:53:36 ~\GitHub\terraform-provider-rundeck\test-project-acl
> terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - rundeck/rundeck in c:\Users\codydiehl\GitHub\terraform-provider-rundeck
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to    
│ become incompatible with published releases.
╵
rundeck_acl_policy.project_test: Refreshing state... [id=test-project.aclpolicy]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the    
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # rundeck_acl_policy.project_test will be updated in-place
  ~ resource "rundeck_acl_policy" "project_test" {
        id      = "test-project.aclpolicy"
        name    = "test-project.aclpolicy"
      ~ policy  = <<-EOT
            description: Test Project ACL
            for:
              resource:
                - allow: [read, run]
              job:
                - allow: [read, run]
          +   node:
          +     - allow: [read]
            by:
              group: [users]
        EOT
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
rundeck_acl_policy.project_test: Modifying... [id=test-project.aclpolicy]
rundeck_acl_policy.project_test: Modifications complete after 1s [id=test-project.aclpolicy]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

## Deletion

```
Mar-04 15:54:40 ~\GitHub\terraform-provider-rundeck\test-project-acl
> terraform destroy -auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - rundeck/rundeck in c:\Users\codydiehl\GitHub\terraform-provider-rundeck
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to    
│ become incompatible with published releases.
╵
rundeck_acl_policy.project_test: Refreshing state... [id=test-project.aclpolicy]
rundeck_acl_policy.system_test: Refreshing state... [id=test-system.aclpolicy]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the    
following symbols:
  - destroy

Terraform will perform the following actions:

  # rundeck_acl_policy.project_test will be destroyed
  - resource "rundeck_acl_policy" "project_test" {
      - id      = "test-project.aclpolicy" -> null
      - name    = "test-project.aclpolicy" -> null
      - policy  = <<-EOT
            description: Test Project ACL
            for:
              resource:
                - allow: [read, run]
              job:
                - allow: [read, run]
              node:
                - allow: [read]
            by:
              group: [users]
        EOT -> null
      - project = "project-testing" -> null
    }

  # rundeck_acl_policy.system_test will be destroyed
  - resource "rundeck_acl_policy" "system_test" {
      - id     = "test-system.aclpolicy" -> null
      - name   = "test-system.aclpolicy" -> null
      - policy = <<-EOT
            description: Test System ACL
            context:
              project: "project-testing"
            for:
              resource:
                - allow: [read, run]
              job:
                - allow: [read, run]
              node:
                - allow: [read]
            by:
              group: [users]
        EOT -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.
rundeck_acl_policy.system_test: Destroying... [id=test-system.aclpolicy]
rundeck_acl_policy.project_test: Destroying... [id=test-project.aclpolicy]
rundeck_acl_policy.system_test: Destruction complete after 0s
rundeck_acl_policy.project_test: Destruction complete after 0s

Destroy complete! Resources: 2 destroyed.
```

This was done with the following terraform:

```hcl
terraform {
  required_providers {
    rundeck = {
      source = "rundeck/rundeck"
    }
  }
}

provider "rundeck" {
  url         = "" # update these
  auth_token  = "" # update these
  api_version = "" # update these
}


resource "rundeck_acl_policy" "system_test" {
  name    = "test-system.aclpolicy"
  policy  = <<-EOT
    description: Test System ACL
    context:
      project: project-testing
    for:
      resource:
        - allow: [read, run]
      job:
        - allow: [read, run]
      node:
        - allow: [read]
    by:
      group: [users]
  EOT
}

# Test project-level ACL (new functionality)
resource "rundeck_acl_policy" "project_test" {
  name    = "test-project.aclpolicy"
  project = "project-testing"
  policy  = <<-EOT
    description: Test Project ACL
    for:
      resource:
        - allow: [read, run]
      job:
        - allow: [read, run]
      node:
        - allow: [read]
    by:
      group: [users]
  EOT
}
```


I have confirmed that the ACL policies existed in the project settings as well as the system ACL's and that it all looked good. 


I will validate imports and report back as well. 

However this will remain in draft until the go-rundeck PR is hopefully good to merge.