### PR TITLE
[RUN-4631] Fix: honor run_for_each_node on job references (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+**Bug Fixes**
+
+### Job Resource
+
+- **Fixed `run_for_each_node` being ignored on job references** ([#256](https://github.com/rundeck/terraform-provider-rundeck/issues/256)) - On a job reference (`command { job { ... } }`), `run_for_each_node` was serialized to a field Rundeck ignores, so the referenced job was always treated as a workflow step rather than a node step (the setting only worked on error handlers). `run_for_each_node` now correctly drives the API's `nodeStep` flag and round-trips on read, restoring pre-1.0 behavior. The `node_step` attribute continues to work as an alias, with `run_for_each_node` taking precedence if both are set.
+
+  This also fixes the underlying cause of a "Provider produced inconsistent result after apply" / unknown-value error that sank an earlier attempt at this fix: the command object type used to read job commands back from the API declared nested blocks (`job`, `error_handler`, `step_plugin`, `node_step_plugin`, `plugins`, `script_interpreter`) with empty, un-typed placeholders instead of their real shape, so read-back silently failed its own internal type check and was discarded whenever a command had a job reference or error handler — the read simply never took effect. This has likely caused unrelated drift/staleness for any job using those nested blocks, even before this attribute existed. Fixing it also required marking a job reference's `uuid`/`name`/`group_name`/`project_name` and an error handler's `keep_going_on_success` as `Computed`, since making the read-back actually work exposed that Rundeck resolves and returns these fields even when not explicitly configured (e.g. a UUID-only reference). (Thanks [@codydiehl](https://github.com/codydiehl) for reporting)
+
 ## 1.3.0
 
 **Enhancements**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.3.1
 
 **Bug Fixes**
 

--- a/rundeck/resource_job_command_schema.go
+++ b/rundeck/resource_job_command_schema.go
@@ -3,6 +3,9 @@ package rundeck
 import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -87,26 +90,51 @@ func jobCommandNestedBlock() schema.ListNestedBlock {
 						Attributes: map[string]schema.Attribute{
 							"uuid": schema.StringAttribute{
 								Optional:    true,
+								Computed:    true,
 								Description: "UUID of the job to reference (immutable, preferred). Can reference another rundeck_job's id attribute.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"name": schema.StringAttribute{
 								Optional:    true,
+								Computed:    true,
 								Description: "Name of the job to reference. Required if uuid is not specified.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"group_name": schema.StringAttribute{
 								Optional:    true,
+								Computed:    true,
 								Description: "Group path of the job. Used with name-based references.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"project_name": schema.StringAttribute{
 								Optional:    true,
-								Description: "Project containing the job. Used with name-based references.",
+								Computed:    true,
+								Description: "Project containing the job. Used with name-based references. Also populated from the API for uuid-based references, since Rundeck always resolves a job reference to a specific project.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"run_for_each_node": schema.BoolAttribute{
-								Optional: true,
+								Optional:    true,
+								Computed:    true,
+								Description: "Whether the referenced job runs once per node (node step). Alias of node_step; both map to the API's nodeStep flag, and run_for_each_node takes precedence if both are set.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"node_step": schema.BoolAttribute{
 								Optional:    true,
-								Description: "Run the referenced job as a node step (once per node)",
+								Computed:    true,
+								Description: "Run the referenced job as a node step (once per node). Alias of run_for_each_node.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"args": schema.StringAttribute{
 								Optional: true,
@@ -225,8 +253,14 @@ func jobCommandNestedBlock() schema.ListNestedBlock {
 								Optional: true,
 							},
 							"keep_going_on_success": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Continue workflow even if error handler succeeds",
+								Optional: true,
+								Computed: true,
+								Description: "Continue workflow even if error handler succeeds. Rundeck's API omits this " +
+									"field entirely when false, so it is Computed to avoid drift/inconsistent-apply " +
+									"errors on that default.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
 							},
 						},
 						Blocks: map[string]schema.Block{
@@ -248,26 +282,51 @@ func jobCommandNestedBlock() schema.ListNestedBlock {
 									Attributes: map[string]schema.Attribute{
 										"uuid": schema.StringAttribute{
 											Optional:    true,
+											Computed:    true,
 											Description: "UUID of the job to reference (immutable, preferred). Can reference another rundeck_job's id attribute.",
+											PlanModifiers: []planmodifier.String{
+												stringplanmodifier.UseStateForUnknown(),
+											},
 										},
 										"name": schema.StringAttribute{
 											Optional:    true,
+											Computed:    true,
 											Description: "Name of the job to reference. Required if uuid is not specified.",
+											PlanModifiers: []planmodifier.String{
+												stringplanmodifier.UseStateForUnknown(),
+											},
 										},
 										"group_name": schema.StringAttribute{
 											Optional:    true,
+											Computed:    true,
 											Description: "Group path of the job. Used with name-based references.",
+											PlanModifiers: []planmodifier.String{
+												stringplanmodifier.UseStateForUnknown(),
+											},
 										},
 										"project_name": schema.StringAttribute{
 											Optional:    true,
-											Description: "Project containing the job. Used with name-based references.",
+											Computed:    true,
+											Description: "Project containing the job. Used with name-based references. Also populated from the API for uuid-based references, since Rundeck always resolves a job reference to a specific project.",
+											PlanModifiers: []planmodifier.String{
+												stringplanmodifier.UseStateForUnknown(),
+											},
 										},
 										"run_for_each_node": schema.BoolAttribute{
-											Optional: true,
+											Optional:    true,
+											Computed:    true,
+											Description: "Whether the referenced job runs once per node (node step). Alias of node_step; both map to the API's nodeStep flag, and run_for_each_node takes precedence if both are set.",
+											PlanModifiers: []planmodifier.Bool{
+												boolplanmodifier.UseStateForUnknown(),
+											},
 										},
 										"node_step": schema.BoolAttribute{
 											Optional:    true,
-											Description: "Run the referenced job as a node step (once per node)",
+											Computed:    true,
+											Description: "Run the referenced job as a node step (once per node). Alias of run_for_each_node.",
+											PlanModifiers: []planmodifier.Bool{
+												boolplanmodifier.UseStateForUnknown(),
+											},
 										},
 										"args": schema.StringAttribute{
 											Optional: true,
@@ -603,6 +662,97 @@ func jobExecutionLifecyclePluginNestedBlock() schema.ListNestedBlock {
 	}
 }
 
+// nodeFilterDispatchObjectType mirrors the "dispatch" nested block on a job
+// reference's node_filters.
+var nodeFilterDispatchObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"thread_count":   types.Int64Type,
+		"keep_going":     types.BoolType,
+		"rank_attribute": types.StringType,
+		"rank_order":     types.StringType,
+	},
+}
+
+// nodeFilterObjectType mirrors the "node_filters" nested block on a job reference.
+var nodeFilterObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"filter":             types.StringType,
+		"exclude_filter":     types.StringType,
+		"exclude_precedence": types.BoolType,
+		"dispatch":           types.ListType{ElemType: nodeFilterDispatchObjectType},
+	},
+}
+
+// jobRefObjectType mirrors the "job" nested block (a reference to another job),
+// used both directly under a command and under its error_handler.
+var jobRefObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"uuid":                 types.StringType,
+		"name":                 types.StringType,
+		"group_name":           types.StringType,
+		"project_name":         types.StringType,
+		"run_for_each_node":    types.BoolType,
+		"node_step":            types.BoolType,
+		"args":                 types.StringType,
+		"import_options":       types.BoolType,
+		"child_nodes":          types.BoolType,
+		"fail_on_disable":      types.BoolType,
+		"ignore_notifications": types.BoolType,
+		"node_filters":         types.ListType{ElemType: nodeFilterObjectType},
+	},
+}
+
+// scriptInterpreterObjectType mirrors the "script_interpreter" nested block.
+var scriptInterpreterObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"invocation_string": types.StringType,
+		"args_quoted":       types.BoolType,
+	},
+}
+
+// stepPluginObjectType mirrors the "step_plugin"/"node_step_plugin" nested blocks.
+var stepPluginObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"type":   types.StringType,
+		"config": types.MapType{ElemType: types.StringType},
+	},
+}
+
+// logFilterPluginObjectType mirrors the "log_filter_plugin" nested block under
+// a command's "plugins" block.
+var logFilterPluginObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"type":   types.StringType,
+		"config": types.MapType{ElemType: types.StringType},
+	},
+}
+
+// commandPluginsObjectType mirrors a command's "plugins" nested block.
+var commandPluginsObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"log_filter_plugin": types.ListType{ElemType: logFilterPluginObjectType},
+	},
+}
+
+// errorHandlerObjectType mirrors the "error_handler" nested block on a command.
+var errorHandlerObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"description":                 types.StringType,
+		"shell_command":               types.StringType,
+		"inline_script":               types.StringType,
+		"script_url":                  types.StringType,
+		"script_file":                 types.StringType,
+		"script_file_args":            types.StringType,
+		"expand_token_in_script_file": types.BoolType,
+		"file_extension":              types.StringType,
+		"keep_going_on_success":       types.BoolType,
+		"script_interpreter":          types.ListType{ElemType: scriptInterpreterObjectType},
+		"job":                         types.ListType{ElemType: jobRefObjectType},
+		"step_plugin":                 types.ListType{ElemType: stepPluginObjectType},
+		"node_step_plugin":            types.ListType{ElemType: stepPluginObjectType},
+	},
+}
+
 // Command model type
 var commandObjectType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
