### PR TITLE
[RUN-4568] Add prepare-community-pr reusable workflow caller

### DIFF
--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -1,0 +1,14 @@
+# Calls the centralized workflow from rundeck/rundeck.
+# To add this to another repo, copy this file — no changes needed.
+name: Prepare community PR
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  prepare:
+    uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   prepare:
+    if: github.event.label.name == 'prepare-community-pr'
     uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main
     permissions:
       contents: write

--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -1,7 +1,5 @@
 # Calls the centralized workflow from rundeck/rundeck.
 # To add this to another repo, copy this file — no changes needed.
-# To update the pinned SHA, get the latest SHA from rundeck/rundeck main:
-#   gh api repos/rundeck/rundeck/commits/main --jq '.sha'
 name: Prepare community PR
 
 on:
@@ -11,7 +9,7 @@ on:
 jobs:
   prepare:
     if: github.event.label.name == 'prepare-community-pr'
-    uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@fa7098fe5b7be9fcc80db49a07f6d3ba6b9933b1
+    uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -1,5 +1,7 @@
 # Calls the centralized workflow from rundeck/rundeck.
 # To add this to another repo, copy this file — no changes needed.
+# To update the pinned SHA, get the latest SHA from rundeck/rundeck main:
+#   gh api repos/rundeck/rundeck/commits/main --jq '.sha'
 name: Prepare community PR
 
 on:
@@ -9,7 +11,7 @@ on:
 jobs:
   prepare:
     if: github.event.label.name == 'prepare-community-pr'
-    uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main
+    uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@fa7098fe5b7be9fcc80db49a07f6d3ba6b9933b1
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

Adds the `prepare-community-pr` workflow to this repo by calling the centralized reusable workflow in `rundeck/rundeck`.

Tracks: https://pagerduty.atlassian.net/browse/RUN-4568
Depends on: rundeck/rundeck#10242

## What this does

When a maintainer applies the `prepare-community-pr` label to a community PR (from a fork), this workflow:

1. Verifies the PR has at least one approved review
2. Creates an integration branch (`bot/prep-community-pr-<number>`)
3. Merges the community PR into that branch
4. Opens an internal PR so full CI (including jobs that need repo secrets) can run

## Why

Community PRs from forks cannot access repository secrets directly. This is the secure pattern to run full CI on them without exposing secrets to untrusted code.

## What changed

A single 14-line caller file: `.github/workflows/prepare-community-pr.yml`

All the actual logic lives in `rundeck/rundeck` and is called via `uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main`.

## Post-merge step

Verify that this repo has access to reusable workflows from `rundeck/rundeck`:
**Settings → Actions → General → Access** → allow workflows from repos in the `rundeck` org.

Made with [Cursor](https://cursor.com)