### PR TITLE
feat: add node_intersect to job reference node filters dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 ## Unreleased
 
-**Enhancements**
+**Bug Fixes**
 
 ### Job Resource
 
-- **Added `node_intersect` to a job reference's `node_filters` `dispatch` block** - Rundeck's "Match Node Filter Intersection" setting (`jobref.nodefilters.dispatch.nodeIntersect`) had no equivalent in the provider, so a referenced job configured this way always ran on its own node set instead of the intersection with the calling job's. The setting is now settable and round-trips on read. Note that Rundeck honors `nodeIntersect` even when the reference sets no `filter` — it is the only `dispatch` field read independently of one — so a `dispatch` block carrying nothing but `node_intersect` is a valid configuration.
+- **Fixed updates being resolved by name instead of UUID, which created duplicate jobs** - On update the provider sent the job's UUID under `id`, but Rundeck writes a job's UUID out under both `uuid` and `id` (`ScheduledExecution.toMap`) while only reading it back from `uuid` (`fromMap`). The identifier therefore never reached the import, and Rundeck fell back to resolving the job by name + group + project — a fallback that only matches when *exactly one* job carries that name (`1 == schedlist.size()` in `loadImportedJobs`).
+
+  Two consequences. **Renaming a job created a second one** — `name` is not `RequiresReplace`, so a rename goes through Update, the new name matched nothing, and Rundeck created a job while the original stayed behind under its old name. And **two jobs sharing a name could never be updated**: every apply added another duplicate, which guaranteed the name would never resolve again. The fallback could also update the *wrong* job when an unrelated one happened to share the name.
+
+  In both cases the apply then fails with `Provider produced inconsistent result after apply`, since the id returned is the job that was just created rather than the one in state. The error is visible; what is silent is the damage left in Rundeck — the duplicate stays, and the original is no longer referenced by Terraform.
+
+  The update payload now carries `uuid`, so Rundeck takes its UUID-first resolution path and the job is targeted unambiguously. **Behaviour change:** renaming a job now renames it in place and succeeds, where it previously failed after creating a duplicate. Duplicates left behind by the previous behaviour are not cleaned up automatically — Terraform no longer references them, so they have to be removed from Rundeck by hand. `group_name` and `project_name` are unaffected: both carry `RequiresReplace`, so changing either already destroys and recreates the job.
+
+- **Fixed a plugin-based `error_handler` being silently discarded** - The schema accepts `step_plugin` and `node_step_plugin` under `error_handler`, and `errorHandlerObjectType` declares both, but neither conversion handled them: the write side emitted only `description`, the script/command fields and `jobref`, and the read side never looked for `type`/`configuration`. A handler such as `flow-control` therefore serialized to an object carrying no action at all. Rundeck accepted the job and dropped the handler, so the read-back returned no block and the apply failed with `error_handler: block count changed from 1 to 0`.
+
+  The plan being perfectly valid, this only ever surfaced at apply time — and the job was left in Rundeck without its handler, so a workflow meant to stop on a condition simply ran on. Both directions now carry `type`, `configuration` and `nodeStep`, the latter distinguishing a workflow step from a node step (Rundeck answers it as a bool or as the string `"true"`, both accepted).
+
+  Note that Rundeck itself refuses a workflow-step handler on a node-oriented workflow (*"Error Handlers for Node Steps must also be Node Steps"*), so a job guarded this way needs `strategy = "sequential"`.
+
 
 ## 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**Enhancements**
+
+### Job Resource
+
+- **Added `node_intersect` to a job reference's `node_filters` `dispatch` block** - Rundeck's "Match Node Filter Intersection" setting (`jobref.nodefilters.dispatch.nodeIntersect`) had no equivalent in the provider, so a referenced job configured this way always ran on its own node set instead of the intersection with the calling job's. The setting is now settable and round-trips on read. Note that Rundeck honors `nodeIntersect` even when the reference sets no `filter` — it is the only `dispatch` field read independently of one — so a `dispatch` block carrying nothing but `node_intersect` is a valid configuration.
+
 ## 1.3.1
 
 **Bug Fixes**

--- a/rundeck/resource_job_command_schema.go
+++ b/rundeck/resource_job_command_schema.go
@@ -187,6 +187,10 @@ func jobCommandNestedBlock() schema.ListNestedBlock {
 														Optional:    true,
 														Description: "Rank order: ascending or descending",
 													},
+													"node_intersect": schema.BoolAttribute{
+														Optional:    true,
+														Description: "Run the referenced job only on the intersection of its own node set and the parent job's (Rundeck's \"Match Node Filter Intersection\")",
+													},
 												},
 											},
 										},
@@ -373,6 +377,10 @@ func jobCommandNestedBlock() schema.ListNestedBlock {
 																},
 																"rank_order": schema.StringAttribute{
 																	Optional: true,
+																},
+																"node_intersect": schema.BoolAttribute{
+																	Optional:    true,
+																	Description: "Run the referenced job only on the intersection of its own node set and the parent job's (Rundeck's \"Match Node Filter Intersection\")",
 																},
 															},
 														},