@@ -615,11 +765,11 @@ var commandObjectType = types.ObjectType{
 		"expand_token_in_script_file": types.BoolType,
 		"file_extension":              types.StringType,
 		"keep_going_on_success":       types.BoolType,
-		"plugins":                     types.ListType{ElemType: types.ObjectType{}},
-		"script_interpreter":          types.ListType{ElemType: types.ObjectType{}},
-		"job":                         types.ListType{ElemType: types.ObjectType{}},
-		"step_plugin":                 types.ListType{ElemType: types.ObjectType{}},
-		"node_step_plugin":            types.ListType{ElemType: types.ObjectType{}},
-		"error_handler":               types.ListType{ElemType: types.ObjectType{}},
+		"plugins":                     types.ListType{ElemType: commandPluginsObjectType},
+		"script_interpreter":          types.ListType{ElemType: scriptInterpreterObjectType},
+		"job":                         types.ListType{ElemType: jobRefObjectType},
+		"step_plugin":                 types.ListType{ElemType: stepPluginObjectType},
+		"node_step_plugin":            types.ListType{ElemType: stepPluginObjectType},
+		"error_handler":               types.ListType{ElemType: errorHandlerObjectType},
 	},
 }

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -12,6 +12,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// jobRefNodeStepExplicit returns the explicitly configured node-step value for a
+// job reference, preferring run_for_each_node over its node_step alias. The
+// second return value reports whether either alias was explicitly set (known and
+// non-null). Both map to the Rundeck jobref "nodeStep" flag (#256).
+func jobRefNodeStepExplicit(jobAttrs map[string]attr.Value) (bool, bool) {
+	if rfn, ok := jobAttrs["run_for_each_node"].(types.Bool); ok && !rfn.IsNull() && !rfn.IsUnknown() {
+		return rfn.ValueBool(), true
+	}
+	if ns, ok := jobAttrs["node_step"].(types.Bool); ok && !ns.IsNull() && !ns.IsUnknown() {
+		return ns.ValueBool(), true
+	}
+	return false, false
+}
+
+// jobRefNodeStep returns the node-step value for a job reference, defaulting to
+// false when neither run_for_each_node nor node_step is set.
+func jobRefNodeStep(jobAttrs map[string]attr.Value) bool {
+	v, _ := jobRefNodeStepExplicit(jobAttrs)
+	return v
+}
+
 // convertCommandsToJSON converts Framework command list to JSON array
 func convertCommandsToJSON(ctx context.Context, commandsList types.List) ([]interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -106,16 +127,13 @@ func convertCommandsToJSON(ctx context.Context, commandsList types.List) ([]inte
 				if project, ok := jobAttrs["project_name"].(types.String); ok && !project.IsNull() {
 					jobMap["project"] = project.ValueString()
 				}
-				if rfn, ok := jobAttrs["run_for_each_node"].(types.Bool); ok && !rfn.IsNull() {
-					jobMap["runForEachNode"] = rfn.ValueBool()
-				}
-				if ns, ok := jobAttrs["node_step"].(types.Bool); ok && !ns.IsNull() {
-					// API expects string "true" or "false" for nodeStep
-					if ns.ValueBool() {
-						jobMap["nodeStep"] = "true"
-					} else {
-						jobMap["nodeStep"] = "false"
-					}
+				// run_for_each_node (documented) and node_step are aliases for the
+				// API's jobref "nodeStep" flag. run_for_each_node takes precedence.
+				// Always send nodeStep so the setting is not silently dropped (#256).
+				if jobRefNodeStep(jobAttrs) {
+					jobMap["nodeStep"] = "true"
+				} else {
+					jobMap["nodeStep"] = "false"
 				}
 				if args, ok := jobAttrs["args"].(types.String); ok && !args.IsNull() {
 					jobMap["args"] = args.ValueString()
@@ -296,12 +314,9 @@ func convertCommandsToJSON(ctx context.Context, commandsList types.List) ([]inte
 						if project, ok := jobAttrs["project_name"].(types.String); ok && !project.IsNull() {
 							jobMap["project"] = project.ValueString()
 						}
-						if rfn, ok := jobAttrs["run_for_each_node"].(types.Bool); ok && !rfn.IsNull() {
-							jobMap["runForEachNode"] = rfn.ValueBool()
-						}
-
-						// Determine if parent command is a node step or workflow step
-						// Error handlers must match the parent command type
+						// Determine if parent command is a node step or workflow step.
+						// Error handlers must match the parent command type, so this is
+						// the fallback when neither alias is set explicitly.
 						isParentNodeStep := false
 						if _, hasNodeStepPlugin := attrs["node_step_plugin"]; hasNodeStepPlugin {
 							isParentNodeStep = true
@@ -312,21 +327,17 @@ func convertCommandsToJSON(ctx context.Context, commandsList types.List) ([]inte
 							isParentNodeStep = false
 						}
 
-						if ns, ok := jobAttrs["node_step"].(types.Bool); ok && !ns.IsNull() {
-							// API expects string "true" or "false" for nodeStep
-							if ns.ValueBool() {
-								jobMap["nodeStep"] = "true"
-							} else {
-								jobMap["nodeStep"] = "false"
-							}
+						// run_for_each_node (documented) and node_step are aliases for the
+						// API's nodeStep flag. Prefer an explicit value, otherwise infer
+						// from the parent command type (#256).
+						nodeStepVal := isParentNodeStep
+						if v, explicit := jobRefNodeStepExplicit(jobAttrs); explicit {
+							nodeStepVal = v
+						}
+						if nodeStepVal {
+							jobMap["nodeStep"] = "true"
 						} else {
-							// If node_step not specified, infer from parent command type
-							// Rundeck requires error handler job references to match parent command type
-							if isParentNodeStep {
-								jobMap["nodeStep"] = "true"
-							} else {
-								jobMap["nodeStep"] = "false"
-							}
+							jobMap["nodeStep"] = "false"
 						}
 						if args, ok := jobAttrs["args"].(types.String); ok && !args.IsNull() {
 							jobMap["args"] = args.ValueString()
@@ -1844,9 +1855,14 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 			if v, ok := handler["expandTokenInScriptFile"].(bool); ok {
 				handlerAttrs["expand_token_in_script_file"] = types.BoolValue(v)
 			}
+			// Rundeck omits keepgoingOnSuccess from the API response entirely when
+			// it is false, so default to a concrete false rather than leaving this
+			// null (keep_going_on_success is Computed to allow this).
+			keepGoingOnSuccess := false
 			if v, ok := handler["keepgoingOnSuccess"].(bool); ok {
-				handlerAttrs["keep_going_on_success"] = types.BoolValue(v)
+				keepGoingOnSuccess = v
 			}
+			handlerAttrs["keep_going_on_success"] = types.BoolValue(keepGoingOnSuccess)
 
 			// Handle job reference in error_handler
 			if jobref, ok := handler["jobref"].(map[string]interface{}); ok {
@@ -1882,9 +1898,6 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 				}
 
 				// Boolean fields
-				if rfn, ok := jobref["runForEachNode"].(bool); ok {
-					jobAttrs["run_for_each_node"] = types.BoolValue(rfn)
-				}
 				if io, ok := jobref["importOptions"].(bool); ok {
 					jobAttrs["import_options"] = types.BoolValue(io)
 				}
@@ -1898,10 +1911,16 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 					jobAttrs["ignore_notifications"] = types.BoolValue(ign)
 				}
 
-				// nodeStep field (API uses string "true"/"false")
+				// run_for_each_node and node_step are aliases for the API's nodeStep
+				// flag; populate both so either configured attribute round-trips (#256).
+				nodeStepBool := false
 				if ns, ok := jobref["nodeStep"].(string); ok && ns != "" {
-					jobAttrs["node_step"] = types.BoolValue(ns == "true")
+					nodeStepBool = ns == "true"
+				} else if ns, ok := jobref["nodeStep"].(bool); ok {
+					nodeStepBool = ns
 				}
+				jobAttrs["run_for_each_node"] = types.BoolValue(nodeStepBool)
+				jobAttrs["node_step"] = types.BoolValue(nodeStepBool)
 
 				// Handle node_filters if present
 				if nodefilters, ok := jobref["nodefilters"].(map[string]interface{}); ok {
@@ -1968,6 +1987,16 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 								[]attr.Value{dispObj},
 							)
 						}
+					} else {
+						// No dispatch config
+						nfAttrs["dispatch"] = types.ListNull(
+							types.ObjectType{AttrTypes: map[string]attr.Type{
+								"thread_count":   types.Int64Type,
+								"keep_going":     types.BoolType,
+								"rank_attribute": types.StringType,
+								"rank_order":     types.StringType,
+							}},
+						)
 					}
 
 					nfObj, nfDiags := types.ObjectValue(
@@ -1985,22 +2014,35 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 						nfAttrs,
 					)
 					diags.Append(nfDiags...)
-					if !nfObj.IsNull() {
-						jobAttrs["node_filters"] = types.ListValueMust(
-							types.ObjectType{AttrTypes: map[string]attr.Type{
-								"filter":             types.StringType,
-								"exclude_filter":     types.StringType,
-								"exclude_precedence": types.BoolType,
-								"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-									"thread_count":   types.Int64Type,
-									"keep_going":     types.BoolType,
-									"rank_attribute": types.StringType,
-									"rank_order":     types.StringType,
-								}}},
-							}},
-							[]attr.Value{nfObj},
-						)
-					}
+					jobAttrs["node_filters"] = types.ListValueMust(
+						types.ObjectType{AttrTypes: map[string]attr.Type{
+							"filter":             types.StringType,
+							"exclude_filter":     types.StringType,
+							"exclude_precedence": types.BoolType,
+							"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
+								"thread_count":   types.Int64Type,
+								"keep_going":     types.BoolType,
+								"rank_attribute": types.StringType,
+								"rank_order":     types.StringType,
+							}}},
+						}},
+						[]attr.Value{nfObj},
+					)
+				} else {
+					// No node_filters
+					jobAttrs["node_filters"] = types.ListNull(
+						types.ObjectType{AttrTypes: map[string]attr.Type{
+							"filter":             types.StringType,
+							"exclude_filter":     types.StringType,
+							"exclude_precedence": types.BoolType,
+							"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
+								"thread_count":   types.Int64Type,
+								"keep_going":     types.BoolType,
+								"rank_attribute": types.StringType,
+								"rank_order":     types.StringType,
+							}}},
+						}},
+					)
 				}
 
 				// Only add job block if there are actual job reference fields
