### PR TITLE
feat: add values_list_delimiter and notify_avg_duration_threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+**Enhancements**
+
+### Job Resource
+
+- **Added `values_list_delimiter` to job options** - Rundeck stores an option's predefined choices as a single delimited string plus the delimiter used to split it (`Option.toMap` always emits `valuesListDelimiter` alongside `values`, defaulting it to a comma). The provider had no way to set it, so a choice containing a comma could not be represented — the option silently split into the wrong values. Distinct from the existing `multi_value_delimiter`, which separates the values a user selects rather than the ones offered.
+
+- **Added `notify_avg_duration_threshold` to `rundeck_job`** - The threshold that decides when the `on_avg_duration` notification fires (a duration, a percentage of the job's average duration, or an increment over it). Without it Rundeck reads the threshold as zero and the guard `jobAverageDurationFinal > 0` never passes, so an `on_avg_duration` notification was configured but could never fire.
+
 ## 1.3.1
 
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 ## Unreleased
 
-**Enhancements**
+**Bug Fixes**
 
 ### Job Resource
 
-- **Added `values_list_delimiter` to job options** - Rundeck stores an option's predefined choices as a single delimited string plus the delimiter used to split it (`Option.toMap` always emits `valuesListDelimiter` alongside `values`, defaulting it to a comma). The provider had no way to set it, so a choice containing a comma could not be represented — the option silently split into the wrong values. Distinct from the existing `multi_value_delimiter`, which separates the values a user selects rather than the ones offered.
+- **Fixed updates being resolved by name instead of UUID, which created duplicate jobs** - On update the provider sent the job's UUID under `id`, but Rundeck writes a job's UUID out under both `uuid` and `id` (`ScheduledExecution.toMap`) while only reading it back from `uuid` (`fromMap`). The identifier therefore never reached the import, and Rundeck fell back to resolving the job by name + group + project — a fallback that only matches when *exactly one* job carries that name (`1 == schedlist.size()` in `loadImportedJobs`).
 
-- **Added `notify_avg_duration_threshold` to `rundeck_job`** - The threshold that decides when the `on_avg_duration` notification fires (a duration, a percentage of the job's average duration, or an increment over it). Without it Rundeck reads the threshold as zero and the guard `jobAverageDurationFinal > 0` never passes, so an `on_avg_duration` notification was configured but could never fire.
+  Two consequences. **Renaming a job created a second one** — `name` is not `RequiresReplace`, so a rename goes through Update, the new name matched nothing, and Rundeck created a job while the original stayed behind under its old name. And **two jobs sharing a name could never be updated**: every apply added another duplicate, which guaranteed the name would never resolve again. The fallback could also update the *wrong* job when an unrelated one happened to share the name.
+
+  In both cases the apply then fails with `Provider produced inconsistent result after apply`, since the id returned is the job that was just created rather than the one in state. The error is visible; what is silent is the damage left in Rundeck — the duplicate stays, and the original is no longer referenced by Terraform.
+
+  The update payload now carries `uuid`, so Rundeck takes its UUID-first resolution path and the job is targeted unambiguously. **Behaviour change:** renaming a job now renames it in place and succeeds, where it previously failed after creating a duplicate. Duplicates left behind by the previous behaviour are not cleaned up automatically — Terraform no longer references them, so they have to be removed from Rundeck by hand. `group_name` and `project_name` are unaffected: both carry `RequiresReplace`, so changing either already destroys and recreates the job.
+
+- **Fixed a plugin-based `error_handler` being silently discarded** - The schema accepts `step_plugin` and `node_step_plugin` under `error_handler`, and `errorHandlerObjectType` declares both, but neither conversion handled them: the write side emitted only `description`, the script/command fields and `jobref`, and the read side never looked for `type`/`configuration`. A handler such as `flow-control` therefore serialized to an object carrying no action at all. Rundeck accepted the job and dropped the handler, so the read-back returned no block and the apply failed with `error_handler: block count changed from 1 to 0`.
+
+  The plan being perfectly valid, this only ever surfaced at apply time — and the job was left in Rundeck without its handler, so a workflow meant to stop on a condition simply ran on. Both directions now carry `type`, `configuration` and `nodeStep`, the latter distinguishing a workflow step from a node step (Rundeck answers it as a bool or as the string `"true"`, both accepted).
+
+  Note that Rundeck itself refuses a workflow-step handler on a node-oriented workflow (*"Error Handlers for Node Steps must also be Node Steps"*), so a job guarded this way needs `strategy = "sequential"`.
+
 
 ## 1.3.1
 

--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -56,34 +56,35 @@ import (
 // - Used with custom HTTP client that explicitly requests application/json
 // - Matches Rundeck API v46+ JSON response format
 type JobJSON struct {
-	ID                     string                   `json:"id"`
-	Name                   string                   `json:"name"`
-	Group                  string                   `json:"group,omitempty"`
-	Project                string                   `json:"project"`
-	Description            string                   `json:"description"`
-	ExecutionEnabled       bool                     `json:"executionEnabled"`
-	ScheduleEnabled        bool                     `json:"scheduleEnabled"`
-	LogLevel               string                   `json:"loglevel,omitempty"`
-	AllowConcurrentExec    bool                     `json:"multipleExecutions,omitempty"`
-	MaxMultipleExecutions  string                   `json:"maxMultipleExecutions,omitempty"`
-	NodeFilterEditable     bool                     `json:"nodeFilterEditable"`
-	NodesSelectedByDefault bool                     `json:"nodesSelectedByDefault"`
-	DefaultTab             string                   `json:"defaultTab,omitempty"`
-	Timeout                string                   `json:"timeout,omitempty"`
-	Retry                  map[string]string        `json:"retry,omitempty"`
-	Options                []map[string]interface{} `json:"options,omitempty"`
-	Sequence               map[string]interface{}   `json:"sequence,omitempty"`
-	Notification           map[string]interface{}   `json:"notification,omitempty"`
-	NodeFilters            map[string]interface{}   `json:"nodefilters,omitempty"` // Contains "filter" and "dispatch" nested objects
-	Dispatch               map[string]interface{}   `json:"dispatch,omitempty"`
-	Schedule               map[string]interface{}   `json:"schedule,omitempty"`
-	Schedules              []map[string]interface{} `json:"schedules,omitempty"`
-	Orchestrator           map[string]interface{}   `json:"orchestrator,omitempty"`
-	Plugins                map[string]interface{}   `json:"plugins,omitempty"`
-	RunnerSelector         map[string]interface{}   `json:"runnerSelector,omitempty"`
-	LogLimit               *string                  `json:"loglimit,omitempty"`
-	LogLimitAction         *string                  `json:"loglimitAction,omitempty"`
-	LogLimitStatus         *string                  `json:"loglimitStatus,omitempty"`
+	ID                         string                   `json:"id"`
+	Name                       string                   `json:"name"`
+	Group                      string                   `json:"group,omitempty"`
+	Project                    string                   `json:"project"`
+	Description                string                   `json:"description"`
+	ExecutionEnabled           bool                     `json:"executionEnabled"`
+	ScheduleEnabled            bool                     `json:"scheduleEnabled"`
+	LogLevel                   string                   `json:"loglevel,omitempty"`
+	AllowConcurrentExec        bool                     `json:"multipleExecutions,omitempty"`
+	MaxMultipleExecutions      string                   `json:"maxMultipleExecutions,omitempty"`
+	NodeFilterEditable         bool                     `json:"nodeFilterEditable"`
+	NodesSelectedByDefault     bool                     `json:"nodesSelectedByDefault"`
+	DefaultTab                 string                   `json:"defaultTab,omitempty"`
+	Timeout                    string                   `json:"timeout,omitempty"`
+	NotifyAvgDurationThreshold string                   `json:"notifyAvgDurationThreshold,omitempty"`
+	Retry                      map[string]string        `json:"retry,omitempty"`
+	Options                    []map[string]interface{} `json:"options,omitempty"`
+	Sequence                   map[string]interface{}   `json:"sequence,omitempty"`
+	Notification               map[string]interface{}   `json:"notification,omitempty"`
+	NodeFilters                map[string]interface{}   `json:"nodefilters,omitempty"` // Contains "filter" and "dispatch" nested objects
+	Dispatch                   map[string]interface{}   `json:"dispatch,omitempty"`
+	Schedule                   map[string]interface{}   `json:"schedule,omitempty"`
+	Schedules                  []map[string]interface{} `json:"schedules,omitempty"`
+	Orchestrator               map[string]interface{}   `json:"orchestrator,omitempty"`
+	Plugins                    map[string]interface{}   `json:"plugins,omitempty"`
+	RunnerSelector             map[string]interface{}   `json:"runnerSelector,omitempty"`
+	LogLimit                   *string                  `json:"loglimit,omitempty"`
+	LogLimitAction             *string                  `json:"loglimitAction,omitempty"`
+	LogLimitStatus             *string                  `json:"loglimitStatus,omitempty"`
 }
 
 // GetJobJSON returns the job details from the Rundeck API.

--- a/rundeck/resource_job_command_schema.go
+++ b/rundeck/resource_job_command_schema.go
@@ -436,6 +436,15 @@ func jobOptionNestedBlock() schema.ListNestedBlock {
 					Optional:    true,
 					ElementType: types.StringType,
 				},
+				// Computed as well as Optional: Rundeck always returns this field
+				// once an option has values, defaulting it to a comma. Leaving it
+				// Optional-only would make an unset delimiter read back as ","
+				// and fail the apply with an inconsistent result.
+				"values_list_delimiter": schema.StringAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Separator used to join the value_choices into the option's values list (Rundeck defaults to a comma). Set it when a choice itself contains the default separator. Distinct from multi_value_delimiter, which separates the values a user selects.",
+				},
 				"value_choices_url": schema.StringAttribute{
 					Optional: true,
 				},

--- a/rundeck/resource_job_command_schema.go
+++ b/rundeck/resource_job_command_schema.go
@@ -439,11 +439,17 @@ func jobOptionNestedBlock() schema.ListNestedBlock {
 				// Computed as well as Optional: Rundeck always returns this field
 				// once an option has values, defaulting it to a comma. Leaving it
 				// Optional-only would make an unset delimiter read back as ","
-				// and fail the apply with an inconsistent result.
+				// and fail the apply with an inconsistent result. UseStateForUnknown
+				// keeps an unconfigured delimiter from planning as "(known after
+				// apply)" on every subsequent plan, matching run_for_each_node/
+				// node_step, the other Optional+Computed attributes on this path.
 				"values_list_delimiter": schema.StringAttribute{
 					Optional:    true,
 					Computed:    true,
 					Description: "Separator used to join the value_choices into the option's values list (Rundeck defaults to a comma). Set it when a choice itself contains the default separator. Distinct from multi_value_delimiter, which separates the values a user selects.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"value_choices_url": schema.StringAttribute{
 					Optional: true,

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -477,6 +477,9 @@ func convertOptionsToJSON(ctx context.Context, optionsList types.List) ([]interf
 		if v, ok := attrs["multi_value_delimiter"].(types.String); ok && !v.IsNull() {
 			optMap["delimiter"] = v.ValueString()
 		}
+		if v, ok := attrs["values_list_delimiter"].(types.String); ok && !v.IsNull() {
+			optMap["valuesListDelimiter"] = v.ValueString()
+		}
 		if v, ok := attrs["storage_path"].(types.String); ok && !v.IsNull() {
 			optMap["storagePath"] = v.ValueString()
 		}
@@ -1561,6 +1564,11 @@ func convertOptionsFromJSON(ctx context.Context, optionsArray []interface{}) (ty
 			optAttrs["multi_value_delimiter"] = types.StringValue(delimiter)
 		}
 
+		optAttrs["values_list_delimiter"] = types.StringNull()
+		if valuesListDelimiter, ok := optMap["valuesListDelimiter"].(string); ok {
+			optAttrs["values_list_delimiter"] = types.StringValue(valuesListDelimiter)
+		}
+
 		// API field is "secure" not "obscureInput"
 		if secure, ok := optMap["secure"].(bool); ok {
 			optAttrs["obscure_input"] = types.BoolValue(secure)
@@ -1658,6 +1666,7 @@ func convertOptionsFromJSON(ctx context.Context, optionsArray []interface{}) (ty
 				"required":                  types.BoolType,
 				"allow_multiple_values":     types.BoolType,
 				"multi_value_delimiter":     types.StringType,
+				"values_list_delimiter":     types.StringType,
 				"require_predefined_choice": types.BoolType,
 				"validation_regex":          types.StringType,
 				"obscure_input":             types.BoolType,
@@ -1691,6 +1700,7 @@ func convertOptionsFromJSON(ctx context.Context, optionsArray []interface{}) (ty
 				"required":                  types.BoolType,
 				"allow_multiple_values":     types.BoolType,
 				"multi_value_delimiter":     types.StringType,
+				"values_list_delimiter":     types.StringType,
 				"require_predefined_choice": types.BoolType,
 				"validation_regex":          types.StringType,
 				"obscure_input":             types.BoolType,

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -477,7 +477,11 @@ func convertOptionsToJSON(ctx context.Context, optionsList types.List) ([]interf
 		if v, ok := attrs["multi_value_delimiter"].(types.String); ok && !v.IsNull() {
 			optMap["delimiter"] = v.ValueString()
 		}
-		if v, ok := attrs["values_list_delimiter"].(types.String); ok && !v.IsNull() {
+		// Unknown as well as null: the attribute is Optional+Computed, so an
+		// option that does not configure it carries an unknown value at plan
+		// time. Serializing that would send an empty delimiter and overwrite
+		// the one Rundeck maintains.
+		if v, ok := attrs["values_list_delimiter"].(types.String); ok && !v.IsNull() && !v.IsUnknown() {
 			optMap["valuesListDelimiter"] = v.ValueString()
 		}
 		if v, ok := attrs["storage_path"].(types.String); ok && !v.IsNull() {

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -525,7 +525,14 @@ func convertOptionsToJSON(ctx context.Context, optionsList types.List) ([]interf
 		if v, ok := attrs["value_choices_url"].(types.String); ok && !v.IsNull() {
 			optMap["valuesUrl"] = v.ValueString()
 		}
-		if v, ok := attrs["multi_value_delimiter"].(types.String); ok && !v.IsNull() {
+		// Unknown as well as null: although multi_value_delimiter is
+		// Optional-only (not Computed), its value can still be unknown at
+		// plan time if it's set from an expression not yet known (e.g. an
+		// attribute of a resource not yet applied). Serializing that would
+		// send an empty delimiter via ValueString() and overwrite the one
+		// Rundeck maintains, exactly like the values_list_delimiter case
+		// below.
+		if v, ok := attrs["multi_value_delimiter"].(types.String); ok && !v.IsNull() && !v.IsUnknown() {
 			optMap["delimiter"] = v.ValueString()
 		}
 		// Unknown as well as null: the attribute is Optional+Computed, so an

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -1269,8 +1269,14 @@ func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *j
 	if job.Timeout != "" {
 		state.Timeout = types.StringValue(job.Timeout)
 	}
+	// Unlike Timeout/TimeZone just above (a pre-existing gap left alone
+	// here), explicitly clear this when the API stops returning it, so a
+	// threshold removed outside Terraform (e.g. via the UI) surfaces as
+	// drift on refresh instead of leaving state stuck on its last value.
 	if job.NotifyAvgDurationThreshold != "" {
 		state.NotifyAvgDurationThreshold = types.StringValue(job.NotifyAvgDurationThreshold)
+	} else {
+		state.NotifyAvgDurationThreshold = types.StringNull()
 	}
 	if job.TimeZone != "" {
 		state.TimeZone = types.StringValue(job.TimeZone)
@@ -1436,8 +1442,14 @@ func (r *jobResource) jobJSONAPIToState(ctx context.Context, job *JobJSON, state
 	if job.Timeout != "" {
 		state.Timeout = types.StringValue(job.Timeout)
 	}
+	// Unlike Timeout just above (a pre-existing gap left alone here),
+	// explicitly clear this when the API stops returning it, so a
+	// threshold removed outside Terraform (e.g. via the UI) surfaces as
+	// drift on refresh instead of leaving state stuck on its last value.
 	if job.NotifyAvgDurationThreshold != "" {
 		state.NotifyAvgDurationThreshold = types.StringValue(job.NotifyAvgDurationThreshold)
+	} else {
+		state.NotifyAvgDurationThreshold = types.StringNull()
 	}
 
 	// Handle retry

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -59,6 +59,7 @@ type jobResourceModel struct {
 	RunnerSelectorFilterMode    types.String `tfsdk:"runner_selector_filter_mode"`
 	RunnerSelectorFilterType    types.String `tfsdk:"runner_selector_filter_type"`
 	Timeout                     types.String `tfsdk:"timeout"`
+	NotifyAvgDurationThreshold  types.String `tfsdk:"notify_avg_duration_threshold"`
 	Schedule                    types.String `tfsdk:"schedule"`
 	ScheduleEnabled             types.Bool   `tfsdk:"schedule_enabled"`
 	NodesSelectedByDefault      types.Bool   `tfsdk:"nodes_selected_by_default"`
@@ -77,35 +78,36 @@ type jobResourceModel struct {
 
 // jobJSON represents the Rundeck Job JSON format (v44+)
 type jobJSON struct {
-	ID                     string             `json:"id,omitempty"`
-	Name                   string             `json:"name"`
-	Group                  string             `json:"group,omitempty"`
-	Project                string             `json:"project"`
-	Description            string             `json:"description"`
-	ExecutionEnabled       bool               `json:"executionEnabled"`
-	DefaultTab             string             `json:"defaultTab,omitempty"`
-	LogLevel               string             `json:"loglevel,omitempty"`
-	Loglimit               *string            `json:"loglimit,omitempty"`
-	LogLimitAction         *string            `json:"loglimitAction,omitempty"`
-	LogLimitStatus         *string            `json:"loglimitStatus,omitempty"`
-	MultipleExecutions     bool               `json:"multipleExecutions,omitempty"`
-	MaxMultipleExecutions  string             `json:"maxMultipleExecutions,omitempty"`
-	Sequence               *jobSequence       `json:"sequence,omitempty"`
-	Notification           interface{}        `json:"notification,omitempty"`
-	Timeout                string             `json:"timeout,omitempty"`
-	Retry                  *jobRetry          `json:"retry,omitempty"`
-	NodeFilterEditable     bool               `json:"nodeFilterEditable"`
-	NodeFilters            *jobNodeFilters    `json:"nodefilters,omitempty"`
-	Options                []interface{}      `json:"options,omitempty"`
-	Plugins                interface{}        `json:"plugins,omitempty"`
-	NodesSelectedByDefault bool               `json:"nodesSelectedByDefault"`
-	Schedule               interface{}        `json:"schedule,omitempty"`
-	Schedules              []interface{}      `json:"schedules,omitempty"`
-	ScheduleEnabled        bool               `json:"scheduleEnabled"`
-	TimeZone               string             `json:"timeZone,omitempty"`
-	Orchestrator           interface{}        `json:"orchestrator,omitempty"`
-	PluginConfig           interface{}        `json:"pluginConfig,omitempty"`
-	RunnerSelector         *jobRunnerSelector `json:"runnerSelector,omitempty"`
+	ID                         string             `json:"id,omitempty"`
+	Name                       string             `json:"name"`
+	Group                      string             `json:"group,omitempty"`
+	Project                    string             `json:"project"`
+	Description                string             `json:"description"`
+	ExecutionEnabled           bool               `json:"executionEnabled"`
+	DefaultTab                 string             `json:"defaultTab,omitempty"`
+	LogLevel                   string             `json:"loglevel,omitempty"`
+	Loglimit                   *string            `json:"loglimit,omitempty"`
+	LogLimitAction             *string            `json:"loglimitAction,omitempty"`
+	LogLimitStatus             *string            `json:"loglimitStatus,omitempty"`
+	MultipleExecutions         bool               `json:"multipleExecutions,omitempty"`
+	MaxMultipleExecutions      string             `json:"maxMultipleExecutions,omitempty"`
+	Sequence                   *jobSequence       `json:"sequence,omitempty"`
+	Notification               interface{}        `json:"notification,omitempty"`
+	Timeout                    string             `json:"timeout,omitempty"`
+	NotifyAvgDurationThreshold string             `json:"notifyAvgDurationThreshold,omitempty"`
+	Retry                      *jobRetry          `json:"retry,omitempty"`
+	NodeFilterEditable         bool               `json:"nodeFilterEditable"`
+	NodeFilters                *jobNodeFilters    `json:"nodefilters,omitempty"`
+	Options                    []interface{}      `json:"options,omitempty"`
+	Plugins                    interface{}        `json:"plugins,omitempty"`
+	NodesSelectedByDefault     bool               `json:"nodesSelectedByDefault"`
+	Schedule                   interface{}        `json:"schedule,omitempty"`
+	Schedules                  []interface{}      `json:"schedules,omitempty"`
+	ScheduleEnabled            bool               `json:"scheduleEnabled"`
+	TimeZone                   string             `json:"timeZone,omitempty"`
+	Orchestrator               interface{}        `json:"orchestrator,omitempty"`
+	PluginConfig               interface{}        `json:"pluginConfig,omitempty"`
+	RunnerSelector             *jobRunnerSelector `json:"runnerSelector,omitempty"`
 }
 
 type jobDispatch struct {
@@ -280,6 +282,10 @@ func (r *jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"timeout": schema.StringAttribute{
 				Optional: true,
+			},
+			"notify_avg_duration_threshold": schema.StringAttribute{
+				Optional:    true,
+				Description: "How long an execution may run before the on_avg_duration notification fires. Accepts a duration (\"2h\", \"30m\"), a percentage of the job's average duration (\"150%\"), or an increment over it (\"+5m\"). Without it Rundeck treats the threshold as zero and the notification never fires.",
 			},
 			"schedule": schema.StringAttribute{
 				Optional: true,
@@ -1026,6 +1032,9 @@ func (r *jobResource) planToJobJSON(ctx context.Context, plan *jobResourceModel)
 		job.MaxMultipleExecutions = fmt.Sprintf("%d", plan.MaxConcurrentExecutions.ValueInt64())
 	}
 
+	if !plan.NotifyAvgDurationThreshold.IsNull() && !plan.NotifyAvgDurationThreshold.IsUnknown() {
+		job.NotifyAvgDurationThreshold = plan.NotifyAvgDurationThreshold.ValueString()
+	}
 	if !plan.Timeout.IsNull() && !plan.Timeout.IsUnknown() {
 		job.Timeout = plan.Timeout.ValueString()
 	}
@@ -1250,6 +1259,9 @@ func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *j
 	if job.Timeout != "" {
 		state.Timeout = types.StringValue(job.Timeout)
 	}
+	if job.NotifyAvgDurationThreshold != "" {
+		state.NotifyAvgDurationThreshold = types.StringValue(job.NotifyAvgDurationThreshold)
+	}
 	if job.TimeZone != "" {
 		state.TimeZone = types.StringValue(job.TimeZone)
 	}
@@ -1413,6 +1425,9 @@ func (r *jobResource) jobJSONAPIToState(ctx context.Context, job *JobJSON, state
 
 	if job.Timeout != "" {
 		state.Timeout = types.StringValue(job.Timeout)
+	}
+	if job.NotifyAvgDurationThreshold != "" {
+		state.NotifyAvgDurationThreshold = types.StringValue(job.NotifyAvgDurationThreshold)
 	}
 
 	// Handle retry

--- a/rundeck/resource_job_option_delimiter_test.go
+++ b/rundeck/resource_job_option_delimiter_test.go
@@ -116,6 +116,28 @@ func TestConvertOptionsToJSON_valuesListDelimiterOmittedWhenUnset(t *testing.T) 
 	}
 }
 
+// values_list_delimiter is Optional+Computed, so an option that does not
+// configure it arrives unknown rather than null at plan time. Serializing that
+// would send an empty delimiter and overwrite the one Rundeck maintains.
+func TestConvertOptionsToJSON_valuesListDelimiterOmittedWhenUnknown(t *testing.T) {
+	opt, diags := types.ObjectValue(testOptionObjectType.AttrTypes,
+		testOptionAttrs(types.StringUnknown()))
+	if diags.HasError() {
+		t.Fatalf("building option object: %v", diags)
+	}
+
+	result, diags := convertOptionsToJSON(context.Background(),
+		types.ListValueMust(testOptionObjectType, []attr.Value{opt}))
+	if diags.HasError() {
+		t.Fatalf("convertOptionsToJSON: %v", diags)
+	}
+
+	optMap := result[0].(map[string]interface{})
+	if v, exists := optMap["valuesListDelimiter"]; exists {
+		t.Errorf("valuesListDelimiter = %q, want it omitted when unknown", v)
+	}
+}
+
 func TestConvertOptionsFromJSON_valuesListDelimiter(t *testing.T) {
 	options := []interface{}{
 		map[string]interface{}{

--- a/rundeck/resource_job_option_delimiter_test.go
+++ b/rundeck/resource_job_option_delimiter_test.go
@@ -138,6 +138,30 @@ func TestConvertOptionsToJSON_valuesListDelimiterOmittedWhenUnknown(t *testing.T
 	}
 }
 
+// multi_value_delimiter is Optional-only, but its value can still be unknown
+// at plan time (e.g. set from an attribute of a resource not yet applied).
+// Serializing that via ValueString() would send an empty delimiter and
+// overwrite the one Rundeck maintains, same as values_list_delimiter above.
+func TestConvertOptionsToJSON_multiValueDelimiterOmittedWhenUnknown(t *testing.T) {
+	attrs := testOptionAttrs(types.StringNull())
+	attrs["multi_value_delimiter"] = types.StringUnknown()
+	opt, diags := types.ObjectValue(testOptionObjectType.AttrTypes, attrs)
+	if diags.HasError() {
+		t.Fatalf("building option object: %v", diags)
+	}
+
+	result, diags := convertOptionsToJSON(context.Background(),
+		types.ListValueMust(testOptionObjectType, []attr.Value{opt}))
+	if diags.HasError() {
+		t.Fatalf("convertOptionsToJSON: %v", diags)
+	}
+
+	optMap := result[0].(map[string]interface{})
+	if v, exists := optMap["delimiter"]; exists {
+		t.Errorf("delimiter = %q, want it omitted when unknown", v)
+	}
+}
+
 func TestConvertOptionsFromJSON_valuesListDelimiter(t *testing.T) {
 	options := []interface{}{
 		map[string]interface{}{
@@ -230,5 +254,36 @@ func TestJobJSONAPIToState_notifyAvgDurationThreshold(t *testing.T) {
 	if state.NotifyAvgDurationThreshold.ValueString() != "150%" {
 		t.Errorf("notify_avg_duration_threshold = %v, want %q",
 			state.NotifyAvgDurationThreshold, "150%")
+	}
+}
+
+// If the threshold is cleared on the Rundeck side (e.g. via the UI) between
+// applies, the API stops returning it and refresh must reflect that as
+// drift - not silently keep whatever was last in state.
+func TestJobJSONToState_notifyAvgDurationThresholdClearedRemotely(t *testing.T) {
+	r := &jobResource{}
+	job := &jobJSON{} // NotifyAvgDurationThreshold unset, as the API now returns it
+
+	state := &jobResourceModel{NotifyAvgDurationThreshold: types.StringValue("30m")}
+	if err := r.jobJSONToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONToState: %v", err)
+	}
+	if !state.NotifyAvgDurationThreshold.IsNull() {
+		t.Errorf("notify_avg_duration_threshold = %v, want null after being cleared remotely",
+			state.NotifyAvgDurationThreshold)
+	}
+}
+
+func TestJobJSONAPIToState_notifyAvgDurationThresholdClearedRemotely(t *testing.T) {
+	r := &jobResource{}
+	job := &JobJSON{} // NotifyAvgDurationThreshold unset, as the API now returns it
+
+	state := &jobResourceModel{NotifyAvgDurationThreshold: types.StringValue("150%")}
+	if err := r.jobJSONAPIToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONAPIToState: %v", err)
+	}
+	if !state.NotifyAvgDurationThreshold.IsNull() {
+		t.Errorf("notify_avg_duration_threshold = %v, want null after being cleared remotely",
+			state.NotifyAvgDurationThreshold)
 	}
 }

--- a/rundeck/resource_job_option_delimiter_test.go
+++ b/rundeck/resource_job_option_delimiter_test.go
@@ -1,0 +1,212 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Plain unit tests (no TF_ACC / live Rundeck required) for two settings the
+// provider could not express:
+//
+//   - an option's values_list_delimiter, the separator Rundeck uses to join the
+//     value choices into the option's values list (Option.toMap: `map.values`
+//     is always accompanied by `map.valuesListDelimiter`, defaulted to a
+//     comma). Without it, a choice containing a comma cannot be represented.
+//   - a job's notify_avg_duration_threshold, which decides when the
+//     on_avg_duration notification fires. ExecutionJob reads it as `?: "0"` and
+//     guards the notification with `jobAverageDurationFinal > 0`, so without a
+//     threshold the notification is configured but never fires.
+
+// testOptionObjectType mirrors the option object built by
+// convertOptionsFromJSON.
+var testOptionObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"name":                      types.StringType,
+		"default_value":             types.StringType,
+		"description":               types.StringType,
+		"label":                     types.StringType,
+		"value_choices":             types.ListType{ElemType: types.StringType},
+		"value_choices_url":         types.StringType,
+		"required":                  types.BoolType,
+		"allow_multiple_values":     types.BoolType,
+		"multi_value_delimiter":     types.StringType,
+		"values_list_delimiter":     types.StringType,
+		"require_predefined_choice": types.BoolType,
+		"validation_regex":          types.StringType,
+		"obscure_input":             types.BoolType,
+		"storage_path":              types.StringType,
+		"type":                      types.StringType,
+		"is_date":                   types.BoolType,
+		"exposed_to_scripts":        types.BoolType,
+		"hidden":                    types.BoolType,
+		"sort_values":               types.BoolType,
+		"date_format":               types.StringType,
+	},
+}
+
+// testOptionAttrs builds the full attribute set of an option, with only the
+// name and the delimiter under test populated.
+func testOptionAttrs(delimiter attr.Value) map[string]attr.Value {
+	return map[string]attr.Value{
+		"name":                      types.StringValue("environment"),
+		"default_value":             types.StringNull(),
+		"description":               types.StringNull(),
+		"label":                     types.StringNull(),
+		"value_choices":             types.ListNull(types.StringType),
+		"value_choices_url":         types.StringNull(),
+		"required":                  types.BoolNull(),
+		"allow_multiple_values":     types.BoolNull(),
+		"multi_value_delimiter":     types.StringNull(),
+		"values_list_delimiter":     delimiter,
+		"require_predefined_choice": types.BoolNull(),
+		"validation_regex":          types.StringNull(),
+		"obscure_input":             types.BoolNull(),
+		"storage_path":              types.StringNull(),
+		"type":                      types.StringNull(),
+		"is_date":                   types.BoolNull(),
+		"exposed_to_scripts":        types.BoolNull(),
+		"hidden":                    types.BoolNull(),
+		"sort_values":               types.BoolNull(),
+		"date_format":               types.StringNull(),
+	}
+}
+
+func TestConvertOptionsToJSON_valuesListDelimiter(t *testing.T) {
+	opt, diags := types.ObjectValue(testOptionObjectType.AttrTypes, testOptionAttrs(types.StringValue(" ")))
+	if diags.HasError() {
+		t.Fatalf("building option object: %v", diags)
+	}
+
+	result, diags := convertOptionsToJSON(context.Background(),
+		types.ListValueMust(testOptionObjectType, []attr.Value{opt}))
+	if diags.HasError() {
+		t.Fatalf("convertOptionsToJSON: %v", diags)
+	}
+	if len(result) != 1 {
+		t.Fatalf("got %d options, want 1", len(result))
+	}
+
+	optMap, ok := result[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("option is %T, want map", result[0])
+	}
+	if got := optMap["valuesListDelimiter"]; got != " " {
+		t.Errorf("valuesListDelimiter = %q, want %q", got, " ")
+	}
+}
+
+func TestConvertOptionsToJSON_valuesListDelimiterOmittedWhenUnset(t *testing.T) {
+	opt, diags := types.ObjectValue(testOptionObjectType.AttrTypes, testOptionAttrs(types.StringNull()))
+	if diags.HasError() {
+		t.Fatalf("building option object: %v", diags)
+	}
+
+	result, diags := convertOptionsToJSON(context.Background(),
+		types.ListValueMust(testOptionObjectType, []attr.Value{opt}))
+	if diags.HasError() {
+		t.Fatalf("convertOptionsToJSON: %v", diags)
+	}
+
+	optMap := result[0].(map[string]interface{})
+	if v, exists := optMap["valuesListDelimiter"]; exists {
+		t.Errorf("valuesListDelimiter = %v, want it omitted when unset", v)
+	}
+}
+
+func TestConvertOptionsFromJSON_valuesListDelimiter(t *testing.T) {
+	options := []interface{}{
+		map[string]interface{}{
+			"name":                "environment",
+			"values":              []interface{}{"eu west", "us east"},
+			"valuesListDelimiter": " ",
+		},
+	}
+
+	result, diags := convertOptionsFromJSON(context.Background(), options)
+	if diags.HasError() {
+		t.Fatalf("convertOptionsFromJSON: %v", diags)
+	}
+	if len(result.Elements()) != 1 {
+		t.Fatalf("got %d options, want 1", len(result.Elements()))
+	}
+
+	attrs := result.Elements()[0].(types.Object).Attributes()
+	got, ok := attrs["values_list_delimiter"].(types.String)
+	if !ok {
+		t.Fatalf("values_list_delimiter is %T, want types.String", attrs["values_list_delimiter"])
+	}
+	if got.IsNull() || got.ValueString() != " " {
+		t.Errorf("values_list_delimiter = %v, want %q", got, " ")
+	}
+}
+
+func TestPlanToJobJSON_notifyAvgDurationThreshold(t *testing.T) {
+	r := &jobResource{}
+	plan := &jobResourceModel{
+		Name:                       types.StringValue("test-job"),
+		ProjectName:                types.StringValue("test-project"),
+		Description:                types.StringValue("desc"),
+		Command:                    testSingleShellCommandList(t),
+		NotifyAvgDurationThreshold: types.StringValue("2h"),
+	}
+
+	job, err := r.planToJobJSON(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("planToJobJSON: %v", err)
+	}
+	if job.NotifyAvgDurationThreshold != "2h" {
+		t.Errorf("notifyAvgDurationThreshold = %q, want %q", job.NotifyAvgDurationThreshold, "2h")
+	}
+}
+
+func TestPlanToJobJSON_notifyAvgDurationThresholdOmittedWhenUnset(t *testing.T) {
+	r := &jobResource{}
+	plan := &jobResourceModel{
+		Name:                       types.StringValue("test-job"),
+		ProjectName:                types.StringValue("test-project"),
+		Description:                types.StringValue("desc"),
+		Command:                    testSingleShellCommandList(t),
+		NotifyAvgDurationThreshold: types.StringNull(),
+	}
+
+	job, err := r.planToJobJSON(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("planToJobJSON: %v", err)
+	}
+	// Empty means the field carries `omitempty` and never reaches the API,
+	// leaving Rundeck's own default in place.
+	if job.NotifyAvgDurationThreshold != "" {
+		t.Errorf("notifyAvgDurationThreshold = %q, want empty", job.NotifyAvgDurationThreshold)
+	}
+}
+
+func TestJobJSONToState_notifyAvgDurationThreshold(t *testing.T) {
+	r := &jobResource{}
+	job := &jobJSON{NotifyAvgDurationThreshold: "30m"}
+
+	state := &jobResourceModel{}
+	if err := r.jobJSONToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONToState: %v", err)
+	}
+	if state.NotifyAvgDurationThreshold.ValueString() != "30m" {
+		t.Errorf("notify_avg_duration_threshold = %v, want %q",
+			state.NotifyAvgDurationThreshold, "30m")
+	}
+}
+
+func TestJobJSONAPIToState_notifyAvgDurationThreshold(t *testing.T) {
+	r := &jobResource{}
+	job := &JobJSON{NotifyAvgDurationThreshold: "150%"}
+
+	state := &jobResourceModel{}
+	if err := r.jobJSONAPIToState(context.Background(), job, state); err != nil {
+		t.Fatalf("jobJSONAPIToState: %v", err)
+	}
+	if state.NotifyAvgDurationThreshold.ValueString() != "150%" {
+		t.Errorf("notify_avg_duration_threshold = %v, want %q",
+			state.NotifyAvgDurationThreshold, "150%")
+	}
+}

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -357,6 +357,97 @@ func TestAccJobOptions_value_choices_from_variable(t *testing.T) {
 	})
 }
 
+// TestAccJobOptions_valuesListDelimiterAndNotifyThreshold covers two
+// previously-unexpressible settings against a real server:
+//   - values_list_delimiter, left unconfigured on one option (the exact
+//     scenario that regressed without UseStateForUnknown: an Optional+
+//     Computed attribute the framework would otherwise replan as unknown
+//     on every subsequent plan, not just the first one) and explicitly set
+//     on another.
+//   - notify_avg_duration_threshold at the job level.
+//
+// The RefreshState/PlanOnly step is the actual regression check: it fails
+// if either attribute shows up as a diff with nothing in config having
+// changed.
+func TestAccJobOptions_valuesListDelimiterAndNotifyThreshold(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobOptions_valuesListDelimiterAndNotifyThreshold,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rundeck_job.test", "name", "delimiter-and-threshold-job"),
+					resource.TestCheckResourceAttr("rundeck_job.test", "notify_avg_duration_threshold", "30m"),
+					resource.TestCheckResourceAttr("rundeck_job.test", "option.0.name", "default_delimiter"),
+					resource.TestCheckResourceAttr("rundeck_job.test", "option.0.values_list_delimiter", ","),
+					resource.TestCheckResourceAttr("rundeck_job.test", "option.1.name", "custom_delimiter"),
+					resource.TestCheckResourceAttr("rundeck_job.test", "option.1.values_list_delimiter", ";"),
+				),
+			},
+			// Core regression check: no diff on refresh with nothing in
+			// config changed. Without UseStateForUnknown on
+			// values_list_delimiter, option.0's unconfigured delimiter
+			// would show up here as "(known after apply)" every time.
+			{
+				RefreshState: true,
+				PlanOnly:     true,
+			},
+		},
+	})
+}
+
+const testAccJobOptions_valuesListDelimiterAndNotifyThreshold = `
+resource "rundeck_project" "test" {
+  name        = "terraform-acc-test-delimiter-threshold"
+  description = "parent project for job acceptance tests"
+
+  resource_model_source {
+    type = "file"
+    config = {
+        format = "resourceyaml"
+        file = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+
+resource "rundeck_job" "test" {
+  project_name                  = rundeck_project.test.name
+  name                           = "delimiter-and-threshold-job"
+  description                    = "A job exercising values_list_delimiter and notify_avg_duration_threshold"
+  notify_avg_duration_threshold  = "30m"
+
+  option {
+    name                   = "default_delimiter"
+    value_choices          = ["a", "b", "c"]
+  }
+
+  # values_list_delimiter's actual purpose: switch away from the default
+  # comma when a choice value itself needs to contain one. Using ";" here
+  # lets "a,b" survive as a single choice instead of being split on comma.
+  option {
+    name                   = "custom_delimiter"
+    value_choices          = ["a,b", "c"]
+    values_list_delimiter  = ";"
+  }
+
+  command {
+    description   = "Prints Hello World"
+    shell_command = "echo Hello World"
+  }
+
+  # notify_avg_duration_threshold is inert without this: confirmed against
+  # a live server, Rundeck doesn't even persist the threshold unless an
+  # on_avg_duration notification actually exists on the job.
+  notification {
+    type = "on_avg_duration"
+    email {
+      recipients = ["test@example.com"]
+    }
+  }
+}
+`
+
 func TestAccJob_plugins(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -308,6 +308,12 @@ The following arguments are supported:
 
 * `timeout` - (Optional) The maximum time for an execution to run. Time in seconds, or specify time units: "120m", "2h", "3d". Use blank or 0 to indicate no timeout.
 
+* `notify_avg_duration_threshold` - (Optional) How long an execution may run before the
+  `on_avg_duration` notification fires. Accepts a duration ("2h", "30m"), a percentage of the job's
+  average duration ("150%"), or an increment over it ("+5m"). Rundeck treats a missing threshold as
+  zero and never fires the notification, so an `on_avg_duration` notification without this attribute
+  is configured but inert.
+
 * `schedule` - (Optional) The job's schedule in Quartz schedule cron format. Similar to unix crontab, but with seven fields instead of five: Second Minute Hour Day-of-Month Month Day-of-Week Year
 
 * `orchestrator` - (Optional) The orchestrator for the job, described below and [here](https://docs.rundeck.com/docs/manual/orchestrator-plugins/bundled.html)
@@ -428,6 +434,12 @@ The following arguments are supported:
 
 * `value_choices`: (Optional) A list of strings giving a set of predefined values that the user
   may choose from when entering a value for the option.
+
+* `values_list_delimiter`: (Optional) Separator Rundeck uses to join `value_choices` into the
+  option's values list, and to split them apart again. Defaults to a comma. Set it when a choice
+  itself contains the default separator — for example a space or a semicolon. This is distinct
+  from `multi_value_delimiter`, which separates the values a user *selects* rather than the ones
+  offered.
 
 * `value_choices_url`: (Optional) Can be used instead of `value_choices` to cause Rundeck to
   obtain a list of choices dynamically by fetching this URL.

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -312,7 +312,9 @@ The following arguments are supported:
   `on_avg_duration` notification fires. Accepts a duration ("2h", "30m"), a percentage of the job's
   average duration ("150%"), or an increment over it ("+5m"). Rundeck treats a missing threshold as
   zero and never fires the notification, so an `on_avg_duration` notification without this attribute
-  is configured but inert.
+  is configured but inert. The reverse is also true and easy to miss: setting this attribute without
+  an `on_avg_duration` notification block does nothing - confirmed against a live server, Rundeck
+  doesn't even persist the threshold in that case, so it reads back as unset on the next refresh.
 
 * `schedule` - (Optional) The job's schedule in Quartz schedule cron format. Similar to unix crontab, but with seven fields instead of five: Second Minute Hour Day-of-Month Month Day-of-Week Year
 


### PR DESCRIPTION
Two settings a job definition can carry that the provider had no way to express. Independent of #284 — different files and, where they share one, different regions of it.

## `values_list_delimiter` on job options

Rundeck stores an option's predefined choices as a single delimited string plus the delimiter used to split it back apart: `Option.toMap` always emits `valuesListDelimiter` alongside `values`, defaulting it to a comma.

With no way to set it, a choice that itself contains a comma cannot be represented — the option silently splits into the wrong values. The only workaround is to avoid commas in choices entirely.

It is distinct from the existing `multi_value_delimiter` (Rundeck's `delimiter`), which separates the values a user *selects* rather than the ones offered. Both exist side by side in `Option.groovy`.

The attribute is `Optional` **and** `Computed`: Rundeck returns the field for every option that has choices, so leaving it `Optional`-only would make an unset delimiter read back as `","` and fail the apply with an inconsistent result.

## `notify_avg_duration_threshold` on `rundeck_job`

This is the threshold that decides when the `on_avg_duration` notification fires. It accepts a duration (`"2h"`, `"30m"`), a percentage of the job's average duration (`"150%"`), or an increment over it (`"+5m"`).

Without it, `ExecutionJob` reads the threshold as `?: "0"` and guards the notification with `jobAverageDurationFinal > 0` — so an `on_avg_duration` notification is configured but can never fire. The provider could already declare the notification, but not the one value that makes it do anything.

The field carries `omitempty`, so an unset threshold leaves Rundeck's own default in place.

## Tests

Unit tests (no live Rundeck needed):

- option delimiter: written to `valuesListDelimiter`, omitted from the payload when unset, read back into state
- threshold: written on the job, omitted when unset, read back through both the typed and API-shaped read paths

## Note on the diff

`job.go` and `resource_job_framework.go` show a large diff because gofmt realigns the surrounding struct fields to the width of the new names. `git diff -w` reduces them to one and fifteen added lines respectively.