@@ -670,6 +678,7 @@ var nodeFilterDispatchObjectType = types.ObjectType{
 		"keep_going":     types.BoolType,
 		"rank_attribute": types.StringType,
 		"rank_order":     types.StringType,
+		"node_intersect": types.BoolType,
 	},
 }
 

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -2012,62 +2012,19 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 					}
 				}
 				if hasJobRef {
+					// jobRefObjectType (resource_job_command_schema.go) is the single
+					// source of truth for this shape; a hand-rolled duplicate here
+					// previously omitted a field and made types.ObjectValue fail with a
+					// silent type-mismatch diagnostic, discarding the whole command on
+					// read (see the note on errorHandlerObjectType below, and #256).
 					jobObj, jobDiags := types.ObjectValue(
-						map[string]attr.Type{
-							"uuid":                 types.StringType,
-							"name":                 types.StringType,
-							"group_name":           types.StringType,
-							"project_name":         types.StringType,
-							"run_for_each_node":    types.BoolType,
-							"node_step":            types.BoolType,
-							"args":                 types.StringType,
-							"import_options":       types.BoolType,
-							"child_nodes":          types.BoolType,
-							"fail_on_disable":      types.BoolType,
-							"ignore_notifications": types.BoolType,
-							"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-								"filter":             types.StringType,
-								"exclude_filter":     types.StringType,
-								"exclude_precedence": types.BoolType,
-								"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-									"thread_count":   types.Int64Type,
-									"keep_going":     types.BoolType,
-									"rank_attribute": types.StringType,
-									"rank_order":     types.StringType,
-									"node_intersect": types.BoolType,
-								}}},
-							}}},
-						},
+						jobRefObjectType.AttrTypes,
 						jobAttrs,
 					)
 					diags.Append(jobDiags...)
 					if !jobObj.IsNull() {
 						handlerAttrs["job"] = types.ListValueMust(
-							types.ObjectType{AttrTypes: map[string]attr.Type{
-								"uuid":                 types.StringType,
-								"name":                 types.StringType,
-								"group_name":           types.StringType,
-								"project_name":         types.StringType,
-								"run_for_each_node":    types.BoolType,
-								"node_step":            types.BoolType,
-								"args":                 types.StringType,
-								"import_options":       types.BoolType,
-								"child_nodes":          types.BoolType,
-								"fail_on_disable":      types.BoolType,
-								"ignore_notifications": types.BoolType,
-								"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-									"filter":             types.StringType,
-									"exclude_filter":     types.StringType,
-									"exclude_precedence": types.BoolType,
-									"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-										"thread_count":   types.Int64Type,
-										"keep_going":     types.BoolType,
-										"rank_attribute": types.StringType,
-										"rank_order":     types.StringType,
-										"node_intersect": types.BoolType,
-									}}},
-								}}},
-							}},
+							jobRefObjectType,
 							[]attr.Value{jobObj},
 						)
 					}
@@ -2295,62 +2252,17 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 				jobAttrs["node_filters"] = types.ListNull(nodeFilterObjectType)
 			}
 
+			// jobRefObjectType (resource_job_command_schema.go) is the single source
+			// of truth for this shape; see the note above for why a hand-rolled
+			// duplicate here is a hazard (#256).
 			jobObj, jobDiags := types.ObjectValue(
-				map[string]attr.Type{
-					"uuid":                 types.StringType,
-					"name":                 types.StringType,
-					"group_name":           types.StringType,
-					"project_name":         types.StringType,
-					"run_for_each_node":    types.BoolType,
-					"node_step":            types.BoolType,
-					"args":                 types.StringType,
-					"import_options":       types.BoolType,
-					"child_nodes":          types.BoolType,
-					"fail_on_disable":      types.BoolType,
-					"ignore_notifications": types.BoolType,
-					"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"filter":             types.StringType,
-						"exclude_filter":     types.StringType,
-						"exclude_precedence": types.BoolType,
-						"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-							"node_intersect": types.BoolType,
-						}}},
-					}}},
-				},
+				jobRefObjectType.AttrTypes,
 				jobAttrs,
 			)
 			diags.Append(jobDiags...)
 
 			cmdAttrs["job"] = types.ListValueMust(
-				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"uuid":                 types.StringType,
-					"name":                 types.StringType,
-					"group_name":           types.StringType,
-					"project_name":         types.StringType,
-					"run_for_each_node":    types.BoolType,
-					"node_step":            types.BoolType,
-					"args":                 types.StringType,
-					"import_options":       types.BoolType,
-					"child_nodes":          types.BoolType,
-					"fail_on_disable":      types.BoolType,
-					"ignore_notifications": types.BoolType,
-					"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"filter":             types.StringType,
-						"exclude_filter":     types.StringType,
-						"exclude_precedence": types.BoolType,
-						"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-							"node_intersect": types.BoolType,
-						}}},
-					}}},
-				}},
+				jobRefObjectType,
 				[]attr.Value{jobObj},
 			)
 		}
@@ -2433,122 +2345,28 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 			}
 		}
 