@@ -2072,77 +2114,31 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 				}
 			}
 
-			// Build error_handler object type with job block included
-			errorHandlerAttrTypes := map[string]attr.Type{
-				"description":                 types.StringType,
-				"shell_command":               types.StringType,
-				"inline_script":               types.StringType,
-				"script_url":                  types.StringType,
-				"script_file":                 types.StringType,
-				"script_file_args":            types.StringType,
-				"file_extension":              types.StringType,
-				"expand_token_in_script_file": types.BoolType,
-				"keep_going_on_success":       types.BoolType,
-				"job": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-					"uuid":                 types.StringType,
-					"name":                 types.StringType,
-					"group_name":           types.StringType,
-					"project_name":         types.StringType,
-					"run_for_each_node":    types.BoolType,
-					"node_step":            types.BoolType,
-					"args":                 types.StringType,
-					"import_options":       types.BoolType,
-					"child_nodes":          types.BoolType,
-					"fail_on_disable":      types.BoolType,
-					"ignore_notifications": types.BoolType,
-					"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"filter":             types.StringType,
-						"exclude_filter":     types.StringType,
-						"exclude_precedence": types.BoolType,
-						"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-						}}},
-					}}},
-				}}},
-			}
-
-			// Initialize job as null if not present
+			// Initialize any missing nested block fields as null to match schema.
+			// errorHandlerObjectType is the single source of truth for this shape
+			// (resource_job_command_schema.go); a hand-rolled duplicate here
+			// previously omitted script_interpreter/step_plugin/node_step_plugin,
+			// which made types.ObjectValue below fail with a silent type-mismatch
+			// diagnostic whenever an error_handler was present, discarding the
+			// entire command read-back (this is what caused #256's fix attempt to
+			// surface "unknown value after apply").
 			if _, exists := handlerAttrs["job"]; !exists {
-				handlerAttrs["job"] = types.ListNull(
-					types.ObjectType{AttrTypes: map[string]attr.Type{
-						"uuid":                 types.StringType,
-						"name":                 types.StringType,
-						"group_name":           types.StringType,
-						"project_name":         types.StringType,
-						"run_for_each_node":    types.BoolType,
-						"node_step":            types.BoolType,
-						"args":                 types.StringType,
-						"import_options":       types.BoolType,
-						"child_nodes":          types.BoolType,
-						"fail_on_disable":      types.BoolType,
-						"ignore_notifications": types.BoolType,
-						"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"filter":             types.StringType,
-							"exclude_filter":     types.StringType,
-							"exclude_precedence": types.BoolType,
-							"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-								"thread_count":   types.Int64Type,
-								"keep_going":     types.BoolType,
-								"rank_attribute": types.StringType,
-								"rank_order":     types.StringType,
-							}}},
-						}}},
-					}},
-				)
+				handlerAttrs["job"] = types.ListNull(jobRefObjectType)
+			}
+			if _, exists := handlerAttrs["script_interpreter"]; !exists {
+				handlerAttrs["script_interpreter"] = types.ListNull(scriptInterpreterObjectType)
+			}
+			if _, exists := handlerAttrs["step_plugin"]; !exists {
+				handlerAttrs["step_plugin"] = types.ListNull(stepPluginObjectType)
+			}
+			if _, exists := handlerAttrs["node_step_plugin"]; !exists {
+				handlerAttrs["node_step_plugin"] = types.ListNull(stepPluginObjectType)
 			}
 
