### PR TITLE
fix: separate workflow and node keepgoing flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-## Unreleased
-
-**Bug Fixes**
-
-### Job Resource
-
-- **Separate workflow and node `keepgoing` flags** - `continue_on_error` and `continue_next_node_on_error` were both wired to the dispatch (node-level) `keepgoing`, leaving `continue_on_error` inert and making it impossible to represent a job whose workflow `keepgoing` differs from its dispatch `keepgoing`. `continue_on_error` now maps to the workflow `<sequence keepgoing>` and `continue_next_node_on_error` to the node `<dispatch keepgoing>`, and each is read back into its own attribute. Jobs that previously set `continue_next_node_on_error` to control workflow keepgoing should set `continue_on_error` instead.
-
 ## 1.2.2
 
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**Bug Fixes**
+
+### Job Resource
+
+- **Separate workflow and node `keepgoing` flags** - `continue_on_error` and `continue_next_node_on_error` were both wired to the dispatch (node-level) `keepgoing`, leaving `continue_on_error` inert and making it impossible to represent a job whose workflow `keepgoing` differs from its dispatch `keepgoing`. `continue_on_error` now maps to the workflow `<sequence keepgoing>` and `continue_next_node_on_error` to the node `<dispatch keepgoing>`, and each is read back into its own attribute. Jobs that previously set `continue_next_node_on_error` to control workflow keepgoing should set `continue_on_error` instead.
+
 ## 1.2.2
 
 **Bug Fixes**

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -1063,8 +1063,8 @@ func (r *jobResource) planToJobJSON(ctx context.Context, plan *jobResourceModel)
 			Commands: commands,
 			Strategy: plan.CommandOrderingStrategy.ValueString(),
 		}
-		if !plan.ContinueNextNodeOnError.IsNull() {
-			job.Sequence.KeepGoing = plan.ContinueNextNodeOnError.ValueBool()
+		if !plan.ContinueOnError.IsNull() {
+			job.Sequence.KeepGoing = plan.ContinueOnError.ValueBool()
 		}
 	}
 
@@ -1259,7 +1259,7 @@ func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *j
 		if job.Sequence.Strategy != "" {
 			state.CommandOrderingStrategy = types.StringValue(job.Sequence.Strategy)
 		}
-		state.ContinueNextNodeOnError = types.BoolValue(job.Sequence.KeepGoing)
+		state.ContinueOnError = types.BoolValue(job.Sequence.KeepGoing)
 	}
 
 	// Convert schedule from JSON to state