-		// Initialize any missing nested block fields as null to match schema
-		// We need to use the exact types from commandObjectType to avoid type mismatch errors
+		// Initialize any missing nested block fields as null to match schema.
+		// Reuse the canonical *ObjectType vars from resource_job_command_schema.go
+		// instead of hand-rolled literals: a duplicate here previously omitted a
+		// field, which made types.ObjectValue below fail with a silent
+		// type-mismatch diagnostic and discarded the entire command on read (#256).
 		if _, exists := cmdAttrs["script_interpreter"]; !exists {
-			cmdAttrs["script_interpreter"] = types.ListNull(
-				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"args_quoted":       types.BoolType,
-					"invocation_string": types.StringType,
-				}},
-			)
+			cmdAttrs["script_interpreter"] = types.ListNull(scriptInterpreterObjectType)
 		}
 		if _, exists := cmdAttrs["plugins"]; !exists {
-			cmdAttrs["plugins"] = types.ListNull(
-				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"log_filter_plugin": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"type":   types.StringType,
-						"config": types.MapType{ElemType: types.StringType},
-					}}},
-				}},
-			)
+			cmdAttrs["plugins"] = types.ListNull(commandPluginsObjectType)
 		}
 		if _, exists := cmdAttrs["job"]; !exists {
-			cmdAttrs["job"] = types.ListNull(
-				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"name":                 types.StringType,
-					"group_name":           types.StringType,
-					"project_name":         types.StringType,
-					"uuid":                 types.StringType,
-					"args":                 types.StringType,
-					"run_for_each_node":    types.BoolType,
-					"node_step":            types.BoolType,
-					"child_nodes":          types.BoolType,
-					"import_options":       types.BoolType,
-					"fail_on_disable":      types.BoolType,
-					"ignore_notifications": types.BoolType,
-					"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"filter":             types.StringType,
-						"exclude_filter":     types.StringType,
-						"exclude_precedence": types.BoolType,
-						"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"thread_count":   types.Int64Type,
-							"keep_going":     types.BoolType,
-							"rank_attribute": types.StringType,
-							"rank_order":     types.StringType,
-							"node_intersect": types.BoolType,
-						}}},
-					}}},
-				}},
-			)
+			cmdAttrs["job"] = types.ListNull(jobRefObjectType)
 		}
 		if _, exists := cmdAttrs["step_plugin"]; !exists {
-			cmdAttrs["step_plugin"] = types.ListNull(
-				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"type":   types.StringType,
-					"config": types.MapType{ElemType: types.StringType},
-				}},
-			)
+			cmdAttrs["step_plugin"] = types.ListNull(stepPluginObjectType)
 		}
 		if _, exists := cmdAttrs["node_step_plugin"]; !exists {
-			cmdAttrs["node_step_plugin"] = types.ListNull(
-				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"type":   types.StringType,
-					"config": types.MapType{ElemType: types.StringType},
-				}},
-			)
+			cmdAttrs["node_step_plugin"] = types.ListNull(stepPluginObjectType)
 		}
 		if _, exists := cmdAttrs["error_handler"]; !exists {
-			cmdAttrs["error_handler"] = types.ListNull(
-				types.ObjectType{AttrTypes: map[string]attr.Type{
-					"description":                 types.StringType,
-					"shell_command":               types.StringType,
-					"inline_script":               types.StringType,
-					"script_url":                  types.StringType,
-					"script_file":                 types.StringType,
-					"script_file_args":            types.StringType,
-					"file_extension":              types.StringType,
-					"expand_token_in_script_file": types.BoolType,
-					"keep_going_on_success":       types.BoolType,
-					"script_interpreter": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"args_quoted":       types.BoolType,
-						"invocation_string": types.StringType,
-					}}},
-					"job": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"uuid":                 types.StringType,
-						"name":                 types.StringType,
-						"group_name":           types.StringType,
-						"project_name":         types.StringType,
-						"run_for_each_node":    types.BoolType,
-						"node_step":            types.BoolType,
-						"args":                 types.StringType,
-						"import_options":       types.BoolType,
-						"child_nodes":          types.BoolType,
-						"fail_on_disable":      types.BoolType,
-						"ignore_notifications": types.BoolType,
-						"node_filters": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-							"filter":             types.StringType,
-							"exclude_filter":     types.StringType,
-							"exclude_precedence": types.BoolType,
-							"dispatch": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-								"thread_count":   types.Int64Type,
-								"keep_going":     types.BoolType,
-								"rank_attribute": types.StringType,
-								"rank_order":     types.StringType,
-								"node_intersect": types.BoolType,
-							}}},
-						}}},
-					}}},
-					"step_plugin": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"type":   types.StringType,
-						"config": types.MapType{ElemType: types.StringType},
-					}}},
-					"node_step_plugin": types.ListType{ElemType: types.ObjectType{AttrTypes: map[string]attr.Type{
-						"type":   types.StringType,
-						"config": types.MapType{ElemType: types.StringType},
-					}}},
-				}},
-			)
+			cmdAttrs["error_handler"] = types.ListNull(errorHandlerObjectType)
 		}
 
 		// Use the commandObjectType defined in resource_job_command_schema.go

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -188,6 +188,9 @@ func convertCommandsToJSON(ctx context.Context, commandsList types.List) ([]inte
 								if ro, ok := dispAttrs["rank_order"].(types.String); ok && !ro.IsNull() {
 									dispMap["rankOrder"] = ro.ValueString()
 								}
+								if ni, ok := dispAttrs["node_intersect"].(types.Bool); ok && !ni.IsNull() {
+									dispMap["nodeIntersect"] = ni.ValueBool()
+								}
 
 								if len(dispMap) > 0 {
 									nfMap["dispatch"] = dispMap
@@ -391,6 +394,9 @@ func convertCommandsToJSON(ctx context.Context, commandsList types.List) ([]inte
 										}
 										if ro, ok := dispAttrs["rank_order"].(types.String); ok && !ro.IsNull() {
 											dispMap["rankOrder"] = ro.ValueString()
+										}
+										if ni, ok := dispAttrs["node_intersect"].(types.Bool); ok && !ni.IsNull() {
+											dispMap["nodeIntersect"] = ni.ValueBool()
 										}
 
 										if len(dispMap) > 0 {
@@ -1947,6 +1953,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 							"keep_going":     types.BoolNull(),
 							"rank_attribute": types.StringNull(),
 							"rank_order":     types.StringNull(),
+							"node_intersect": types.BoolNull(),
 						}
 
 						// threadcount can be int or float64 from JSON
@@ -1964,6 +1971,9 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 						}
 						if ro, ok := dispatch["rankOrder"].(string); ok && ro != "" {
 							dispAttrs["rank_order"] = types.StringValue(ro)
+						}
+						if ni, ok := dispatch["nodeIntersect"].(bool); ok {
+							dispAttrs["node_intersect"] = types.BoolValue(ni)
 						}
 
 						dispObj, dispDiags := types.ObjectValue(
@@ -2024,6 +2034,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 									"keep_going":     types.BoolType,
 									"rank_attribute": types.StringType,
 									"rank_order":     types.StringType,
+									"node_intersect": types.BoolType,
 								}}},
 							}}},
 						},