-			handlerObj, handlerDiags := types.ObjectValue(errorHandlerAttrTypes, handlerAttrs)
+			handlerObj, handlerDiags := types.ObjectValue(errorHandlerObjectType.AttrTypes, handlerAttrs)
 			diags.Append(handlerDiags...)
 			cmdAttrs["error_handler"] = types.ListValueMust(
-				types.ObjectType{AttrTypes: errorHandlerAttrTypes},
+				errorHandlerObjectType,
 				[]attr.Value{handlerObj},
 			)
 		}
@@ -2240,9 +2236,6 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 			}
 
 			// Boolean fields
-			if rfn, ok := jobref["runForEachNode"].(bool); ok {
-				jobAttrs["run_for_each_node"] = types.BoolValue(rfn)
-			}
 			if io, ok := jobref["importOptions"].(bool); ok {
 				jobAttrs["import_options"] = types.BoolValue(io)
 			}
@@ -2256,12 +2249,16 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 				jobAttrs["ignore_notifications"] = types.BoolValue(ign)
 			}
 
-			// nodeStep field (API can use string "true"/"false" or boolean)
+			// run_for_each_node and node_step are aliases for the API's nodeStep
+			// flag; populate both so either configured attribute round-trips (#256).
+			nodeStepBool := false
 			if ns, ok := jobref["nodeStep"].(string); ok && ns != "" {
-				jobAttrs["node_step"] = types.BoolValue(ns == "true")
+				nodeStepBool = ns == "true"
 			} else if ns, ok := jobref["nodeStep"].(bool); ok {
-				jobAttrs["node_step"] = types.BoolValue(ns)
+				nodeStepBool = ns
 			}
