### PR TITLE
fix: use correct JSON field names for runner selector

### DIFF
--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -137,8 +137,8 @@ type jobNodeFilters struct {
 
 type jobRunnerSelector struct {
 	Filter     string `json:"filter,omitempty"`
-	FilterMode string `json:"filterMode,omitempty"`
-	FilterType string `json:"filterType,omitempty"`
+	FilterMode string `json:"runnerFilterMode,omitempty"`
+	FilterType string `json:"runnerFilterType,omitempty"`
 }
 
 func NewJobResource() resource.Resource {


### PR DESCRIPTION
The runnerFilterMode and runnerFilterType fields were serialized as filterMode and filterType, causing Rundeck to ignore them. Restored the runner prefix to match the API's expected field names.

Fix #244 