@@ -2053,6 +2064,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 										"keep_going":     types.BoolType,
 										"rank_attribute": types.StringType,
 										"rank_order":     types.StringType,
+										"node_intersect": types.BoolType,
 									}}},
 								}}},
 							}},
@@ -2233,6 +2245,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 						"keep_going":     types.BoolNull(),
 						"rank_attribute": types.StringNull(),
 						"rank_order":     types.StringNull(),
+						"node_intersect": types.BoolNull(),
 					}
 
 					// threadcount can be int or float64 from JSON
@@ -2250,6 +2263,9 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 					}
 					if ro, ok := dispatch["rankOrder"].(string); ok && ro != "" {
 						dispAttrs["rank_order"] = types.StringValue(ro)
+					}
+					if ni, ok := dispatch["nodeIntersect"].(bool); ok {
+						dispAttrs["node_intersect"] = types.BoolValue(ni)
 					}
 
 					dispObj, dispDiags := types.ObjectValue(
@@ -2301,6 +2317,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 							"keep_going":     types.BoolType,
 							"rank_attribute": types.StringType,
 							"rank_order":     types.StringType,
+							"node_intersect": types.BoolType,
 						}}},
 					}}},
 				},
@@ -2330,6 +2347,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 							"keep_going":     types.BoolType,
 							"rank_attribute": types.StringType,
 							"rank_order":     types.StringType,
+							"node_intersect": types.BoolType,
 						}}},
 					}}},
 				}},
@@ -2458,6 +2476,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 							"keep_going":     types.BoolType,
 							"rank_attribute": types.StringType,
 							"rank_order":     types.StringType,
+							"node_intersect": types.BoolType,
 						}}},
 					}}},
 				}},
@@ -2516,6 +2535,7 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 								"keep_going":     types.BoolType,
 								"rank_attribute": types.StringType,
 								"rank_order":     types.StringType,
+								"node_intersect": types.BoolType,
 							}}},
 						}}},
 					}}},

