### PR TITLE
Fix resource_model_source to use ListNestedAttribute instead of ListAttribute

### DIFF
--- a/rundeck/resource_project_framework.go
+++ b/rundeck/resource_project_framework.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/rundeck/go-rundeck/rundeck"
@@ -97,23 +99,6 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "URL of the project in the Rundeck UI.",
 				Computed:    true,
 			},
-			"resource_model_source": schema.ListNestedAttribute{
-				Description: "Resource model sources configuration.",
-				Required:    true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"type": schema.StringAttribute{
-							Description: "The name of the resource model plugin to use.",
-							Required:    true,
-						},
-						"config": schema.MapAttribute{
-							Description: "Map of configuration properties for the resource model plugin.",
-							Optional:    true,
-							ElementType: types.StringType,
-						},
-					},
-				},
-			},
 			"default_node_file_copier_plugin": schema.StringAttribute{
 				Description: "Default node file copier plugin.",
 				Optional:    true,
@@ -145,6 +130,27 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				ElementType: types.StringType,
 				Optional:    true,
 				Computed:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"resource_model_source": schema.ListNestedBlock{
+				Description: "Resource model sources configuration.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Description: "The name of the resource model plugin to use.",
+							Required:    true,
+						},
+						"config": schema.MapAttribute{
+							Description: "Optional map of configuration properties for the resource model plugin. May be omitted for plugins that do not require configuration (for example, when type is \"local\").",
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+					},
+				},
 			},
 		},
 	}

--- a/rundeck/resource_project_test.go
+++ b/rundeck/resource_project_test.go
@@ -135,6 +135,73 @@ resource "rundeck_project" "test" {
 }
 `
 
+func TestAccProject_dynamicResourceModelSource(t *testing.T) {
+	var project rundeck.Project
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccProjectCheckDestroy(&project),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectConfig_dynamicSource,
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists("rundeck_project.dynamic", &project),
+					func(s *terraform.State) error {
+						projectConfig := project.Config.(map[string]interface{})
+
+						if expected := "terraform-acc-test-dynamic"; *project.Name != expected {
+							return fmt.Errorf("wrong name; expected %v, got %v", expected, *project.Name)
+						}
+						if expected := "file"; projectConfig["resources.source.1.type"] != expected {
+							return fmt.Errorf("wrong resources.source.1.type; expected %v, got %v", expected, projectConfig["resources.source.1.type"])
+						}
+						if expected := "local"; projectConfig["resources.source.2.type"] != expected {
+							return fmt.Errorf("wrong resources.source.2.type; expected %v, got %v", expected, projectConfig["resources.source.2.type"])
+						}
+						return nil
+					},
+				),
+			},
+			{
+				RefreshState: true,
+				PlanOnly:     true,
+			},
+		},
+	})
+}
+
+const testAccProjectConfig_dynamicSource = `
+locals {
+  model_sources = [
+    {
+      type = "file"
+      config = {
+        format = "resourceyaml"
+        file   = "/tmp/terraform-acc-dynamic.yaml"
+      }
+    },
+    {
+      type   = "local"
+      config = null
+    },
+  ]
+}
+
+resource "rundeck_project" "dynamic" {
+  name        = "terraform-acc-test-dynamic"
+  description = "Test project with dynamic resource model sources"
+
+  dynamic "resource_model_source" {
+    for_each = local.model_sources
+    content {
+      type   = resource_model_source.value.type
+      config = resource_model_source.value.config
+    }
+  }
+}
+`
+
 const testAccProjectConfig_basic = `
 resource "rundeck_project" "main" {
   name = "terraform-acc-test-basic"

--- a/website/docs/r/project.html.md
+++ b/website/docs/r/project.html.md
@@ -86,8 +86,9 @@ The following arguments are supported:
 
 * `type` - (Required) The name of the resource model plugin to use.
 
-* `config` - (Required) Map of arbitrary configuration properties for the selected resource model
-  plugin.
+* `config` - (Optional) Map of arbitrary configuration properties for the selected resource model
+  plugin. May be omitted for plugins that do not require configuration (for example, when type is
+  `"local"`).
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

- **Fix:** Changes `resource_model_source` in the `rundeck_project` resource from `schema.ListAttribute` to `schema.ListNestedAttribute`, enabling the documented HCL block syntax and `dynamic` block support.
- **Null guard:** Adds a null check on the `config` map in `updateProjectConfig()` so resource model sources without config (e.g., `type = "local"`) don't cause errors.
- **Simplify read:** Replaces manual `ObjectValue`/`ListValue` assembly in `readProject()` with idiomatic `types.ListValueFrom` using model structs.

## Problem

`resource_model_source` was defined as `schema.ListAttribute` with an `ElementType` of `types.ObjectType`. This made it a Terraform **attribute**, which:
- Required assignment syntax: `resource_model_source = [{ ... }]`
- Broke the HCL block syntax shown in the provider documentation: `resource_model_source { ... }`
- Prevented `dynamic` blocks from working

Users saw this error when using block syntax:
```
Required attribute "resource_model_source" not specified
```

## Test plan

- [ ] Existing acceptance tests (`TestAccProject_basic`, `TestAccProject_localSourceNoConfig`) pass -- these already use block syntax
- [ ] Verify `resource_model_source { type = "local" }` (no config) works without error
- [ ] Verify `dynamic "resource_model_source"` blocks work
- [ ] Verify no plan drift on apply -> refresh -> plan cycle


Made with [Cursor](https://cursor.com)