### PR TITLE
feat: add per-project dispatch configuration to system_runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**Enhancements**
+
+### System Runner Resource
+
+- **Added per-project dispatch configuration support** - `rundeck_system_runner` now supports `assigned_projects_config`, a new nested attribute that allows configuring per-project runner dispatch settings (`runner_as_node_enabled`, `remote_node_dispatch`, `runner_node_filter`) directly in Terraform. This eliminates the need for manual UI/API configuration after Terraform apply, enabling full Infrastructure-as-Code for system-level runners across multiple projects. When a project appears in both `assigned_projects` and `assigned_projects_config`, the latter takes precedence, allowing gradual migration. This feature was designed to support large-scale DR automation scenarios where hundreds of runners need to be managed as code.
+
 ## 1.2.2
 
 **Bug Fixes**

--- a/docs/resource_system_runner.md
+++ b/docs/resource_system_runner.md
@@ -16,7 +16,7 @@ resource "rundeck_system_runner" "basic" {
   
   assigned_projects = {
     "project1" = "admin"
-    "project2" = "user"
+    "project2" = "execute"
   }
 }
 ```
@@ -89,12 +89,12 @@ The following arguments are supported:
 
 - `tag_names` - (Optional) Comma-separated tags for the runner. Rundeck normalizes tags to lowercase and sorts them alphabetically. The provider handles this automatically to prevent plan drift.
 
-- `assigned_projects` - (Optional) Map of assigned projects with their access levels (e.g., `"project-name" = "admin"`). This is the legacy approach for simple project assignments without dispatch configuration.
+- `assigned_projects` - (Optional) Map of assigned projects with their access levels. Valid access levels: `read`, `execute`, `admin`. This is the legacy approach for simple project assignments without dispatch configuration.
 
 - `project_runner_as_node` - (Optional) Map of projects where the runner acts as a node (boolean values). **Deprecated:** Use `assigned_projects_config` instead for new configurations.
 
 - `assigned_projects_config` - (Optional) Map of project configurations with full dispatch settings. Each project configuration supports:
-  - `access_level` - (Required) Access level for the project (e.g., "admin", "user").
+  - `access_level` - (Required) Access level for the project. Valid values: `read`, `execute`, `admin`.
   - `runner_as_node_enabled` - (Optional, Default: `false`) Enable the runner to act as a node for this project.
   - `remote_node_dispatch` - (Optional, Default: `false`) Enable remote node dispatch for the runner in this project.
   - `runner_node_filter` - (Optional) Node filter string for the runner in this project (e.g., "tags: RUNNER").

--- a/docs/resource_system_runner.md
+++ b/docs/resource_system_runner.md
@@ -159,6 +159,6 @@ terraform import rundeck_system_runner.example runner-id-here
 
 ## Requirements
 
-- Rundeck version: 5.0.0+ / RBA 6.1.0+
+- Rundeck version: 5.17.0+
 - API version: 56+ (Enterprise feature)
 - Set `api_version = "56"` or higher in your provider configuration

--- a/docs/resource_system_runner.md
+++ b/docs/resource_system_runner.md
@@ -4,24 +4,75 @@ This resource allows you to create and manage Rundeck System Runners using the n
 
 ## Example Usage
 
+### Basic Usage with Simple Project Assignment
+
 ```hcl
-resource "rundeck_system_runner" "example" {
-  name        = "my-runner"
-  description = "Example runner created with Terraform"
-  tag_names   = "production,api"
+resource "rundeck_system_runner" "basic" {
+  name              = "my-runner"
+  description       = "Example runner created with Terraform"
+  tag_names         = "production,api"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
   
   assigned_projects = {
-    "project1" = "full"
-    "project2" = "limited"
+    "project1" = "admin"
+    "project2" = "user"
   }
+}
+```
+
+### Advanced Usage with Per-Project Dispatch Configuration
+
+```hcl
+resource "rundeck_system_runner" "with_dispatch" {
+  name              = "runner-with-dispatch"
+  description       = "Runner with per-project dispatch settings"
+  tag_names         = "production,runners"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
   
-  project_runner_as_node = {
-    "project1" = true
-    "project2" = false
+  assigned_projects_config = {
+    "project1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: RUNNER"
+    }
+    
+    "project2" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = false
+      runner_node_filter       = "tags: DEFAULT"
+    }
   }
-  
-  installation_type = "docker"
+}
+```
+
+### Mixed Configuration (Gradual Migration)
+
+```hcl
+resource "rundeck_system_runner" "mixed" {
+  name              = "mixed-runner"
+  description       = "Runner with mixed configuration"
+  tag_names         = "production"
+  installation_type = "linux"
   replica_type      = "manual"
+  
+  # Simple projects without special dispatch needs
+  assigned_projects = {
+    "simple-project" = "admin"
+  }
+  
+  # Projects requiring specific dispatch configuration
+  assigned_projects_config = {
+    "dr-project" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR,tags: RUNNER"
+    }
+  }
 }
 ```
 
@@ -29,21 +80,74 @@ resource "rundeck_system_runner" "example" {
 
 The following arguments are supported:
 
-- `name` - (Required) Name of the runner
-- `description` - (Required) Description of the runner
-- `tag_names` - (Optional) Comma separated tags for the runner
-- `assigned_projects` - (Optional) Map of assigned projects with their access levels
-- `project_runner_as_node` - (Optional) Map of projects where runner acts as node (boolean values)
-- `installation_type` - (Optional) Installation type of the runner
-- `replica_type` - (Optional) Replica type of the runner
+### Required Arguments
+
+- `name` - (Required) Name of the runner.
+- `description` - (Required) Description of the runner.
+
+### Optional Arguments
+
+- `tag_names` - (Optional) Comma-separated tags for the runner. Rundeck normalizes tags to lowercase and sorts them alphabetically. The provider handles this automatically to prevent plan drift.
+
+- `assigned_projects` - (Optional) Map of assigned projects with their access levels (e.g., `"project-name" = "admin"`). This is the legacy approach for simple project assignments without dispatch configuration.
+
+- `project_runner_as_node` - (Optional) Map of projects where the runner acts as a node (boolean values). **Deprecated:** Use `assigned_projects_config` instead for new configurations.
+
+- `assigned_projects_config` - (Optional) Map of project configurations with full dispatch settings. Each project configuration supports:
+  - `access_level` - (Required) Access level for the project (e.g., "admin", "user").
+  - `runner_as_node_enabled` - (Optional, Default: `false`) Enable the runner to act as a node for this project.
+  - `remote_node_dispatch` - (Optional, Default: `false`) Enable remote node dispatch for the runner in this project.
+  - `runner_node_filter` - (Optional) Node filter string for the runner in this project (e.g., "tags: RUNNER").
+
+- `installation_type` - (Optional, Default: `"linux"`) Installation type of the runner. Valid values: `linux`, `windows`, `kubernetes`, `docker`.
+
+- `replica_type` - (Optional, Default: `"manual"`) Replica type of the runner. Valid values: `manual`, `ephemeral`.
+
+### Precedence Rules
+
+When a project appears in both `assigned_projects` and `assigned_projects_config`, the configuration in `assigned_projects_config` takes precedence. This allows for gradual migration from the legacy approach to the new dispatch configuration.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `runner_id` - The ID of the created runner
-- `token` - Authentication token for the runner (sensitive)
-- `download_token` - Download token for the runner package (sensitive)
+- `id` - The ID of the runner.
+- `runner_id` - The ID of the created runner.
+- `token` - Authentication token for the runner (sensitive, only available on creation).
+- `download_token` - Download token for the runner package (sensitive, only available on creation).
+
+## Important Notes
+
+### API Limitations
+
+The Rundeck API does not expose a GET endpoint for per-project dispatch settings (`runner_as_node_enabled`, `remote_node_dispatch`, `runner_node_filter`). As a result:
+
+- These settings are stored in Terraform state during `create`/`update` operations.
+- The provider cannot detect out-of-band changes made via the Rundeck UI or API.
+- If dispatch settings are modified outside of Terraform, use `terraform import` to refresh the state.
+
+### Disaster Recovery / High Availability Use Case
+
+This feature was designed to support large-scale DR automation scenarios where hundreds of runners need to be managed with Terraform. Example:
+
+```hcl
+resource "rundeck_system_runner" "dr_primary" {
+  name              = "dr-primary-runner"
+  description       = "Primary DR runner"
+  tag_names         = "dr,primary"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
+
+  assigned_projects_config = {
+    "dr-project-1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-PRIMARY"
+    }
+  }
+}
+```
 
 ## Import
 
@@ -53,6 +157,8 @@ Runners can be imported using their ID:
 terraform import rundeck_system_runner.example runner-id-here
 ```
 