--- a/rundeck/resource_job_node_intersect_test.go
+++ b/rundeck/resource_job_node_intersect_test.go
@@ -1,0 +1,414 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Plain unit tests (no TF_ACC / live Rundeck required) for node_intersect on a
+// job reference's node_filters dispatch block.
+//
+// Rundeck maps this to jobref.nodefilters.dispatch.nodeIntersect (see
+// JobExec.toMap/fromMap in rundeck/rundeck). Two behaviours from that mapping
+// matter here and are asserted below:
+//
+//   - nodeIntersect is the only dispatch field Rundeck reads independently of a
+//     node filter, and when no filter is set it emits nodefilters carrying
+//     nothing but dispatch.nodeIntersect. That shape must survive the round
+//     trip, otherwise the read-back drops the flag and every plan shows drift.
+//   - An absent flag must stay null in state rather than read back as an
+//     explicit false, so an unconfigured dispatch block does not gain a value
+//     the configuration never asked for.
+
+// testJobRefDispatchList builds a node_filters list holding a single dispatch
+// block whose only set attribute is node_intersect.
+func testJobRefDispatchList(t *testing.T, nodeIntersect attr.Value) types.List {
+	t.Helper()
+
+	disp, diags := types.ObjectValue(nodeFilterDispatchObjectType.AttrTypes, map[string]attr.Value{
+		"thread_count":   types.Int64Null(),
+		"keep_going":     types.BoolNull(),
+		"rank_attribute": types.StringNull(),
+		"rank_order":     types.StringNull(),
+		"node_intersect": nodeIntersect,
+	})
+	if diags.HasError() {
+		t.Fatalf("building dispatch object: %v", diags)
+	}
+
+	nf, diags := types.ObjectValue(nodeFilterObjectType.AttrTypes, map[string]attr.Value{
+		"filter":             types.StringNull(),
+		"exclude_filter":     types.StringNull(),
+		"exclude_precedence": types.BoolNull(),
+		"dispatch":           types.ListValueMust(nodeFilterDispatchObjectType, []attr.Value{disp}),
+	})
+	if diags.HasError() {
+		t.Fatalf("building node_filters object: %v", diags)
+	}
+
+	return types.ListValueMust(nodeFilterObjectType, []attr.Value{nf})
+}
+
+// testJobRefObject builds a minimal job reference carrying the given
+// node_filters list.
+func testJobRefObject(t *testing.T, nodeFilters types.List) types.Object {
+	t.Helper()
+
+	jobRef, diags := types.ObjectValue(jobRefObjectType.AttrTypes, map[string]attr.Value{
+		"uuid":                 types.StringNull(),
+		"name":                 types.StringValue("target-job"),
+		"group_name":           types.StringNull(),
+		"project_name":         types.StringNull(),
+		"run_for_each_node":    types.BoolNull(),
+		"node_step":            types.BoolNull(),
+		"args":                 types.StringNull(),
+		"import_options":       types.BoolNull(),
+		"child_nodes":          types.BoolNull(),
+		"fail_on_disable":      types.BoolNull(),
+		"ignore_notifications": types.BoolNull(),
+		"node_filters":         nodeFilters,
+	})
+	if diags.HasError() {
+		t.Fatalf("building job reference object: %v", diags)
+	}
+	return jobRef
+}
+
+// testCommandWithJobRefs builds a one-command list whose command references a
+// job both directly and through its error handler, so a single conversion
+// exercises both code paths.
+func testCommandWithJobRefs(t *testing.T, jobRef types.Object) types.List {
+	t.Helper()
+
+	handler, diags := types.ObjectValue(errorHandlerObjectType.AttrTypes, map[string]attr.Value{
+		"description":                 types.StringNull(),
+		"shell_command":               types.StringNull(),
+		"inline_script":               types.StringNull(),
+		"script_url":                  types.StringNull(),
+		"script_file":                 types.StringNull(),
+		"script_file_args":            types.StringNull(),
+		"expand_token_in_script_file": types.BoolNull(),
+		"file_extension":              types.StringNull(),
+		"keep_going_on_success":       types.BoolNull(),
+		"script_interpreter":          types.ListNull(scriptInterpreterObjectType),
+		"job":                         types.ListValueMust(jobRefObjectType, []attr.Value{jobRef}),
+		"step_plugin":                 types.ListNull(stepPluginObjectType),
+		"node_step_plugin":            types.ListNull(stepPluginObjectType),
+	})
+	if diags.HasError() {
+		t.Fatalf("building error handler object: %v", diags)
+	}
+
+	cmd, diags := types.ObjectValue(commandObjectType.AttrTypes, map[string]attr.Value{
+		"description":                 types.StringNull(),
+		"shell_command":               types.StringNull(),
+		"inline_script":               types.StringNull(),
+		"script_url":                  types.StringNull(),
+		"script_file":                 types.StringNull(),
+		"script_file_args":            types.StringNull(),
+		"expand_token_in_script_file": types.BoolNull(),
+		"file_extension":              types.StringNull(),
+		"keep_going_on_success":       types.BoolNull(),
+		"plugins":                     types.ListNull(commandPluginsObjectType),
+		"script_interpreter":          types.ListNull(scriptInterpreterObjectType),
+		"job":                         types.ListValueMust(jobRefObjectType, []attr.Value{jobRef}),
+		"step_plugin":                 types.ListNull(stepPluginObjectType),
+		"node_step_plugin":            types.ListNull(stepPluginObjectType),
+		"error_handler":               types.ListValueMust(errorHandlerObjectType, []attr.Value{handler}),
+	})
+	if diags.HasError() {
+		t.Fatalf("building command object: %v", diags)
+	}
+
+	return types.ListValueMust(commandObjectType, []attr.Value{cmd})
+}
+
+// jobRefDispatchJSON digs out jobref.nodefilters.dispatch from a converted
+// command map, failing the test if any level is missing.
+func jobRefDispatchJSON(t *testing.T, jobref interface{}) map[string]interface{} {
+	t.Helper()
+
+	ref, ok := jobref.(map[string]interface{})
+	if !ok {
+		t.Fatalf("jobref is %T, want map", jobref)
+	}
+	nf, ok := ref["nodefilters"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("jobref.nodefilters is %T, want map", ref["nodefilters"])
+	}
+	disp, ok := nf["dispatch"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("jobref.nodefilters.dispatch is %T, want map", nf["dispatch"])
+	}
+	return disp
+}
+
+func TestConvertCommandsToJSON_nodeIntersect(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value bool
+	}{
+		{"true", true},
+		{"false", false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			commands := testCommandWithJobRefs(t,
+				testJobRefObject(t, testJobRefDispatchList(t, types.BoolValue(tc.value))))
+
+			result, diags := convertCommandsToJSON(context.Background(), commands)
+			if diags.HasError() {
+				t.Fatalf("convertCommandsToJSON: %v", diags)
+			}
+			if len(result) != 1 {
+				t.Fatalf("got %d commands, want 1", len(result))
+			}
+
+			cmd, ok := result[0].(map[string]interface{})
+			if !ok {
+				t.Fatalf("command is %T, want map", result[0])
+			}
+
+			// Direct job reference.
+			if got := jobRefDispatchJSON(t, cmd["jobref"])["nodeIntersect"]; got != tc.value {
+				t.Errorf("jobref dispatch nodeIntersect = %v, want %v", got, tc.value)
+			}
+
+			// Error handler job reference.
+			handler, ok := cmd["errorhandler"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("errorhandler is %T, want map", cmd["errorhandler"])
+			}
+			if got := jobRefDispatchJSON(t, handler["jobref"])["nodeIntersect"]; got != tc.value {
+				t.Errorf("error handler dispatch nodeIntersect = %v, want %v", got, tc.value)
+			}
+		})
+	}
+}
+
+func TestConvertCommandsToJSON_nodeIntersectOmittedWhenUnset(t *testing.T) {
+	commands := testCommandWithJobRefs(t,
+		testJobRefObject(t, testJobRefDispatchList(t, types.BoolNull())))
+
+	result, diags := convertCommandsToJSON(context.Background(), commands)
+	if diags.HasError() {
+		t.Fatalf("convertCommandsToJSON: %v", diags)
+	}
+
+	cmd := result[0].(map[string]interface{})
+	ref := cmd["jobref"].(map[string]interface{})
+	nf, ok := ref["nodefilters"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("jobref.nodefilters is %T, want map", ref["nodefilters"])
+	}
+	if _, exists := nf["dispatch"]; exists {
+		t.Errorf("dispatch = %v, want it omitted when no field is set", nf["dispatch"])
+	}
+}
+
+// dispatchStateAttrs digs node_filters[0].dispatch[0] out of a job reference
+// object read back from the API.
+func dispatchStateAttrs(t *testing.T, jobList attr.Value) map[string]attr.Value {
+	t.Helper()
+
+	jobs, ok := jobList.(types.List)
+	if !ok || jobs.IsNull() || len(jobs.Elements()) == 0 {
+		t.Fatalf("job reference list is %v, want one element", jobList)
+	}
+	jobAttrs := jobs.Elements()[0].(types.Object).Attributes()
+
+	nfList, ok := jobAttrs["node_filters"].(types.List)
+	if !ok || nfList.IsNull() || len(nfList.Elements()) == 0 {
+		t.Fatalf("node_filters is %v, want one element", jobAttrs["node_filters"])
+	}
+	nfAttrs := nfList.Elements()[0].(types.Object).Attributes()
+
+	dispList, ok := nfAttrs["dispatch"].(types.List)
+	if !ok || dispList.IsNull() || len(dispList.Elements()) == 0 {
+		t.Fatalf("dispatch is %v, want one element", nfAttrs["dispatch"])
+	}
+	return dispList.Elements()[0].(types.Object).Attributes()
+}
+
+// testJobRefCommandJSON mirrors what Rundeck emits for a job reference whose
+// only dispatch setting is nodeIntersect: nodefilters carries the dispatch map
+// and nothing else (JobExec.toMap).
+func testJobRefCommandJSON(dispatch map[string]interface{}) []interface{} {
+	jobref := map[string]interface{}{
+		"name":        "target-job",
+		"group":       "",
+		"nodefilters": map[string]interface{}{"dispatch": dispatch},
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"jobref":       jobref,
+			"errorhandler": map[string]interface{}{"jobref": jobref},
+		},
+	}
+}
+
+func TestConvertCommandsFromJSON_nodeIntersect(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value bool
+	}{
+		{"true", true},
+		{"false", false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			commands := testJobRefCommandJSON(map[string]interface{}{"nodeIntersect": tc.value})
+
+			result, diags := convertCommandsFromJSON(context.Background(), commands)
+			if diags.HasError() {
+				t.Fatalf("convertCommandsFromJSON: %v", diags)
+			}
+			if len(result.Elements()) != 1 {
+				t.Fatalf("got %d commands, want 1", len(result.Elements()))
+			}
+			cmdAttrs := result.Elements()[0].(types.Object).Attributes()
+
+			// Direct job reference.
+			ni := dispatchStateAttrs(t, cmdAttrs["job"])["node_intersect"].(types.Bool)
+			if ni.IsNull() || ni.ValueBool() != tc.value {
+				t.Errorf("jobref node_intersect = %v, want %v", ni, tc.value)
+			}
+
+			// Error handler job reference.
+			handlers, ok := cmdAttrs["error_handler"].(types.List)
+			if !ok || handlers.IsNull() || len(handlers.Elements()) == 0 {
+				t.Fatalf("error_handler is %v, want one element", cmdAttrs["error_handler"])
+			}
+			handlerAttrs := handlers.Elements()[0].(types.Object).Attributes()
+			ni = dispatchStateAttrs(t, handlerAttrs["job"])["node_intersect"].(types.Bool)
+			if ni.IsNull() || ni.ValueBool() != tc.value {
+				t.Errorf("error handler node_intersect = %v, want %v", ni, tc.value)
+			}
+		})
+	}
+}
+
+func TestConvertCommandsFromJSON_nodeIntersectAbsentStaysNull(t *testing.T) {
+	// A dispatch block carrying another field but no nodeIntersect: the flag
+	// must stay null rather than read back as an explicit false.
+	commands := testJobRefCommandJSON(map[string]interface{}{"keepgoing": true})
+
+	result, diags := convertCommandsFromJSON(context.Background(), commands)
+	if diags.HasError() {
+		t.Fatalf("convertCommandsFromJSON: %v", diags)
+	}
+	cmdAttrs := result.Elements()[0].(types.Object).Attributes()
+
+	if ni := dispatchStateAttrs(t, cmdAttrs["job"])["node_intersect"].(types.Bool); !ni.IsNull() {
+		t.Errorf("node_intersect = %v, want null when the API omits nodeIntersect", ni)
+	}
+}
+
+// TestAccJob_cmd_referred_job_nodeIntersect exercises node_intersect against a
+// live Rundeck, on a job reference with no node filter of its own (the shape
+// Rundeck emits as nodefilters carrying only dispatch.nodeIntersect) and on one
+// that also sets a filter, both directly under a command and under an error
+// handler. The second step asserts the setting round-trips with an empty plan.
+func TestAccJob_cmd_referred_job_nodeIntersect(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccJobCheckDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_cmd_referred_job_nodeIntersect,
+				Check: resource.ComposeTestCheckFunc(
+					// Reference carrying nothing but node_intersect.
+					resource.TestCheckResourceAttr("rundeck_job.caller",
+						"command.0.job.0.node_filters.0.dispatch.0.node_intersect", "true"),
+					// Same setting on an error handler reference.
+					resource.TestCheckResourceAttr("rundeck_job.caller",
+						"command.0.error_handler.0.job.0.node_filters.0.dispatch.0.node_intersect", "true"),
+					// Reference combining a filter with node_intersect.
+					resource.TestCheckResourceAttr("rundeck_job.caller",
+						"command.1.job.0.node_filters.0.filter", "name: tacobell"),
+					resource.TestCheckResourceAttr("rundeck_job.caller",
+						"command.1.job.0.node_filters.0.dispatch.0.node_intersect", "true"),
+				),
+			},
+			{
+				// Re-apply with the same config: this must produce an empty plan.
+				Config:   testAccJobConfig_cmd_referred_job_nodeIntersect,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+const testAccJobConfig_cmd_referred_job_nodeIntersect = `
+resource "rundeck_project" "test" {
+  name        = "terraform-acc-test-job-node-intersect"
+  description = "Test project for node_intersect on job references"
+  resource_model_source {
+    type = "file"
+    config = {
+      format = "resourceyaml"
+      file   = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+
+resource "rundeck_job" "target" {
+  project_name      = rundeck_project.test.name
+  name              = "target-job"
+  description       = "Job to be referenced"
+  execution_enabled = true
+  command {
+    shell_command = "echo 'I am the target job'"
+  }
+}
+
+resource "rundeck_job" "caller" {
+  project_name      = rundeck_project.test.name
+  name              = "caller-job"
+  description       = "Job referencing another job with node_intersect"
+  execution_enabled = true
+
+  command {
+    description = "call target on the intersection with this job's nodes"
+    job {
+      name         = rundeck_job.target.name
+      project_name = rundeck_project.test.name
+      node_filters {
+        dispatch {
+          node_intersect = true
+        }
+      }
+    }
+    error_handler {
+      job {
+        name         = rundeck_job.target.name
+        project_name = rundeck_project.test.name
+        node_filters {
+          dispatch {
+            node_intersect = true
+          }
+        }
+      }
+    }
+  }
+
+  command {
+    description = "call target with both a filter and node_intersect"
+    job {
+      name         = rundeck_job.target.name
+      project_name = rundeck_project.test.name
+      node_filters {
+        filter = "name: tacobell"
+        dispatch {
+          node_intersect = true
+        }
+      }
+    }
+  }
+}
+`

--- a/rundeck/resource_job_node_intersect_test.go
+++ b/rundeck/resource_job_node_intersect_test.go
@@ -208,6 +208,19 @@ func TestConvertCommandsToJSON_nodeIntersectOmittedWhenUnset(t *testing.T) {
 	if _, exists := nf["dispatch"]; exists {
 		t.Errorf("dispatch = %v, want it omitted when no field is set", nf["dispatch"])
 	}
+
+	// testCommandWithJobRefs sets up the identical job reference under
+	// error_handler.job too, but that path's write logic is NOT identical
+	// to the direct one above: unlike the direct path (which always emits
+	// nodefilters once the block is present in config, even empty - the
+	// case asserted above), the error_handler path only emits nodefilters
+	// when something inside it was actually set, and omits it entirely
+	// otherwise. So here nodefilters itself, not just dispatch, is absent.
+	handler := cmd["errorhandler"].(map[string]interface{})
+	handlerRef := handler["jobref"].(map[string]interface{})
+	if _, exists := handlerRef["nodefilters"]; exists {
+		t.Errorf("errorhandler.jobref.nodefilters = %v, want it omitted entirely when nothing is set", handlerRef["nodefilters"])
+	}
 }
 
 // dispatchStateAttrs digs node_filters[0].dispatch[0] out of a job reference

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -556,6 +556,22 @@ A command's `node_filters` block has the following structure:
 
 * `exclude_filter`: (Optional) The query string for nodes ***not to use***.
 
+* `dispatch`: (Optional) A block overriding how the referenced job dispatches over its nodes. See below for the structure.
+
+A `node_filters` `dispatch` block has the following structure:
+
+* `thread_count`: (Optional) Number of threads to use for parallel dispatch.
+
+* `keep_going`: (Optional) Whether to continue on the remaining nodes after a node fails.
+
+* `rank_attribute`: (Optional) The name of the node attribute used to order the sequence of nodes.
+
+* `rank_order`: (Optional) The order direction for node ranking, either `ascending` or `descending`.
+
+* `node_intersect`: (Optional) Whether to run the referenced job only on the intersection of its own
+  node set and the calling job's — Rundeck's "Match Node Filter Intersection". Unlike the other
+  `dispatch` settings, Rundeck honors this one even when no `filter` is set on the reference.
+
 A command's `plugins` block has the following structure:
 
 * `log_filter_plugin`: A log filter plugin to add to the command. Can be repeated to add multiple log filters. See below for the structure.


### PR DESCRIPTION
## Problem

A job reference can be configured to run only on the intersection of its own node set and the calling job's — Rundeck's "Match Node Filter Intersection". The provider has no equivalent, so the setting is dropped on write and never read back: the referenced job always runs on its own nodes.

There is no workaround at the configuration level. The dispatch fields the provider does expose (`thread_count`, `keep_going`, `rank_attribute`, `rank_order`) do not cover it, and a `node_filters` block carrying only this setting currently ends up entirely null — Rundeck stores nothing and returns the block absent, which fails the apply with `Provider produced inconsistent result after apply`.

## The mapping

The flag lives at `jobref.nodefilters.dispatch.nodeIntersect`, written and read by `JobExec.toMap` / `fromMap`.

It behaves differently from the other `dispatch` fields, and the difference shapes this change:

- `threadcount`, `keepgoing`, `rankAttribute` and `rankOrder` are read **only when the reference overrides the node filter** (`fromMap`, inside `if (exec.nodeFilter)`), and are only pushed into the execution context inside that same branch (`ExecutionService`, job-reference dispatch). They parametrize a dispatch over an overridden node set.
- `nodeIntersect` is not a dispatch parameter but a **node-set modifier**: it intersects the referenced job's own selector with the caller's nodes. That is meaningful with no filter override at all, so Rundeck reads it unconditionally and gives it a dedicated branch in both `fromMap` and the execution path (`else if (nodeIntersect)`).

Two consequences:

- A `nodefilters` block carrying nothing but `dispatch.nodeIntersect` is a shape **Rundeck itself emits** (`toMap`: `else if (null != nodeIntersect) → nodefilters = [dispatch: [nodeIntersect: ...]]`), so it is a valid one to send.
- When both a filter and the intersection are set, the effects combine: the intersection then applies to the overridden filter rather than to the referenced job's own.

## Changes

- `node_intersect` added to the `dispatch` block of a job reference's `node_filters`, in both places it exists (`command.job` and `command.error_handler.job`), plus the shared object type.
- Serialized to `nodeIntersect` on write, read back on refresh.
- An absent flag stays null in state rather than reading back as an explicit `false`, so an unconfigured `dispatch` block does not gain a value the configuration never asked for.
- The `dispatch` block itself was undocumented; this documents it along with the new attribute.

## Tests

Unit tests (no live Rundeck needed) covering both the command and error-handler paths:

- write: `true` and `false` both reach `jobref.nodefilters.dispatch.nodeIntersect`
- write: no `dispatch` is emitted when nothing in the block is set
- read: `true` and `false` round-trip into state
- read: an absent `nodeIntersect` leaves the attribute null

Plus an acceptance test exercising a reference with no filter of its own, one combining a filter with the intersection, and an error-handler reference — with a `PlanOnly` second step asserting an empty plan.

## Verified against a live Rundeck 6.0.1

Applied to a staging catalogue of **34 job references** — 26 carrying no filter of their own, 8 combining a filter with the intersection. All applied in place, **no resource recreated and no job UUID changed**, and the following plan reported `No changes`, confirming the round trip end to end.