+			jobAttrs["run_for_each_node"] = types.BoolValue(nodeStepBool)
+			jobAttrs["node_step"] = types.BoolValue(nodeStepBool)
 
 			// Handle node_filters if present
 			if nodefilters, ok := jobref["nodefilters"].(map[string]interface{}); ok {

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -1967,82 +1967,30 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 						}
 
 						dispObj, dispDiags := types.ObjectValue(
-							map[string]attr.Type{
-								"thread_count":   types.Int64Type,
-								"keep_going":     types.BoolType,
-								"rank_attribute": types.StringType,
-								"rank_order":     types.StringType,
-							},
+							nodeFilterDispatchObjectType.AttrTypes,
 							dispAttrs,
 						)
 						diags.Append(dispDiags...)
 						if !dispObj.IsNull() {
 							nfAttrs["dispatch"] = types.ListValueMust(
-								types.ObjectType{AttrTypes: map[string]attr.Type{
-									"thread_count":   types.Int64Type,
-									"keep_going":     types.BoolType,
-									"rank_attribute": types.StringType,
-									"rank_order":     types.StringType,
-								}},
+								nodeFilterDispatchObjectType,
 								[]attr.Value{dispObj},
 							)
 						}
 					} else {
 						// No dispatch config
-						nfAttrs["dispatch"] = types.ListNull(
-							types.ObjectType{AttrTypes: map[string]attr.Type{
-								"thread_count":   types.Int64Type,
-								"keep_going":     types.BoolType,
-								"rank_attribute": types.StringType,
-								"rank_order":     types.StringType,
-							}},
-						)
+						nfAttrs["dispatch"] = types.ListNull(nodeFilterDispatchObjectType)
 					}
 
-					nfObj, nfDiags := types.ObjectValue(
-						map[string]attr.Type{
-							"filter":             types.StringType,
-							"exclude_filter":     types.StringType,
-							"exclude_precedence": types.BoolType,
-							"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-								"thread_count":   types.Int64Type,
-								"keep_going":     types.BoolType,
-								"rank_attribute": types.StringType,
-								"rank_order":     types.StringType,
-							}}},
-						},
-						nfAttrs,
-					)
+					nfObj, nfDiags := types.ObjectValue(nodeFilterObjectType.AttrTypes, nfAttrs)
 					diags.Append(nfDiags...)
 					jobAttrs["node_filters"] = types.ListValueMust(
-						types.ObjectType{AttrTypes: map[string]attr.Type{
-							"filter":             types.StringType,
-							"exclude_filter":     types.StringType,
-							"exclude_precedence": types.BoolType,
-							"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-								"thread_count":   types.Int64Type,
-								"keep_going":     types.BoolType,
-								"rank_attribute": types.StringType,
-								"rank_order":     types.StringType,
-							}}},
-						}},
+						nodeFilterObjectType,
 						[]attr.Value{nfObj},
 					)
 				} else {
 					// No node_filters
-					jobAttrs["node_filters"] = types.ListNull(
-						types.ObjectType{AttrTypes: map[string]attr.Type{
-							"filter":             types.StringType,
-							"exclude_filter":     types.StringType,
-							"exclude_precedence": types.BoolType,
-							"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-								"thread_count":   types.Int64Type,
-								"keep_going":     types.BoolType,
-								"rank_attribute": types.StringType,
-								"rank_order":     types.StringType,
-							}}},
-						}},
-					)
+					jobAttrs["node_filters"] = types.ListNull(nodeFilterObjectType)
 				}
 
 				// Only add job block if there are actual job reference fields