-## Note
+## Requirements
 
-This resource uses the new Rundeck v2 API and requires Rundeck version 42 or later.
+- Rundeck version: 5.0.0+ / RBA 6.1.0+
+- API version: 56+ (Enterprise feature)
+- Set `api_version = "56"` or higher in your provider configuration

--- a/examples/system_runner.tf
+++ b/examples/system_runner.tf
@@ -38,7 +38,7 @@ resource "rundeck_system_runner" "with_dispatch" {
     }
 
     "project-3" = {
-      access_level             = "user"
+      access_level             = "execute"
       runner_as_node_enabled   = false
       remote_node_dispatch     = false
     }

--- a/examples/system_runner.tf
+++ b/examples/system_runner.tf
@@ -1,0 +1,121 @@
+# Example 1: Basic system runner with legacy assigned_projects
+resource "rundeck_system_runner" "basic" {
+  name              = "basic-runner"
+  description       = "Basic system runner"
+  tag_names         = "production,default"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
+
+  # Legacy approach - simple project assignment without dispatch config
+  assigned_projects = {
+    "project-1" = "admin"
+    "project-2" = "user"
+  }
+}
+
+# Example 2: System runner with full per-project dispatch configuration
+resource "rundeck_system_runner" "with_dispatch" {
+  name              = "runner-with-dispatch"
+  description       = "System runner with per-project dispatch settings"
+  tag_names         = "production,runners"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
+
+  # New approach - full dispatch configuration per project
+  assigned_projects_config = {
+    "project-1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: RUNNER"
+    }
+
+    "project-2" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = false
+      runner_node_filter       = "tags: DEFAULT"
+    }
+
+    "project-3" = {
+      access_level             = "user"
+      runner_as_node_enabled   = false
+      remote_node_dispatch     = false
+    }
+  }
+}
+
+# Example 3: Mixed usage (assigned_projects_config takes precedence)
+resource "rundeck_system_runner" "mixed" {
+  name              = "mixed-runner"
+  description       = "System runner with mixed configuration"
+  tag_names         = "production"
+  installation_type = "linux"
+  replica_type      = "manual"
+
+  # Projects without special dispatch needs
+  assigned_projects = {
+    "simple-project-1" = "admin"
+    "simple-project-2" = "user"
+  }
+
+  # Projects with specific dispatch configuration
+  # These will override any entry in assigned_projects for the same project
+  assigned_projects_config = {
+    "dr-project" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR,tags: RUNNER"
+    }
+  }
+}
+
+# Example 4: DR/HA use case - multiple runners with different dispatch configs
+resource "rundeck_system_runner" "dr_primary" {
+  name              = "dr-primary-runner"
+  description       = "Primary DR runner"
+  tag_names         = "dr,primary"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
+
+  assigned_projects_config = {
+    "dr-project-1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-PRIMARY"
+    }
+
+    "dr-project-2" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-PRIMARY"
+    }
+  }
+}
+
+resource "rundeck_system_runner" "dr_secondary" {
+  name              = "dr-secondary-runner"
+  description       = "Secondary DR runner"
+  tag_names         = "dr,secondary"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
+
+  assigned_projects_config = {
+    "dr-project-1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-SECONDARY"
+    }
+
+    "dr-project-2" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-SECONDARY"
+    }
+  }
+}

--- a/rundeck/resource_system_runner_framework.go
+++ b/rundeck/resource_system_runner_framework.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -49,18 +50,28 @@ type systemRunnerResource struct {
 	clients *RundeckClients
 }
 
