### PR TITLE
fix: use correct JSON field names for runner selector

### DIFF
--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -137,8 +137,8 @@ type jobNodeFilters struct {
 
 type jobRunnerSelector struct {
 	Filter     string `json:"filter,omitempty"`
-	FilterMode string `json:"filterMode,omitempty"`
-	FilterType string `json:"filterType,omitempty"`
+	FilterMode string `json:"runnerFilterMode,omitempty"`
+	FilterType string `json:"runnerFilterType,omitempty"`
 }
 
 func NewJobResource() resource.Resource {

--- a/rundeck/resource_job_runner_selector_test.go
+++ b/rundeck/resource_job_runner_selector_test.go
@@ -1,0 +1,61 @@
+package rundeck
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestJobRunnerSelector_JSONFieldNames is a regression test for #244 / #258.
+// Rundeck's job runnerSelector expects the field names "runnerFilterMode" and
+// "runnerFilterType". They were previously serialized as "filterMode"/"filterType",
+// which Rundeck silently ignored, dropping the runner filter settings.
+func TestJobRunnerSelector_JSONFieldNames(t *testing.T) {
+	selector := jobRunnerSelector{
+		Filter:     "tags: runner",
+		FilterMode: "TAGS",
+		FilterType: "TAG_FILTER_AND",
+	}
+
+	data, err := json.Marshal(selector)
+	if err != nil {
+		t.Fatalf("failed to marshal jobRunnerSelector: %s", err)
+	}
+
+	jsonStr := string(data)
+
+	for _, expected := range []string{"runnerFilterMode", "runnerFilterType"} {
+		if !strings.Contains(jsonStr, expected) {
+			t.Errorf("expected marshaled JSON to contain %q, got: %s", expected, jsonStr)
+		}
+	}
+
+	// Ensure the old (incorrect) field names are not emitted.
+	for _, unexpected := range []string{`"filterMode"`, `"filterType"`} {
+		if strings.Contains(jsonStr, unexpected) {
+			t.Errorf("marshaled JSON should not contain legacy field %s, got: %s", unexpected, jsonStr)
+		}
+	}
+}
+
+// TestJobRunnerSelector_JSONRoundTrip verifies that a runnerSelector returned by
+// the Rundeck API (using runnerFilterMode/runnerFilterType) deserializes back into
+// the struct, ensuring no plan drift on read.
+func TestJobRunnerSelector_JSONRoundTrip(t *testing.T) {
+	apiJSON := `{"filter":"tags: runner","runnerFilterMode":"TAGS","runnerFilterType":"TAG_FILTER_AND"}`
+
+	var selector jobRunnerSelector
+	if err := json.Unmarshal([]byte(apiJSON), &selector); err != nil {
+		t.Fatalf("failed to unmarshal jobRunnerSelector: %s", err)
+	}
+
+	if selector.Filter != "tags: runner" {
+		t.Errorf("expected Filter %q, got %q", "tags: runner", selector.Filter)
+	}
+	if selector.FilterMode != "TAGS" {
+		t.Errorf("expected FilterMode %q, got %q", "TAGS", selector.FilterMode)
+	}
+	if selector.FilterType != "TAG_FILTER_AND" {
+		t.Errorf("expected FilterType %q, got %q", "TAG_FILTER_AND", selector.FilterType)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes the job runner selector being silently ignored by Rundeck: `jobRunnerSelector` was serializing as `filterMode`/`filterType`, but the API expects `runnerFilterMode`/`runnerFilterType`. Because the same struct is used for both serialize and deserialize, this corrects the round trip in both directions and resolves the plan-drift symptom (runner selector settings showing as removed) documented in the upgrade guide. Fixes #244.
- Includes the original community contribution from @ozon2 (#258), plus unit tests.

## Changes
- `rundeck/resource_job_framework.go` — correct JSON tags on `jobRunnerSelector` (@ozon2, #258).
- `rundeck/resource_job_runner_selector_test.go` — unit tests asserting the correct field names are emitted (and legacy names are not) and that API JSON round-trips back into state. No Rundeck server required.

## Test plan
- [x] `go build ./...` and `go vet ./rundeck/` pass
- [x] `go test ./rundeck/ -run TestJobRunnerSelector` passes
- [x] `make fmt` clean

Note: CHANGELOG entry intentionally deferred until the 1.3.0 section lands.