@@ -2305,82 +2253,30 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 					}
 
 					dispObj, dispDiags := types.ObjectValue(
-						map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-						},
+						nodeFilterDispatchObjectType.AttrTypes,
 						dispAttrs,
 					)
 					diags.Append(dispDiags...)
 
 					nfAttrs["dispatch"] = types.ListValueMust(
-						types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-						}},
+						nodeFilterDispatchObjectType,
 						[]attr.Value{dispObj},
 					)
 				} else {
 					// No dispatch config
-					nfAttrs["dispatch"] = types.ListNull(
-						types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-						}},
-					)
+					nfAttrs["dispatch"] = types.ListNull(nodeFilterDispatchObjectType)
 				}
 
-				nfObj, nfDiags := types.ObjectValue(
-					map[string]attr.Type{
-						"filter":             types.StringType,
-						"exclude_filter":     types.StringType,
-						"exclude_precedence": types.BoolType,
-						"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-						}}},
-					},
-					nfAttrs,
-				)
+				nfObj, nfDiags := types.ObjectValue(nodeFilterObjectType.AttrTypes, nfAttrs)
 				diags.Append(nfDiags...)
 
 				jobAttrs["node_filters"] = types.ListValueMust(
-					types.ObjectType{AttrTypes: map[string]attr.Type{
-						"filter":             types.StringType,
-						"exclude_filter":     types.StringType,
-						"exclude_precedence": types.BoolType,
-						"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-						}}},
-					}},
+					nodeFilterObjectType,
 					[]attr.Value{nfObj},
 				)
 			} else {
 				// No node_filters
-				jobAttrs["node_filters"] = types.ListNull(
-					types.ObjectType{AttrTypes: map[string]attr.Type{
-						"filter":             types.StringType,
-						"exclude_filter":     types.StringType,
-						"exclude_precedence": types.BoolType,
-						"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-						}}},
-					}},
-				)
+				jobAttrs["node_filters"] = types.ListNull(nodeFilterObjectType)
 			}
 
 			jobObj, jobDiags := types.ObjectValue(

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -337,7 +337,11 @@ func validateJobRefNodeStep(ctx context.Context, jobAttr attr.Value, p path.Path
 		return
 	}
 	var jobs []types.Object
-	diags.Append(jobList.ElementsAs(ctx, &jobs, false)...)
+	elemDiags := jobList.ElementsAs(ctx, &jobs, false)
+	diags.Append(elemDiags...)
+	if elemDiags.HasError() {
+		return
+	}
 	for _, job := range jobs {
 		a := job.Attributes()
 		rfn, rok := a["run_for_each_node"].(types.Bool)

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -328,12 +328,60 @@ func (r *jobResource) Configure(_ context.Context, req resource.ConfigureRequest
 	r.client = clients
 }
 
+// validateJobRefNodeStep reports an error when a job reference sets both
+// run_for_each_node and node_step (aliases for the API's nodeStep flag) to
+// different values.
+func validateJobRefNodeStep(ctx context.Context, jobAttr attr.Value, p path.Path, diags *diag.Diagnostics) {
+	jobList, ok := jobAttr.(types.List)
+	if !ok || jobList.IsNull() || jobList.IsUnknown() {
+		return
+	}
+	var jobs []types.Object
+	diags.Append(jobList.ElementsAs(ctx, &jobs, false)...)
+	for _, job := range jobs {
+		a := job.Attributes()
+		rfn, rok := a["run_for_each_node"].(types.Bool)
+		ns, nok := a["node_step"].(types.Bool)
+		if rok && nok &&
+			!rfn.IsNull() && !rfn.IsUnknown() && !ns.IsNull() && !ns.IsUnknown() &&
+			rfn.ValueBool() != ns.ValueBool() {
+			diags.AddAttributeError(p,
+				"Conflicting node step settings",
+				"run_for_each_node and node_step are aliases for the same setting but are set to different values. Set only one, or set both to the same value.")
+		}
+	}
+}
+
 func (r *jobResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var config jobResourceModel
 	diags := req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Validate job references: run_for_each_node and node_step are aliases for the
+	// same API flag (nodeStep), so reject conflicting values (#256).
+	if !config.Command.IsNull() && !config.Command.IsUnknown() {
+		var commands []types.Object
+		resp.Diagnostics.Append(config.Command.ElementsAs(ctx, &commands, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		for i, cmd := range commands {
+			cmdAttrs := cmd.Attributes()
+			validateJobRefNodeStep(ctx, cmdAttrs["job"],
+				path.Root("command").AtListIndex(i).AtName("job"), &resp.Diagnostics)
+			if ehList, ok := cmdAttrs["error_handler"].(types.List); ok && !ehList.IsNull() && !ehList.IsUnknown() {
+				var ehs []types.Object
+				resp.Diagnostics.Append(ehList.ElementsAs(ctx, &ehs, false)...)
+				for j, eh := range ehs {
+					validateJobRefNodeStep(ctx, eh.Attributes()["job"],
+						path.Root("command").AtListIndex(i).AtName("error_handler").AtListIndex(j).AtName("job"),
+						&resp.Diagnostics)
+				}
+			}
+		}
 	}
 
 	// Validate notifications: check for duplicates and alphabetical ordering

--- a/rundeck/resource_job_keepgoing_test.go
+++ b/rundeck/resource_job_keepgoing_test.go
@@ -20,7 +20,6 @@ import (
 func testSingleShellCommandList(t *testing.T) types.List {
 	t.Helper()
 
-	emptyObjList := types.ListNull(types.ObjectType{})
 	cmd, diags := types.ObjectValue(commandObjectType.AttrTypes, map[string]attr.Value{
 		"description":                 types.StringValue("echo"),
 		"shell_command":               types.StringValue("echo hi"),
@@ -31,12 +30,12 @@ func testSingleShellCommandList(t *testing.T) types.List {
 		"expand_token_in_script_file": types.BoolNull(),
 		"file_extension":              types.StringNull(),
 		"keep_going_on_success":       types.BoolNull(),
-		"plugins":                     emptyObjList,
-		"script_interpreter":          emptyObjList,
-		"job":                         emptyObjList,
-		"step_plugin":                 emptyObjList,
-		"node_step_plugin":            emptyObjList,
-		"error_handler":               emptyObjList,
+		"plugins":                     types.ListNull(commandPluginsObjectType),
+		"script_interpreter":          types.ListNull(scriptInterpreterObjectType),
+		"job":                         types.ListNull(jobRefObjectType),
+		"step_plugin":                 types.ListNull(stepPluginObjectType),
+		"node_step_plugin":            types.ListNull(stepPluginObjectType),
+		"error_handler":               types.ListNull(errorHandlerObjectType),
 	})
 	if diags.HasError() {
 		t.Fatalf("building command object: %v", diags)

--- a/rundeck/resource_job_node_step_test.go
+++ b/rundeck/resource_job_node_step_test.go
@@ -1,0 +1,43 @@
+package rundeck
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Regression tests for #256: run_for_each_node on a job reference was serialized
+// to a non-existent "runForEachNode" key and silently ignored by Rundeck. It must
+// drive the API's "nodeStep" flag (with node_step as an alias), and round-trip
+// back into both alias attributes.
+
+func TestJobRefNodeStepExplicit(t *testing.T) {
+	cases := []struct {
+		name         string
+		attrs        map[string]attr.Value
+		wantVal      bool
+		wantExplicit bool
+	}{
+		{"run_for_each_node true", map[string]attr.Value{"run_for_each_node": types.BoolValue(true)}, true, true},
+		{"run_for_each_node false", map[string]attr.Value{"run_for_each_node": types.BoolValue(false)}, false, true},
+		{"node_step alias true", map[string]attr.Value{"node_step": types.BoolValue(true)}, true, true},
+		{"run_for_each_node precedence over node_step", map[string]attr.Value{"run_for_each_node": types.BoolValue(true), "node_step": types.BoolValue(false)}, true, true},
+		{"neither set", map[string]attr.Value{}, false, false},
+		{"null values", map[string]attr.Value{"run_for_each_node": types.BoolNull(), "node_step": types.BoolNull()}, false, false},
+		{"unknown run_for_each_node falls back to node_step", map[string]attr.Value{"run_for_each_node": types.BoolUnknown(), "node_step": types.BoolValue(true)}, true, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gotVal, gotExplicit := jobRefNodeStepExplicit(tc.attrs)
+			if gotVal != tc.wantVal || gotExplicit != tc.wantExplicit {
+				t.Errorf("jobRefNodeStepExplicit = (%v, %v), want (%v, %v)", gotVal, gotExplicit, tc.wantVal, tc.wantExplicit)
+			}
+			if got := jobRefNodeStep(tc.attrs); got != tc.wantVal {
+				t.Errorf("jobRefNodeStep = %v, want %v", got, tc.wantVal)
+			}
+		})
+	}
+}

--- a/rundeck/resource_job_run_for_each_node_test.go
+++ b/rundeck/resource_job_run_for_each_node_test.go
@@ -1,0 +1,116 @@
+package rundeck
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccJob_cmd_referred_job_runForEachNode is a regression test for #256:
+// run_for_each_node on a job reference was serialized to a field Rundeck
+// ignores, so the referenced job was always treated as a workflow step. This
+// exercises run_for_each_node and its node_step alias on both a plain command
+// job reference and an error_handler job reference, and asserts the setting
+// round-trips (no drift, no "inconsistent result after apply") on a second
+// plan.
+func TestAccJob_cmd_referred_job_runForEachNode(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccJobCheckDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_cmd_referred_job_runForEachNode,
+				Check: resource.ComposeTestCheckFunc(
+					// command[0].job: run_for_each_node explicitly set true, node_step
+					// must read back as true too (alias round-trip).
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.0.job.0.run_for_each_node", "true"),
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.0.job.0.node_step", "true"),
+					// command[0].error_handler.job: same setting, must also work on
+					// error handlers (this was the only path that worked pre-fix).
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.0.error_handler.0.job.0.run_for_each_node", "true"),
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.0.error_handler.0.job.0.node_step", "true"),
+					// command[1].job: node_step alias set true, run_for_each_node must
+					// read back as true too.
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.1.job.0.node_step", "true"),
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.1.job.0.run_for_each_node", "true"),
+					// command[2].job: neither alias configured, defaults to false (a
+					// workflow step, not a node step).
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.2.job.0.run_for_each_node", "false"),
+					resource.TestCheckResourceAttr("rundeck_job.caller", "command.2.job.0.node_step", "false"),
+				),
+			},
+			{
+				// Re-apply with the same config: this must produce an empty plan.
+				// The original fix attempt was reverted because this step surfaced
+				// "unknown value after apply" / drift for some job references.
+				Config:   testAccJobConfig_cmd_referred_job_runForEachNode,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+const testAccJobConfig_cmd_referred_job_runForEachNode = `
+resource "rundeck_project" "test" {
+  name        = "terraform-acc-test-job-run-for-each-node"
+  description = "Test project for run_for_each_node regression (#256)"
+  resource_model_source {
+    type = "file"
+    config = {
+      format = "resourceyaml"
+      file   = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+
+resource "rundeck_job" "target" {
+  project_name       = rundeck_project.test.name
+  name               = "target-job"
+  description        = "Job to be referenced"
+  execution_enabled  = true
+  command {
+    shell_command = "echo 'I am the target job'"
+  }
+}
+
+resource "rundeck_job" "caller" {
+  project_name      = rundeck_project.test.name
+  name              = "caller-job"
+  description       = "Job referencing another job with run_for_each_node/node_step (#256)"
+  execution_enabled = true
+
+  command {
+    description = "call target via run_for_each_node"
+    job {
+      name              = rundeck_job.target.name
+      project_name      = rundeck_project.test.name
+      run_for_each_node = true
+    }
+    error_handler {
+      job {
+        name              = rundeck_job.target.name
+        project_name      = rundeck_project.test.name
+        run_for_each_node = true
+      }
+    }
+  }
+
+  command {
+    description = "call target via node_step alias"
+    job {
+      name         = rundeck_job.target.name
+      project_name = rundeck_project.test.name
+      node_step    = true
+    }
+  }
+
+  command {
+    description = "call target with neither alias set"
+    job {
+      name         = rundeck_job.target.name
+      project_name = rundeck_project.test.name
+    }
+  }
+}
+`

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -524,12 +524,16 @@ A command's `job` block has the following structure:
 
 * `group_name`: (Optional) The name of the group that the target job belongs to, if any. Used with name-based references.
 
-* `project_name` - (Optional) The name of another project that holds the target job. Used with name-based references.
+* `project_name` - (Optional) The name of another project that holds the target job. Used with name-based references. Rundeck always resolves and returns all four identification fields for a job reference, so `uuid`/`name`/`group_name`/`project_name` are populated from the API on refresh even when only a subset was configured (e.g. a UUID-only reference).
 
 **Job Execution Options:**
 
 * `run_for_each_node`: (Optional) Boolean controlling whether the job is run only once (`false`,
-  the default) or whether it is run once for each node (`true`).
+  the default) or whether it is run once for each node (`true`). This maps to the referenced job
+  being a node step.
+
+* `node_step`: (Optional) Alias of `run_for_each_node`; both control whether the referenced job
+  runs once per node. If both are set they must agree, and `run_for_each_node` takes precedence.
 
 * `args`: (Optional) A string giving the arguments to pass to the target job, using
   [Rundeck's job arguments syntax](http://rundeck.org/docs/manual/jobs.html#job-reference-step).


### PR DESCRIPTION
## Summary

- Fixes #256: `run_for_each_node` on a job reference (`command { job { ... } }`) was serialized to a non-existent `runForEachNode` API key and silently ignored by Rundeck, so the referenced job was always treated as a workflow step (the setting only worked on `error_handler` job references). It now correctly drives the API's `nodeStep` flag and round-trips on read. `node_step` continues to work as an alias (`run_for_each_node` takes precedence if both are set); both are `Optional`+`Computed`, and a `ValidateConfig` check rejects conflicting values.
- Fixes the root cause of why the earlier attempt at this ([#265](https://github.com/rundeck/terraform-provider-rundeck/pull/265)) was reverted: `commandObjectType`/the hand-rolled `error_handler` object type declared nested blocks (`job`, `error_handler`, `step_plugin`, `node_step_plugin`, `plugins`, `script_interpreter`) with empty, untyped placeholders instead of their real shape. Building the per-command object silently failed its own type check whenever a command had a job reference or error handler, and the caller swallowed the resulting diagnostics and skipped updating state — i.e. **command read-back has been a silent no-op for any job using those features**, invisible until something (like a newly-Computed attribute) actually required a resolved value.
- That fix, once read-back actually started working, exposed two more previously-dormant bugs that I fixed as well:
  - A job reference's `uuid`/`name`/`group_name`/`project_name` weren't `Computed`, but Rundeck always resolves and returns all four for a reference regardless of which fields were configured (e.g. a UUID-only reference), so they're now `Optional`+`Computed`.
  - An `error_handler`'s `keep_going_on_success` read back as `null` instead of `false`, because Rundeck omits the field from its API response entirely when it's `false`. Now `Computed` and defaults to a concrete `false`.

## Test plan

- [x] `go build ./...`, `go vet ./rundeck/`, `gofmt -l`, and unit tests pass
- [x] Verified against a live Rundeck 5.17.0 instance via the repo's local `docker-compose` acceptance-test setup:
  - Reproduced the exact "unknown value after apply" failure that sank the original attempt, then root-caused and fixed it (see above)
  - Added `TestAccJob_cmd_referred_job_runForEachNode`, covering `run_for_each_node`, the `node_step` alias, neither set, and an `error_handler` job reference — including a second `PlanOnly` apply step to catch drift
  - Full `TestAccJob*` suite passes; the only remaining failures in the full suite are 6 pre-existing `TestAccRundeckWebhook_*` failures (`"Webhook user 'admin' not found"`) confirmed to also fail on unmodified `master` — an unrelated local environment/setup gap
