### PR TITLE
fix: separate workflow and node keepgoing flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**Bug Fixes**
+
+### Job Resource
+
+- **Separate workflow and node `keepgoing` flags** - `continue_on_error` and `continue_next_node_on_error` were both wired to the dispatch (node-level) `keepgoing`, leaving `continue_on_error` inert and making it impossible to represent a job whose workflow `keepgoing` differs from its dispatch `keepgoing`. `continue_on_error` now maps to the workflow `<sequence keepgoing>` and `continue_next_node_on_error` to the node `<dispatch keepgoing>`, and each is read back into its own attribute. Jobs that previously set `continue_next_node_on_error` to control workflow keepgoing should set `continue_on_error` instead.
+
 ## 1.2.2
 
 **Bug Fixes**

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -1063,8 +1063,8 @@ func (r *jobResource) planToJobJSON(ctx context.Context, plan *jobResourceModel)
 			Commands: commands,
 			Strategy: plan.CommandOrderingStrategy.ValueString(),
 		}
-		if !plan.ContinueNextNodeOnError.IsNull() {
-			job.Sequence.KeepGoing = plan.ContinueNextNodeOnError.ValueBool()
+		if !plan.ContinueOnError.IsNull() {
+			job.Sequence.KeepGoing = plan.ContinueOnError.ValueBool()
 		}
 	}
 
@@ -1259,7 +1259,7 @@ func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *j
 		if job.Sequence.Strategy != "" {
 			state.CommandOrderingStrategy = types.StringValue(job.Sequence.Strategy)
 		}
-		state.ContinueNextNodeOnError = types.BoolValue(job.Sequence.KeepGoing)
+		state.ContinueOnError = types.BoolValue(job.Sequence.KeepGoing)
 	}
 
 	// Convert schedule from JSON to state
@@ -1413,8 +1413,9 @@ func (r *jobResource) jobJSONAPIToState(ctx context.Context, job *JobJSON, state
 
 	// Handle sequence
 	if job.Sequence != nil {
+		// continue_on_error comes from sequence.keepgoing (workflow-level setting)
 		if keepGoing, ok := job.Sequence["keepgoing"].(bool); ok {
-			state.ContinueNextNodeOnError = types.BoolValue(keepGoing)
+			state.ContinueOnError = types.BoolValue(keepGoing)
 		}
 		if strategy, ok := job.Sequence["strategy"].(string); ok {
 			state.CommandOrderingStrategy = types.StringValue(strategy)

--- a/rundeck/resource_job_keepgoing_test.go
+++ b/rundeck/resource_job_keepgoing_test.go
@@ -1,0 +1,141 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// These are plain unit tests (no TF_ACC / live Rundeck required). They guard
+// the mapping that keeps the two job-level keepgoing flags independent:
+//   - continue_on_error            <-> workflow  <sequence keepgoing>
+//   - continue_next_node_on_error  <-> node      <dispatch keepgoing>
+// Previously both attributes were wired to the dispatch keepgoing, leaving
+// continue_on_error inert and making the two flags impossible to differ.
+
+// testSingleShellCommandList builds a minimal one-command list so that
+// planToJobJSON produces a non-nil Sequence.
+func testSingleShellCommandList(t *testing.T) types.List {
+	t.Helper()
+
+	emptyObjList := types.ListNull(types.ObjectType{})
+	cmd, diags := types.ObjectValue(commandObjectType.AttrTypes, map[string]attr.Value{
+		"description":                 types.StringValue("echo"),
+		"shell_command":               types.StringValue("echo hi"),
+		"inline_script":               types.StringNull(),
+		"script_url":                  types.StringNull(),
+		"script_file":                 types.StringNull(),
+		"script_file_args":            types.StringNull(),
+		"expand_token_in_script_file": types.BoolNull(),
+		"file_extension":              types.StringNull(),
+		"keep_going_on_success":       types.BoolNull(),
+		"plugins":                     emptyObjList,
+		"script_interpreter":          emptyObjList,
+		"job":                         emptyObjList,
+		"step_plugin":                 emptyObjList,
+		"node_step_plugin":            emptyObjList,
+		"error_handler":               emptyObjList,
+	})
+	if diags.HasError() {
+		t.Fatalf("building command object: %v", diags)
+	}
+
+	list, diags := types.ListValue(commandObjectType, []attr.Value{cmd})
+	if diags.HasError() {
+		t.Fatalf("building command list: %v", diags)
+	}
+	return list
+}
+
+func TestPlanToJobJSON_keepGoingFlagsAreIndependent(t *testing.T) {
+	cases := []struct {
+		name             string
+		continueOnError  bool
+		continueNextNode bool
+	}{
+		{"workflow on, node off", true, false},
+		{"workflow off, node on", false, true},
+	}
+
+	r := &jobResource{}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			plan := &jobResourceModel{
+				Name:                    types.StringValue("test-job"),
+				ProjectName:             types.StringValue("test-project"),
+				Description:             types.StringValue("desc"),
+				Command:                 testSingleShellCommandList(t),
+				ContinueOnError:         types.BoolValue(tc.continueOnError),
+				ContinueNextNodeOnError: types.BoolValue(tc.continueNextNode),
+			}
+
+			job, err := r.planToJobJSON(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("planToJobJSON: %v", err)
+			}
+
+			if job.Sequence == nil {
+				t.Fatal("expected job.Sequence to be set")
+			}
+			if job.Sequence.KeepGoing != tc.continueOnError {
+				t.Errorf("workflow sequence keepgoing = %v, want %v (from continue_on_error)",
+					job.Sequence.KeepGoing, tc.continueOnError)
+			}
+
+			if job.NodeFilters == nil || job.NodeFilters.Dispatch == nil {
+				t.Fatal("expected job.NodeFilters.Dispatch to be set")
+			}
+			if job.NodeFilters.Dispatch.KeepGoing != tc.continueNextNode {
+				t.Errorf("node dispatch keepgoing = %v, want %v (from continue_next_node_on_error)",
+					job.NodeFilters.Dispatch.KeepGoing, tc.continueNextNode)
+			}
+		})
+	}
+}
+
+func TestJobJSONToState_keepGoingFlagsReadIndependently(t *testing.T) {
+	r := &jobResource{}
+	job := &jobJSON{
+		Sequence: &jobSequence{KeepGoing: true, Commands: []interface{}{}},
+		NodeFilters: &jobNodeFilters{
+			Dispatch: &jobDispatch{KeepGoing: false},
+		},
+	}
+
+	state := &jobResourceModel{}
+	if err := r.jobJSONToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONToState: %v", err)
+	}
+
+	if !state.ContinueOnError.ValueBool() {
+		t.Error("sequence keepgoing=true should map to continue_on_error=true")
+	}
+	if state.ContinueNextNodeOnError.ValueBool() {
+		t.Error("dispatch keepgoing=false should map to continue_next_node_on_error=false")
+	}
+}
+
+func TestJobJSONAPIToState_keepGoingFlagsReadIndependently(t *testing.T) {
+	r := &jobResource{}
+	job := &JobJSON{
+		Sequence: map[string]interface{}{"keepgoing": true},
+		NodeFilters: map[string]interface{}{
+			"dispatch": map[string]interface{}{"keepgoing": false},
+		},
+	}
+
+	state := &jobResourceModel{}
+	if err := r.jobJSONAPIToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONAPIToState: %v", err)
+	}
+
+	if !state.ContinueOnError.ValueBool() {
+		t.Error("sequence keepgoing=true should map to continue_on_error=true")
+	}
+	if state.ContinueNextNodeOnError.ValueBool() {
+		t.Error("dispatch keepgoing=false should map to continue_next_node_on_error=false")
+	}
+}