+// projectRunnerConfig represents the configuration for a project assignment
+// including access level and node dispatch settings
+type projectRunnerConfig struct {
+	AccessLevel          types.String `tfsdk:"access_level"`
+	RunnerAsNodeEnabled types.Bool   `tfsdk:"runner_as_node_enabled"`
+	RemoteNodeDispatch  types.Bool   `tfsdk:"remote_node_dispatch"`
+	RunnerNodeFilter    types.String `tfsdk:"runner_node_filter"`
+}
+
 type systemRunnerResourceModel struct {
-	ID                  types.String    `tfsdk:"id"`
-	Name                types.String    `tfsdk:"name"`
-	Description         types.String    `tfsdk:"description"`
-	TagNames            RunnerTagsValue `tfsdk:"tag_names"`
-	AssignedProjects    types.Map       `tfsdk:"assigned_projects"`
-	ProjectRunnerAsNode types.Map       `tfsdk:"project_runner_as_node"`
-	InstallationType    types.String    `tfsdk:"installation_type"`
-	ReplicaType         types.String    `tfsdk:"replica_type"`
-	RunnerID            types.String    `tfsdk:"runner_id"`
-	Token               types.String    `tfsdk:"token"`
-	DownloadToken       types.String    `tfsdk:"download_token"`
+	ID                     types.String    `tfsdk:"id"`
+	Name                   types.String    `tfsdk:"name"`
+	Description            types.String    `tfsdk:"description"`
+	TagNames               RunnerTagsValue `tfsdk:"tag_names"`
+	AssignedProjects       types.Map       `tfsdk:"assigned_projects"`
+	ProjectRunnerAsNode    types.Map       `tfsdk:"project_runner_as_node"`
+	AssignedProjectsConfig types.Map       `tfsdk:"assigned_projects_config"`
+	InstallationType       types.String    `tfsdk:"installation_type"`
+	ReplicaType            types.String    `tfsdk:"replica_type"`
+	RunnerID               types.String    `tfsdk:"runner_id"`
+	Token                  types.String    `tfsdk:"token"`
+	DownloadToken          types.String    `tfsdk:"download_token"`
 }
 
 func (r *systemRunnerResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -100,6 +111,34 @@ func (r *systemRunnerResource) Schema(_ context.Context, _ resource.SchemaReques
 				Description: "Map of projects where runner acts as node.",
 				ElementType: types.BoolType,
 				Optional:    true,
+			},
+			"assigned_projects_config": schema.MapNestedAttribute{
+				Description: "Map of project configurations with full dispatch settings. When a project appears in both assigned_projects and assigned_projects_config, assigned_projects_config takes precedence.",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"access_level": schema.StringAttribute{
+							Description: "Access level for the project (e.g., 'admin', 'user').",
+							Required:    true,
+						},
+						"runner_as_node_enabled": schema.BoolAttribute{
+							Description: "Enable the runner to act as a node for this project.",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+						},
+						"remote_node_dispatch": schema.BoolAttribute{
+							Description: "Enable remote node dispatch for the runner in this project.",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+						},
+						"runner_node_filter": schema.StringAttribute{
+							Description: "Node filter string for the runner in this project.",
+							Optional:    true,
+						},
+					},
+				},
 			},
 			"installation_type": schema.StringAttribute{
 				Description: "Installation type of the runner (linux, windows, kubernetes, docker).",
@@ -248,6 +287,98 @@ func (r *systemRunnerResource) Create(ctx context.Context, req resource.CreateRe
 		plan.DownloadToken = types.StringValue(*response.DownloadTk)
 	}
 
+	// Get runner ID for dispatch settings
+	runnerId := plan.RunnerID.ValueString()
+
+	// Handle assigned_projects_config - full dispatch configuration per project
+	if !plan.AssignedProjectsConfig.IsNull() && !plan.AssignedProjectsConfig.IsUnknown() {
+		projectConfigs := make(map[string]projectRunnerConfig)
+		resp.Diagnostics.Append(plan.AssignedProjectsConfig.ElementsAs(ctx, &projectConfigs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Build merged project assignments (assigned_projects_config takes precedence)
+		mergedProjects := make(map[string]string)
+
+		// First, add projects from assigned_projects
+		if !plan.AssignedProjects.IsNull() && !plan.AssignedProjects.IsUnknown() {
+			projects := make(map[string]types.String)
+			resp.Diagnostics.Append(plan.AssignedProjects.ElementsAs(ctx, &projects, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			for k, v := range projects {
+				mergedProjects[k] = v.ValueString()
+			}
+		}
+
+		// Then, add/override with assigned_projects_config
+		for projectName, config := range projectConfigs {
+			mergedProjects[projectName] = config.AccessLevel.ValueString()
+		}
+
+		// Apply project assignments if needed (if assigned_projects_config added new projects)
+		if len(mergedProjects) > 0 {
+			saveRequest := openapi.NewSaveProjectRunnerRequest(runnerId)
+			saveRequest.SetName(name)
+			saveRequest.SetDescription(description)
+			saveRequest.SetAssignedProjects(mergedProjects)
+
+			if !plan.TagNames.IsNull() && !plan.TagNames.IsUnknown() {
+				saveRequest.SetTagNames(plan.TagNames.ValueString())
+			}
+
+			installationType := plan.InstallationType.ValueString()
+			if installationType == "" {
+				installationType = "linux"
+			}
+			saveRequest.SetInstallationType(strings.ToLower(installationType))
+
+			replicaType := plan.ReplicaType.ValueString()
+			if replicaType == "" {
+				replicaType = "manual"
+			}
+			saveRequest.SetReplicaType(strings.ToLower(replicaType))
+
+			_, _, err = client.RunnerAPI.SaveRunner(apiCtx, runnerId).SaveProjectRunnerRequest(*saveRequest).Execute()
+			if err != nil {
+				resp.Diagnostics.AddWarning(
+					"Warning assigning projects",
+					fmt.Sprintf("Runner created but failed to update project assignments: %s", err.Error()),
+				)
+			}
+		}
+
+		// Apply dispatch settings for each project in assigned_projects_config
+		for projectName, config := range projectConfigs {
+			// Only apply dispatch settings if any are set
+			if !config.RunnerAsNodeEnabled.IsNull() || !config.RemoteNodeDispatch.IsNull() || !config.RunnerNodeFilter.IsNull() {
+				nodeDispatchRequest := openapi.NewSaveProjectRunnerNodeDispatchSettingsRequest(runnerId)
+
+				if !config.RunnerAsNodeEnabled.IsNull() {
+					nodeDispatchRequest.SetRunnerAsNodeEnabled(config.RunnerAsNodeEnabled.ValueBool())
+				}
+
+				if !config.RemoteNodeDispatch.IsNull() {
+					nodeDispatchRequest.SetRemoteNodeDispatch(config.RemoteNodeDispatch.ValueBool())
+				}
+
+				if !config.RunnerNodeFilter.IsNull() && !config.RunnerNodeFilter.IsUnknown() {
+					nodeDispatchRequest.SetRunnerNodeFilter(config.RunnerNodeFilter.ValueString())
+				}
+
+				_, _, err := client.RunnerAPI.SaveProjectRunnerNodeDispatchSettings(apiCtx, projectName).SaveProjectRunnerNodeDispatchSettingsRequest(*nodeDispatchRequest).Execute()
+				if err != nil {
+					resp.Diagnostics.AddWarning(
+						"Warning configuring node dispatch",
+						fmt.Sprintf("Runner created but failed to configure node dispatch for project %s: %s", projectName, err.Error()),
+					)
+				}
+			}
+		}
+	}
+
 	// Set state initially
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -332,6 +463,10 @@ func (r *systemRunnerResource) Read(ctx context.Context, req resource.ReadReques
 	// Preserve the existing values from state to prevent drift
 	// (state.Token and state.DownloadToken are already set from req.State.Get())
 
+	// AssignedProjects, ProjectRunnerAsNode, and AssignedProjectsConfig are also preserved from state
+	// The RunnerInfo API does not return per-project dispatch settings, so we rely on state
+	// (state.AssignedProjects, state.ProjectRunnerAsNode, state.AssignedProjectsConfig already set from req.State.Get())
+
 	// InstallationType and ReplicaType are returned by the RunnerInfo API
 	// With new feature flags, API returns lowercase values directly
 	if runnerInfo.InstallationType != nil {
@@ -395,17 +530,36 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 	// Enum values are lowercase (manual, ephemeral) with new SDK
 	saveRequest.SetReplicaType(strings.ToLower(replicaType))
 
+	// Build merged project assignments (assigned_projects_config takes precedence)
+	mergedProjects := make(map[string]string)
+
+	// First, add projects from assigned_projects
 	if !plan.AssignedProjects.IsNull() && !plan.AssignedProjects.IsUnknown() {
 		projects := make(map[string]types.String)
 		resp.Diagnostics.Append(plan.AssignedProjects.ElementsAs(ctx, &projects, false)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		projectsMap := make(map[string]string)
 		for k, v := range projects {
-			projectsMap[k] = v.ValueString()
+			mergedProjects[k] = v.ValueString()
 		}
-		saveRequest.SetAssignedProjects(projectsMap)
+	}
+
+	// Then, add/override with assigned_projects_config
+	if !plan.AssignedProjectsConfig.IsNull() && !plan.AssignedProjectsConfig.IsUnknown() {
+		projectConfigs := make(map[string]projectRunnerConfig)
+		resp.Diagnostics.Append(plan.AssignedProjectsConfig.ElementsAs(ctx, &projectConfigs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		for projectName, config := range projectConfigs {
+			mergedProjects[projectName] = config.AccessLevel.ValueString()
+		}
+	}
+
+	// Apply merged projects if any
+	if len(mergedProjects) > 0 {
+		saveRequest.SetAssignedProjects(mergedProjects)
 	}
 
 	// Execute the save request
@@ -422,6 +576,42 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 			fmt.Sprintf("Could not update system runner %s: %s", runnerId, err.Error()),
 		)
 		return
+	}
+
+	// Update dispatch settings for each project in assigned_projects_config
+	if !plan.AssignedProjectsConfig.IsNull() && !plan.AssignedProjectsConfig.IsUnknown() {
+		projectConfigs := make(map[string]projectRunnerConfig)
+		resp.Diagnostics.Append(plan.AssignedProjectsConfig.ElementsAs(ctx, &projectConfigs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		for projectName, config := range projectConfigs {
+			// Only apply dispatch settings if any are set
+			if !config.RunnerAsNodeEnabled.IsNull() || !config.RemoteNodeDispatch.IsNull() || !config.RunnerNodeFilter.IsNull() {
+				nodeDispatchRequest := openapi.NewSaveProjectRunnerNodeDispatchSettingsRequest(runnerId)
+
+				if !config.RunnerAsNodeEnabled.IsNull() {
+					nodeDispatchRequest.SetRunnerAsNodeEnabled(config.RunnerAsNodeEnabled.ValueBool())
+				}
+
+				if !config.RemoteNodeDispatch.IsNull() {
+					nodeDispatchRequest.SetRemoteNodeDispatch(config.RemoteNodeDispatch.ValueBool())
+				}
+
+				if !config.RunnerNodeFilter.IsNull() && !config.RunnerNodeFilter.IsUnknown() {
+					nodeDispatchRequest.SetRunnerNodeFilter(config.RunnerNodeFilter.ValueString())
+				}
+
+				_, _, err := client.RunnerAPI.SaveProjectRunnerNodeDispatchSettings(apiCtx, projectName).SaveProjectRunnerNodeDispatchSettingsRequest(*nodeDispatchRequest).Execute()
+				if err != nil {
+					resp.Diagnostics.AddWarning(
+						"Warning updating node dispatch",
+						fmt.Sprintf("Runner updated but failed to configure node dispatch for project %s: %s", projectName, err.Error()),
+					)
+				}
+			}
+		}
 	}
 
 	// Set state with normalized values

--- a/rundeck/resource_system_runner_framework.go
+++ b/rundeck/resource_system_runner_framework.go
@@ -356,11 +356,11 @@ func (r *systemRunnerResource) Create(ctx context.Context, req resource.CreateRe
 			if !config.RunnerAsNodeEnabled.IsNull() || !config.RemoteNodeDispatch.IsNull() || !config.RunnerNodeFilter.IsNull() {
 				nodeDispatchRequest := openapi.NewSaveProjectRunnerNodeDispatchSettingsRequest(runnerId)
 
-				if !config.RunnerAsNodeEnabled.IsNull() {
+				if !config.RunnerAsNodeEnabled.IsNull() && !config.RunnerAsNodeEnabled.IsUnknown() {
 					nodeDispatchRequest.SetRunnerAsNodeEnabled(config.RunnerAsNodeEnabled.ValueBool())
 				}
 
-				if !config.RemoteNodeDispatch.IsNull() {
+				if !config.RemoteNodeDispatch.IsNull() && !config.RemoteNodeDispatch.IsUnknown() {
 					nodeDispatchRequest.SetRemoteNodeDispatch(config.RemoteNodeDispatch.ValueBool())
 				}
 
@@ -557,8 +557,9 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 		}
 	}
 
-	// Apply merged projects if any
-	if len(mergedProjects) > 0 {
+	// Apply merged projects if assigned_projects or assigned_projects_config are set
+	// This allows users to clear all assignments by setting both to empty maps
+	if !plan.AssignedProjects.IsNull() || !plan.AssignedProjectsConfig.IsNull() {
 		saveRequest.SetAssignedProjects(mergedProjects)
 	}
 
@@ -591,11 +592,11 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 			if !config.RunnerAsNodeEnabled.IsNull() || !config.RemoteNodeDispatch.IsNull() || !config.RunnerNodeFilter.IsNull() {
 				nodeDispatchRequest := openapi.NewSaveProjectRunnerNodeDispatchSettingsRequest(runnerId)
 
-				if !config.RunnerAsNodeEnabled.IsNull() {
+				if !config.RunnerAsNodeEnabled.IsNull() && !config.RunnerAsNodeEnabled.IsUnknown() {
 					nodeDispatchRequest.SetRunnerAsNodeEnabled(config.RunnerAsNodeEnabled.ValueBool())
 				}
 
-				if !config.RemoteNodeDispatch.IsNull() {
+				if !config.RemoteNodeDispatch.IsNull() && !config.RemoteNodeDispatch.IsUnknown() {
 					nodeDispatchRequest.SetRemoteNodeDispatch(config.RemoteNodeDispatch.ValueBool())
 				}
 

--- a/rundeck/resource_system_runner_framework.go
+++ b/rundeck/resource_system_runner_framework.go
@@ -118,7 +118,7 @@ func (r *systemRunnerResource) Schema(_ context.Context, _ resource.SchemaReques
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"access_level": schema.StringAttribute{
-							Description: "Access level for the project (e.g., 'admin', 'user').",
+							Description: "Access level for the project. Valid values: 'read', 'execute', 'admin'.",
 							Required:    true,
 						},
 						"runner_as_node_enabled": schema.BoolAttribute{

--- a/rundeck/resource_system_runner_test.go
+++ b/rundeck/resource_system_runner_test.go
@@ -162,9 +162,174 @@ resource "rundeck_system_runner" "test" {
   tag_names        = "terraform,updated"
   installation_type = "docker"
   replica_type     = "ephemeral"
-  
+
   assigned_projects = {
     "test-project" = ".*"
+  }
+}
+`
+
+func TestAccRundeckSystemRunner_withAssignedProjectsConfig(t *testing.T) {
+	if os.Getenv("RUNDECK_ENTERPRISE_TESTS") != "1" {
+		t.Skip("ENTERPRISE ONLY: System runners (requires Rundeck 5.17.0+, API v56+) - set RUNDECK_ENTERPRISE_TESTS=1")
+	}
+
+	var runner openapi.RunnerInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccSystemRunnerCheckDestroy(&runner),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckSystemRunnerConfig_withAssignedProjectsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "name", "test-runner-with-config"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "description", "Test runner with project config"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.access_level", "admin"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.runner_as_node_enabled", "true"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.remote_node_dispatch", "true"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.runner_node_filter", "tags: RUNNER"),
+				),
+			},
+			{
+				Config: testAccRundeckSystemRunnerConfig_withAssignedProjectsConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.access_level", "admin"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.runner_as_node_enabled", "true"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.remote_node_dispatch", "false"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.runner_node_filter", "tags: DEFAULT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRundeckSystemRunner_backwardCompatAssignedProjects(t *testing.T) {
+	if os.Getenv("RUNDECK_ENTERPRISE_TESTS") != "1" {
+		t.Skip("ENTERPRISE ONLY: System runners (requires Rundeck 5.17.0+, API v56+) - set RUNDECK_ENTERPRISE_TESTS=1")
+	}
+
+	var runner openapi.RunnerInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccSystemRunnerCheckDestroy(&runner),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckSystemRunnerConfig_legacyAssignedProjects,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "name", "test-legacy-runner"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects.test-project", "admin"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRundeckSystemRunner_precedenceAssignedProjectsConfig(t *testing.T) {
+	if os.Getenv("RUNDECK_ENTERPRISE_TESTS") != "1" {
+		t.Skip("ENTERPRISE ONLY: System runners (requires Rundeck 5.17.0+, API v56+) - set RUNDECK_ENTERPRISE_TESTS=1")
+	}
+
+	var runner openapi.RunnerInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(),
+		CheckDestroy:             testAccSystemRunnerCheckDestroy(&runner),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckSystemRunnerConfig_precedence,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "name", "test-precedence-runner"),
+					// assigned_projects_config should take precedence
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.access_level", "admin"),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.runner_as_node_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccRundeckSystemRunnerConfig_withAssignedProjectsConfig = `
+resource "rundeck_system_runner" "test" {
+  name             = "test-runner-with-config"
+  description      = "Test runner with project config"
+  tag_names        = "terraform,test"
+  installation_type = "kubernetes"
+  replica_type     = "ephemeral"
+
+  assigned_projects_config = {
+    "test-project" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: RUNNER"
+    }
+  }
+}
+`
+
+const testAccRundeckSystemRunnerConfig_withAssignedProjectsConfigUpdated = `
+resource "rundeck_system_runner" "test" {
+  name             = "test-runner-with-config"
+  description      = "Test runner with project config"
+  tag_names        = "terraform,test"
+  installation_type = "kubernetes"
+  replica_type     = "ephemeral"
+
+  assigned_projects_config = {
+    "test-project" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = false
+      runner_node_filter       = "tags: DEFAULT"
+    }
+  }
+}
+`
+
+const testAccRundeckSystemRunnerConfig_legacyAssignedProjects = `
+resource "rundeck_system_runner" "test" {
+  name             = "test-legacy-runner"
+  description      = "Test legacy assigned_projects"
+  tag_names        = "terraform,test"
+  installation_type = "linux"
+  replica_type     = "manual"
+
+  assigned_projects = {
+    "test-project" = "admin"
+  }
+}
+`
+
+const testAccRundeckSystemRunnerConfig_precedence = `
+resource "rundeck_system_runner" "test" {
+  name             = "test-precedence-runner"
+  description      = "Test precedence of assigned_projects_config"
+  tag_names        = "terraform,test"
+  installation_type = "linux"
+  replica_type     = "manual"
+
+  # This should be overridden by assigned_projects_config
+  assigned_projects = {
+    "test-project" = "user"
+  }
+
+  # This should take precedence
+  assigned_projects_config = {
+    "test-project" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = false
+      runner_node_filter       = "tags: RUNNER"
+    }
   }
 }
 `

--- a/rundeck/resource_system_runner_test.go
+++ b/rundeck/resource_system_runner_test.go
@@ -319,7 +319,7 @@ resource "rundeck_system_runner" "test" {
 
   # This should be overridden by assigned_projects_config
   assigned_projects = {
-    "test-project" = "user"
+    "test-project" = "execute"
   }
 
   # This should take precedence

--- a/website/docs/r/system_runner.html.md
+++ b/website/docs/r/system_runner.html.md
@@ -3,16 +3,18 @@ layout: "rundeck"
 page_title: "Rundeck: rundeck_system_runner"
 sidebar_current: "docs-rundeck-resource-system-runner"
 description: |-
-  The rundeck_system_runner resource allows system-level (global) Enterprise Runners to be managed by Terraform.
+  The rundeck_system_runner resource allows system-level (global) Enterprise Runners to be managed by Terraform with full per-project dispatch configuration.
 ---
 
 # rundeck\_system\_runner
 
-The system runner resource allows system level Enterprise Runners (Runbook Automation commercial feature) to be managed by Terraform. System runners are created at the system level and can be assigned to multiple projects.
+The system runner resource allows system level Enterprise Runners (Runbook Automation commercial feature) to be managed by Terraform. System runners are created at the system level and can be assigned to multiple projects with per-project dispatch configuration.
 
-**Requirements:** Requires Rundeck Enterprise 5.17.0+ (API v56). Configure the provider with `api_version = "56"` or higher.
+**Requirements:** Requires Rundeck Enterprise 5.0.0+ / RBA 6.1.0+ (API v56). Configure the provider with `api_version = "56"` or higher.
 
 ## Example Usage
+
+### Basic Usage
 
 ```hcl
 provider "rundeck" {
@@ -21,26 +23,99 @@ provider "rundeck" {
   api_version = "56"  # Required for runner resources
 }
 
-# Create a system runner
-resource "rundeck_system_runner" "example" {
-  name        = "example-system-runner"
-  description = "Global runner for multiple projects"
-  
-  tag_names = "system,production,global"
+# Simple system runner with basic project assignment
+resource "rundeck_system_runner" "basic" {
+  name              = "basic-runner"
+  description       = "Basic system runner"
+  tag_names         = "production,default"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
   
   assigned_projects = {
-    "project-1" = "read"
-    "project-2" = "execute"
-    "project-3" = "admin"
+    "project-1" = "admin"
+    "project-2" = "user"
   }
+}
+```
+
+### Advanced Usage with Per-Project Dispatch Configuration
+
+```hcl
+# System runner with full per-project dispatch settings
+resource "rundeck_system_runner" "with_dispatch" {
+  name              = "runner-with-dispatch"
+  description       = "Runner with per-project dispatch configuration"
+  tag_names         = "production,runners"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
   
-  project_runner_as_node = {
-    "project-1" = true
-    "project-2" = false
+  assigned_projects_config = {
+    "project-1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: RUNNER"
+    }
+    
+    "project-2" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = false
+      runner_node_filter       = "tags: DEFAULT"
+    }
   }
-  
-  installation_type = "docker"
-  replica_type      = "manual"
+}
+```
+
+### DR/HA Use Case
+
+```hcl
+# Primary DR runner for disaster recovery automation
+resource "rundeck_system_runner" "dr_primary" {
+  name              = "dr-primary-runner"
+  description       = "Primary DR runner for HA"
+  tag_names         = "dr,primary"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
+
+  assigned_projects_config = {
+    "dr-project-1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-PRIMARY"
+    }
+    "dr-project-2" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-PRIMARY"
+    }
+  }
+}
+
+# Secondary DR runner
+resource "rundeck_system_runner" "dr_secondary" {
+  name              = "dr-secondary-runner"
+  description       = "Secondary DR runner for HA"
+  tag_names         = "dr,secondary"
+  installation_type = "kubernetes"
+  replica_type      = "ephemeral"
+
+  assigned_projects_config = {
+    "dr-project-1" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-SECONDARY"
+    }
+    "dr-project-2" = {
+      access_level             = "admin"
+      runner_as_node_enabled   = true
+      remote_node_dispatch     = true
+      runner_node_filter       = "tags: DR-SECONDARY"
+    }
+  }
 }
 ```
 
@@ -54,23 +129,54 @@ The following arguments are supported:
 
 * `tag_names` - (Optional) Comma-separated tags for the runner. Rundeck normalizes tags to lowercase and sorts them alphabetically. The provider handles this automatically using semantic equality to prevent plan drift.
 
-* `assigned_projects` - (Optional) Map of assigned projects with their access levels (e.g., "read", "execute", "admin").
+* `assigned_projects` - (Optional) Map of assigned projects with their access levels (e.g., "admin", "user"). This is the legacy approach for simple project assignments without dispatch configuration.
 
-* `project_runner_as_node` - (Optional) Map of projects where the runner acts as a node (boolean values).
+* `project_runner_as_node` - (Optional) **Deprecated.** Map of projects where the runner acts as a node (boolean values). Use `assigned_projects_config` instead for new configurations.
+
+* `assigned_projects_config` - (Optional) Map of project configurations with full dispatch settings. Each project configuration supports:
+  * `access_level` - (Required) Access level for the project (e.g., "admin", "user").
+  * `runner_as_node_enabled` - (Optional, Default: `false`) Enable the runner to act as a node for this project.
+  * `remote_node_dispatch` - (Optional, Default: `false`) Enable remote node dispatch for the runner in this project.
+  * `runner_node_filter` - (Optional) Node filter string for the runner in this project (e.g., "tags: RUNNER").
 
 * `installation_type` - (Optional) Installation type of the runner. Valid values: `linux`, `windows`, `kubernetes`, `docker`. Defaults to `linux`.
 
 * `replica_type` - (Optional) Replica type of the runner. Valid values: `manual`, `ephemeral`. Defaults to `manual`.
 
+### Precedence Rules
+
+When a project appears in both `assigned_projects` and `assigned_projects_config`, the configuration in `assigned_projects_config` **takes precedence**. This allows for gradual migration from the legacy approach to the new dispatch configuration.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - The ID of the runner.
+
 * `runner_id` - The ID of the created runner.
 
-* `token` - The authentication token for the runner (sensitive).
+* `token` - The authentication token for the runner (sensitive, only returned on creation).
 
-* `download_token` - The download token for the runner package (sensitive).
+* `download_token` - The download token for the runner package (sensitive, only returned on creation).
+
+## Important Notes
+
+### API Limitations
+
+The Rundeck API does not currently expose a GET endpoint for per-project dispatch settings (`runner_as_node_enabled`, `remote_node_dispatch`, `runner_node_filter`). As a result:
+
+- These settings are stored in Terraform state during `create`/`update` operations.
+- The provider cannot detect out-of-band changes made via the Rundeck UI or API.
+- If dispatch settings are modified outside of Terraform, use `terraform import` to refresh the state.
+
+### Use Case: Disaster Recovery Automation
+
+This feature was designed to support large-scale DR automation scenarios where hundreds of runners need to be managed as code. The per-project dispatch configuration allows customers to:
+
+- Manage 600+ runners across multiple projects with Terraform
+- Configure different node dispatch settings per project
+- Support HA/DR with primary/secondary runner configurations
+- Eliminate manual UI/API configuration after Terraform apply
 
 ## Import
 
@@ -79,6 +185,8 @@ System runners can be imported using the runner ID:
 ```
 terraform import rundeck_system_runner.example 12345678-1234-1234-1234-123456789abc
 ```
+
+**Note:** Imported runners will preserve `assigned_projects` in state, but `assigned_projects_config` settings (if configured via UI) will need to be manually added to your Terraform configuration after import.
 
 ## Enterprise Feature
 

--- a/website/docs/r/system_runner.html.md
+++ b/website/docs/r/system_runner.html.md
@@ -33,7 +33,7 @@ resource "rundeck_system_runner" "basic" {
   
   assigned_projects = {
     "project-1" = "admin"
-    "project-2" = "user"
+    "project-2" = "execute"
   }
 }
 ```
@@ -129,12 +129,12 @@ The following arguments are supported:
 
 * `tag_names` - (Optional) Comma-separated tags for the runner. Rundeck normalizes tags to lowercase and sorts them alphabetically. The provider handles this automatically using semantic equality to prevent plan drift.
 
-* `assigned_projects` - (Optional) Map of assigned projects with their access levels (e.g., "admin", "user"). This is the legacy approach for simple project assignments without dispatch configuration.
+* `assigned_projects` - (Optional) Map of assigned projects with their access levels. Valid access levels: `read`, `execute`, `admin`. This is the legacy approach for simple project assignments without dispatch configuration.
 
 * `project_runner_as_node` - (Optional) **Deprecated.** Map of projects where the runner acts as a node (boolean values). Use `assigned_projects_config` instead for new configurations.
 
 * `assigned_projects_config` - (Optional) Map of project configurations with full dispatch settings. Each project configuration supports:
-  * `access_level` - (Required) Access level for the project (e.g., "admin", "user").
+  * `access_level` - (Required) Access level for the project. Valid values: `read`, `execute`, `admin`.
   * `runner_as_node_enabled` - (Optional, Default: `false`) Enable the runner to act as a node for this project.
   * `remote_node_dispatch` - (Optional, Default: `false`) Enable remote node dispatch for the runner in this project.
   * `runner_node_filter` - (Optional) Node filter string for the runner in this project (e.g., "tags: RUNNER").

--- a/website/docs/r/system_runner.html.md
+++ b/website/docs/r/system_runner.html.md
@@ -10,7 +10,7 @@ description: |-
 
 The system runner resource allows system level Enterprise Runners (Runbook Automation commercial feature) to be managed by Terraform. System runners are created at the system level and can be assigned to multiple projects with per-project dispatch configuration.
 
-**Requirements:** Requires Rundeck Enterprise 5.0.0+ / RBA 6.1.0+ (API v56). Configure the provider with `api_version = "56"` or higher.
+**Requirements:** Requires Rundeck Enterprise 5.17.0+ (API v56). Configure the provider with `api_version = "56"` or higher.
 
 ## Example Usage
 


### PR DESCRIPTION
# Add per-project dispatch configuration to system_runner

## Summary

Adds `assigned_projects_config` attribute to `rundeck_system_runner` resource, enabling full per-project runner dispatch settings (`runner_as_node_enabled`, `remote_node_dispatch`, `runner_node_filter`) to be managed as Infrastructure-as-Code.


### Problem Statement

Currency Cloud manages ~600 Rundeck runners across clusters/projects using Terraform for disaster recovery (DR). Currently, only project-level runners support full dispatch configuration in Terraform, forcing them to use post-Terraform API/UI workarounds that:

- Break the Infrastructure-as-Code (IaC) model
- Increase operational risk
- Limit scalability for DR automation

### Solution

This PR adds full per-project dispatch configuration support to `rundeck_system_runner`, allowing customers to manage all runner settings in Terraform without manual post-apply steps.

## Changes

### New Feature: `assigned_projects_config`

A new nested attribute that allows per-project configuration including:

```hcl
resource "rundeck_system_runner" "dr_primary" {
  name              = "dr-primary-runner"
  description       = "Primary DR runner"
  tag_names         = "dr,primary"
  installation_type = "kubernetes"
  replica_type      = "ephemeral"

  assigned_projects_config = {
    "dr-project-1" = {
      access_level             = "admin"
      runner_as_node_enabled   = true
      remote_node_dispatch     = true
      runner_node_filter       = "tags: DR-PRIMARY"
    }
  }
}
```

### Implementation Details

**Files Modified:**
- `rundeck/resource_system_runner_framework.go` (+218 lines)
  - New `projectRunnerConfig` struct for nested configuration
  - `Create()` applies dispatch settings via `SaveProjectRunnerNodeDispatchSettings` API
  - `Update()` handles changes to dispatch configuration
  - `Read()` preserves dispatch settings from state (API limitation documented)
  
- `rundeck/resource_system_runner_test.go` (+167 lines)
  - `TestAccRundeckSystemRunner_withAssignedProjectsConfig` - Full lifecycle test
  - `TestAccRundeckSystemRunner_backwardCompatAssignedProjects` - Backward compatibility
  - `TestAccRundeckSystemRunner_precedenceAssignedProjectsConfig` - Precedence validation

- `docs/resource_system_runner.md` (rewritten)
- `website/docs/r/system_runner.html.md` (rewritten)
- `examples/system_runner.tf` (new)
- `CHANGELOG.md` (updated)

### Backward Compatibility

 **100% backward compatible** - No breaking changes

- Existing `assigned_projects` continues to work unchanged
- Existing `project_runner_as_node` continues to work
- **Precedence rule:** When a project appears in both `assigned_projects` and `assigned_projects_config`, the latter takes precedence (allows gradual migration)

### API Limitations

The Rundeck API does not expose a GET endpoint for per-project dispatch settings. As a result:

- Dispatch settings are stored in Terraform state during `create`/`update` operations
- The provider cannot detect out-of-band changes made via the Rundeck UI or API
- This matches the existing behavior of `project_runner` resource
- Documented in resource docs with workaround (`terraform import`)

## Testing

### Compilation
-  Go build successful
-  Test compilation successful

### Acceptance Tests
**New tests added** (require `RUNDECK_ENTERPRISE_TESTS=1`):
- `TestAccRundeckSystemRunner_withAssignedProjectsConfig` - Create + Update lifecycle
- `TestAccRundeckSystemRunner_backwardCompatAssignedProjects` - Legacy compatibility
- `TestAccRundeckSystemRunner_precedenceAssignedProjectsConfig` - Precedence rules

**To run:**
```bash
export RUNDECK_ENTERPRISE_TESTS=1
export RUNDECK_URL="https://your-rundeck.com"
export RUNDECK_AUTH_TOKEN="your-token"
export RUNDECK_API_VERSION="56"

go test -v ./rundeck -run TestAccRundeckSystemRunner_withAssignedProjectsConfig
go test -v ./rundeck -run TestAccRundeckSystemRunner_backwardCompatAssignedProjects
go test -v ./rundeck -run TestAccRundeckSystemRunner_precedenceAssignedProjectsConfig
```

### Manual Testing Checklist
- [ ] Apply `examples/system_runner.tf` against Rundeck Enterprise
- [ ] Verify runner created with correct dispatch settings in UI
- [ ] Run `terraform plan` → should show no changes
- [ ] Update dispatch settings in Terraform → apply → verify in UI
- [ ] Test backward compat: use `assigned_projects` only → verify still works

## Requirements

- **Rundeck version:** 5.0.0+ / RBA 6.1.0+
- **API version:** 56+ (Enterprise feature)
- **Provider config:** Must set `api_version = "56"` or higher

## Example Use Cases

### DR/HA Automation (Currency Cloud)
```hcl
# Primary DR runner
resource "rundeck_system_runner" "dr_primary" {
  name              = "dr-primary-runner"
  description       = "Primary DR runner"
  tag_names         = "dr,primary"
  installation_type = "kubernetes"
  replica_type      = "ephemeral"

  assigned_projects_config = {
    "dr-project-1" = {
      access_level             = "admin"
      runner_as_node_enabled   = true
      remote_node_dispatch     = true
      runner_node_filter       = "tags: DR-PRIMARY"
    }
    "dr-project-2" = {
      access_level             = "admin"
      runner_as_node_enabled   = true
      remote_node_dispatch     = true
      runner_node_filter       = "tags: DR-PRIMARY"
    }
  }
}

# Secondary DR runner
resource "rundeck_system_runner" "dr_secondary" {
  name              = "dr-secondary-runner"
  description       = "Secondary DR runner"
  tag_names         = "dr,secondary"
  installation_type = "kubernetes"
  replica_type      = "ephemeral"

  assigned_projects_config = {
    "dr-project-1" = {
      access_level             = "admin"
      runner_as_node_enabled   = true
      remote_node_dispatch     = true
      runner_node_filter       = "tags: DR-SECONDARY"
    }
    "dr-project-2" = {
      access_level             = "admin"
      runner_as_node_enabled   = true
      remote_node_dispatch     = true
      runner_node_filter       = "tags: DR-SECONDARY"
    }
  }
}
```

### Gradual Migration from Legacy Approach
```hcl
resource "rundeck_system_runner" "mixed" {
  name              = "mixed-runner"
  description       = "Runner with mixed configuration"
  tag_names         = "production"
  installation_type = "linux"
  replica_type      = "manual"

  # Simple projects without special dispatch needs
  assigned_projects = {
    "simple-project-1" = "admin"
    "simple-project-2" = "user"
  }

  # Projects requiring specific dispatch configuration
  # These will override any entry in assigned_projects for the same project
  assigned_projects_config = {
    "critical-project" = {
      access_level             = "admin"
      runner_as_node_enabled   = true
      remote_node_dispatch     = true
      runner_node_filter       = "tags: CRITICAL"
    }
  }
}
```

## Checklist

- [x] Code compiles without errors
- [x] Tests compile without errors
- [x] Backward compatibility maintained
- [x] Documentation updated (resource docs + examples)
- [x] CHANGELOG.md updated
- [ ] Acceptance tests passed (requires Enterprise Rundeck env)
- [ ] Manual testing completed (requires Enterprise Rundeck env)

## Reviewers

@luis-toledo @jaime-tobar

**Note:** This PR requires access to a Rundeck Enterprise environment (API v56+) to fully validate acceptance tests and manual testing.

## Related Links

- Customer Case: [00805079](https://pagerduty.lightning.force.com/lightning/r/Case/00805079/view)
- JIRA Ticket: [FDE-229](https://pagerduty.atlassian.net/browse/FDE-229)
- Approvals: Luis Toledo, Jaime Tobar, Rocío Bayon


[FDE-229]: https://pagerduty.atlassian.net/browse/FDE-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FDE-229]: https://pagerduty.atlassian.net/browse/FDE-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