@@ -1413,8 +1413,9 @@ func (r *jobResource) jobJSONAPIToState(ctx context.Context, job *JobJSON, state
 
 	// Handle sequence
 	if job.Sequence != nil {
+		// continue_on_error comes from sequence.keepgoing (workflow-level setting)
 		if keepGoing, ok := job.Sequence["keepgoing"].(bool); ok {
-			state.ContinueNextNodeOnError = types.BoolValue(keepGoing)
+			state.ContinueOnError = types.BoolValue(keepGoing)
 		}
 		if strategy, ok := job.Sequence["strategy"].(string); ok {
 			state.CommandOrderingStrategy = types.StringValue(strategy)

--- a/rundeck/resource_job_keepgoing_test.go
+++ b/rundeck/resource_job_keepgoing_test.go
@@ -1,0 +1,141 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// These are plain unit tests (no TF_ACC / live Rundeck required). They guard
+// the mapping that keeps the two job-level keepgoing flags independent:
+//   - continue_on_error            <-> workflow  <sequence keepgoing>
+//   - continue_next_node_on_error  <-> node      <dispatch keepgoing>
+// Previously both attributes were wired to the dispatch keepgoing, leaving
+// continue_on_error inert and making the two flags impossible to differ.
+
+// testSingleShellCommandList builds a minimal one-command list so that
+// planToJobJSON produces a non-nil Sequence.
+func testSingleShellCommandList(t *testing.T) types.List {
+	t.Helper()
+
+	emptyObjList := types.ListNull(types.ObjectType{})
+	cmd, diags := types.ObjectValue(commandObjectType.AttrTypes, map[string]attr.Value{
+		"description":                 types.StringValue("echo"),
+		"shell_command":               types.StringValue("echo hi"),
+		"inline_script":               types.StringNull(),
+		"script_url":                  types.StringNull(),
+		"script_file":                 types.StringNull(),
+		"script_file_args":            types.StringNull(),
+		"expand_token_in_script_file": types.BoolNull(),
+		"file_extension":              types.StringNull(),
+		"keep_going_on_success":       types.BoolNull(),
+		"plugins":                     emptyObjList,
+		"script_interpreter":          emptyObjList,
+		"job":                         emptyObjList,
+		"step_plugin":                 emptyObjList,
+		"node_step_plugin":            emptyObjList,
+		"error_handler":               emptyObjList,
+	})
+	if diags.HasError() {
+		t.Fatalf("building command object: %v", diags)
+	}
+
+	list, diags := types.ListValue(commandObjectType, []attr.Value{cmd})
+	if diags.HasError() {
+		t.Fatalf("building command list: %v", diags)
+	}
+	return list
+}
+
+func TestPlanToJobJSON_keepGoingFlagsAreIndependent(t *testing.T) {
+	cases := []struct {
+		name             string
+		continueOnError  bool
+		continueNextNode bool
+	}{
+		{"workflow on, node off", true, false},
+		{"workflow off, node on", false, true},
+	}
+
+	r := &jobResource{}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			plan := &jobResourceModel{
+				Name:                    types.StringValue("test-job"),
+				ProjectName:             types.StringValue("test-project"),
+				Description:             types.StringValue("desc"),
+				Command:                 testSingleShellCommandList(t),
+				ContinueOnError:         types.BoolValue(tc.continueOnError),
+				ContinueNextNodeOnError: types.BoolValue(tc.continueNextNode),
+			}
+
+			job, err := r.planToJobJSON(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("planToJobJSON: %v", err)
+			}
+
+			if job.Sequence == nil {
+				t.Fatal("expected job.Sequence to be set")
+			}
+			if job.Sequence.KeepGoing != tc.continueOnError {
+				t.Errorf("workflow sequence keepgoing = %v, want %v (from continue_on_error)",
+					job.Sequence.KeepGoing, tc.continueOnError)
+			}
+
+			if job.NodeFilters == nil || job.NodeFilters.Dispatch == nil {
+				t.Fatal("expected job.NodeFilters.Dispatch to be set")
+			}
+			if job.NodeFilters.Dispatch.KeepGoing != tc.continueNextNode {
+				t.Errorf("node dispatch keepgoing = %v, want %v (from continue_next_node_on_error)",
+					job.NodeFilters.Dispatch.KeepGoing, tc.continueNextNode)
+			}
+		})
+	}
+}
+
+func TestJobJSONToState_keepGoingFlagsReadIndependently(t *testing.T) {
+	r := &jobResource{}
+	job := &jobJSON{
+		Sequence: &jobSequence{KeepGoing: true, Commands: []interface{}{}},
+		NodeFilters: &jobNodeFilters{
+			Dispatch: &jobDispatch{KeepGoing: false},
+		},
+	}
+
+	state := &jobResourceModel{}
+	if err := r.jobJSONToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONToState: %v", err)
+	}
+
+	if !state.ContinueOnError.ValueBool() {
+		t.Error("sequence keepgoing=true should map to continue_on_error=true")
+	}
+	if state.ContinueNextNodeOnError.ValueBool() {
+		t.Error("dispatch keepgoing=false should map to continue_next_node_on_error=false")
+	}
+}
+
+func TestJobJSONAPIToState_keepGoingFlagsReadIndependently(t *testing.T) {
+	r := &jobResource{}
+	job := &JobJSON{
+		Sequence: map[string]interface{}{"keepgoing": true},
+		NodeFilters: map[string]interface{}{
+			"dispatch": map[string]interface{}{"keepgoing": false},
+		},
+	}
+
+	state := &jobResourceModel{}
+	if err := r.jobJSONAPIToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONAPIToState: %v", err)
+	}
+
+	if !state.ContinueOnError.ValueBool() {
+		t.Error("sequence keepgoing=true should map to continue_on_error=true")
+	}
+	if state.ContinueNextNodeOnError.ValueBool() {
+		t.Error("dispatch keepgoing=false should map to continue_next_node_on_error=false")
+	}
+}


### PR DESCRIPTION
## Summary

- Splits the two job-level `keepgoing` flags that were both wired to the node (dispatch) keepgoing:
  - `continue_on_error` → workflow `<sequence keepgoing>`
  - `continue_next_node_on_error` → node `<dispatch keepgoing>`
- Previously `continue_on_error` was declared but never read or written (inert), and on read `continue_next_node_on_error` was assigned from dispatch and then overwritten by sequence — so the two flags could never differ. This aligns the code with the existing documentation in `website/docs/r/job.html.md`.
- Includes the original community contribution from @karldebisschop (#262), plus unit tests. CHANGELOG entry intentionally omitted here; it will be added in the 1.3.0 rollup.

## Behavior change / migration
Configurations that previously set `continue_next_node_on_error` to control workflow keepgoing should switch to `continue_on_error`. On first refresh after upgrade, existing state may show a one-time correction where the two flags settle into their correct attributes.

## Test plan
- [x] `go build ./...` and `go vet ./rundeck/` pass
- [x] `go test ./rundeck/ -run keepGoing` passes (write path + both read paths; no live Rundeck required)
- [ ] Existing `TestAcc*` suites require a live Rundeck (not run here)