### PR DESCRIPTION
## What

Splits the two job-level keepgoing flags that were both wired to the node
(dispatch) keepgoing:

| Attribute | Rundeck mapping |
|---|---|
| `continue_on_error` | workflow `<sequence keepgoing>` |
| `continue_next_node_on_error` | node `<dispatch keepgoing>` |

## Why

`continue_on_error` was declared in the schema but never read or written —
both it and `continue_next_node_on_error` collapsed onto the dispatch
keepgoing. As a result:

- `continue_on_error` was inert.
- A job whose workflow keepgoing differs from its dispatch keepgoing could
  not be represented; the two flags always drifted together.

This also brings the code in line with the existing documentation, which
already describes `continue_on_error` as governing subsequent **steps**
(workflow) and `continue_next_node_on_error` as governing subsequent
**nodes** (dispatch) — see `website/docs/r/job.html.md`.

## Changes

- `planToJobJSON`: workflow sequence keepgoing now sourced from
  `continue_on_error` (was `continue_next_node_on_error`).
- `jobJSONToState` and `jobJSONAPIToState`: sequence keepgoing now read back
  into `continue_on_error` (was `continue_next_node_on_error`). Dispatch
  keepgoing → `continue_next_node_on_error` is unchanged.
- Added unit tests covering the write path (both flag combinations) and both
  read paths. These run without a live Rundeck.
- CHANGELOG entry under Unreleased.

## Migration note (behavior change)

Configurations that previously set `continue_next_node_on_error` to control
workflow keepgoing should switch to `continue_on_error`. On the next apply,
`continue_next_node_on_error` will now affect only the node dispatch
keepgoing.

## Follow-up for maintainers

`continue_on_error` is now read back from sequence keepgoing, so it may no
longer need to sit in `ImportStateVerifyIgnore`
(`rundeck/import_resource_job_test.go`). I left it in place pending
confirmation that `sequence.keepgoing` round-trips on import across the
Rundeck versions this provider's CI targets — happy to remove it if that's
verified.

## Testing

- `go build ./...`, `go vet ./rundeck/` — clean.
- New unit tests pass (`go test ./rundeck/ -run keepGoing`).
- Existing `TestAcc*` suites require a live Rundeck and were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
