### PR TITLE
fix: allow enforced options with value_choices_url, fix ssh_key_storage_path drift

### DIFF
--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -418,10 +418,14 @@ func (r *jobResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 				}
 
 				// If value_choices_url is set, skip value_choices validation:
-				// Rundeck enforces the constraint server-side against the URL's values.
+				// - when it is unknown, defer validation until apply
+				// - when it is a known non-empty string, Rundeck enforces the constraint
+				//   server-side against the URL's values.
 				if urlAttr, ok := attrs["value_choices_url"]; ok {
-					if urlStr, ok := urlAttr.(types.String); ok && !urlStr.IsNull() && !urlStr.IsUnknown() && urlStr.ValueString() != "" {
-						continue
+					if urlStr, ok := urlAttr.(types.String); ok && !urlStr.IsNull() {
+						if urlStr.IsUnknown() || urlStr.ValueString() != "" {
+							continue
+						}
 					}
 				}
 

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -417,6 +417,14 @@ func (r *jobResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 					}
 				}
 
+				// If value_choices_url is set, skip value_choices validation:
+				// Rundeck enforces the constraint server-side against the URL's values.
+				if urlAttr, ok := attrs["value_choices_url"]; ok {
+					if urlStr, ok := urlAttr.(types.String); ok && !urlStr.IsNull() && !urlStr.IsUnknown() && urlStr.ValueString() != "" {
+						continue
+					}
+				}
+
 				// Check value_choices
 				valueChoicesAttr, hasValueChoices := attrs["value_choices"]
 				if !hasValueChoices {

--- a/rundeck/resource_job_integration_test.go
+++ b/rundeck/resource_job_integration_test.go
@@ -466,6 +466,81 @@ func TestAccJob_ScheduleDayOfMonthIntegration(t *testing.T) {
 	})
 }
 
+// TestAccJob_EnforcedOptionWithValuesURL tests that require_predefined_choice=true
+// is accepted and correctly stored by Rundeck when value_choices_url is set (no
+// static value_choices required).
+func TestAccJob_EnforcedOptionWithValuesURL(t *testing.T) {
+	var jobID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccJobCheckDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_EnforcedOptionWithValuesURL,
+				Check: resource.ComposeTestCheckFunc(
+					testAccJobGetID("rundeck_job.enforced_url_test", &jobID),
+					resource.TestCheckResourceAttr("rundeck_job.enforced_url_test", "option.0.name", "env"),
+					resource.TestCheckResourceAttr("rundeck_job.enforced_url_test", "option.0.require_predefined_choice", "true"),
+					resource.TestCheckResourceAttr("rundeck_job.enforced_url_test", "option.0.value_choices_url", "http://localhost/choices"),
+
+					testAccJobValidateAPI(&jobID, func(jobData map[string]interface{}) error {
+						options, ok := jobData["options"].([]interface{})
+						if !ok || len(options) == 0 {
+							return fmt.Errorf("Options not found in API response")
+						}
+						option := options[0].(map[string]interface{})
+						if enforced, ok := option["enforced"].(bool); !ok || !enforced {
+							return fmt.Errorf("Expected option enforced=true in API response, got %v", option["enforced"])
+						}
+						if valuesUrl, ok := option["valuesUrl"].(string); !ok || valuesUrl == "" {
+							return fmt.Errorf("Expected option valuesUrl to be set in API response")
+						}
+						return nil
+					}),
+				),
+			},
+			// Verify no plan drift on refresh
+			{
+				RefreshState: true,
+				PlanOnly:     true,
+			},
+		},
+	})
+}
+
+const testAccJobConfig_EnforcedOptionWithValuesURL = `
+resource "rundeck_project" "test" {
+  name        = "terraform-acc-test-enforced-url"
+  description = "Test project for enforced option with values URL"
+
+  resource_model_source {
+    type = "file"
+    config = {
+      format = "resourceyaml"
+      file   = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+
+resource "rundeck_job" "enforced_url_test" {
+  project_name = rundeck_project.test.name
+  name         = "enforced-option-url-test"
+  description  = "Job testing require_predefined_choice with value_choices_url"
+
+  command {
+    shell_command = "echo $RD_OPTION_ENV"
+  }
+
+  option {
+    name                    = "env"
+    value_choices_url       = "http://localhost/choices"
+    require_predefined_choice = true
+  }
+}
+`
+
 const testAccJobConfig_ScheduleDayOfMonthIntegration = `
 resource "rundeck_project" "test" {
   name        = "terraform-acc-test-schedule-dom-integration"

--- a/rundeck/resource_project_framework.go
+++ b/rundeck/resource_project_framework.go
@@ -35,7 +35,7 @@ var projectConfigAttributes = map[string]string{
 	"service.FileCopier.default.provider":   "default_node_file_copier_plugin",
 	"service.NodeExecutor.default.provider": "default_node_executor_plugin",
 	"project.ssh-authentication":            "ssh_authentication_type",
-	"project.ssh-keypath":                   "ssh_key_storage_path",
+	"project.ssh-keypath":                   "ssh_key_file_path",
 	"project.ssh-key-storage-path":          "ssh_key_storage_path",
 	"project.ssh-keypath-file":              "ssh_key_file_path",
 }

--- a/rundeck/resource_project_test.go
+++ b/rundeck/resource_project_test.go
@@ -135,6 +135,49 @@ resource "rundeck_project" "test" {
 }
 `
 
+// TestAccProject_SSHKeyFilePath tests that ssh_key_file_path is correctly stored
+// and does not produce drift after apply (regression for project.ssh-keypath mapping bug).
+func TestAccProject_SSHKeyFilePath(t *testing.T) {
+	var project rundeck.Project
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccProjectCheckDestroy(&project),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectConfig_SSHKeyFilePath,
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists("rundeck_project.test", &project),
+					resource.TestCheckResourceAttr("rundeck_project.test", "ssh_key_file_path", "/var/lib/rundeck/.ssh/id_rsa"),
+					resource.TestCheckNoResourceAttr("rundeck_project.test", "ssh_key_storage_path"),
+				),
+			},
+			// Verify no plan drift on refresh — this is the core regression check
+			{
+				RefreshState: true,
+				PlanOnly:     true,
+			},
+		},
+	})
+}
+
+const testAccProjectConfig_SSHKeyFilePath = `
+resource "rundeck_project" "test" {
+  name             = "terraform-acc-test-ssh-key-file-path"
+  description      = "Test project for ssh_key_file_path drift regression"
+  ssh_key_file_path = "/var/lib/rundeck/.ssh/id_rsa"
+
+  resource_model_source {
+    type = "file"
+    config = {
+      format = "resourceyaml"
+      file   = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+`
+
 const testAccProjectConfig_basic = `
 resource "rundeck_project" "main" {
   name = "terraform-acc-test-basic"


### PR DESCRIPTION
## Summary

- **Job options**: `require_predefined_choice = true` was rejected by the validator if `value_choices` (static list) was absent, even when `value_choices_url` was set. The validator now skips `value_choices` validation when `value_choices_url` is non-null — Rundeck enforces the constraint server-side against the URL's values.

- **Project SSH key**: The Rundeck API key `project.ssh-keypath` (filesystem path) was incorrectly mapped to `ssh_key_storage_path` instead of `ssh_key_file_path`. This caused a *"Provider produced inconsistent result after apply"* error on `rundeck_project` whenever Rundeck returned this key in its response (e.g. default value `/home/rundeck/.ssh/id_rundeck`).
