### PR TITLE
feat: add rundeck_system_execution_mode resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**Enhancements**
+
+### System Execution Mode Resource
+
+- **Added `rundeck_system_execution_mode`** - Controls whether a server executes jobs (`active` / `passive`), the switch used during migrations and maintenance windows. Rundeck exposes this over the API (`system/executions/{status,enable,disable}`) but the provider had no way to reach it, so the mode could only be set through the `rundeck.executionMode` property — which is read at startup only, meaning a change required a restart and any manual switch went unnoticed until the next one. Managing it as a resource makes the intended mode explicit and surfaces out-of-band changes as drift. Removing the resource leaves the server untouched rather than flipping its mode.
+
 ## 1.3.1
 
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 ## Unreleased
 
-**Enhancements**
+**Bug Fixes**
 
-### System Execution Mode Resource
+### Job Resource
 
-- **Added `rundeck_system_execution_mode`** - Controls whether a server executes jobs (`active` / `passive`), the switch used during migrations and maintenance windows. Rundeck exposes this over the API (`system/executions/{status,enable,disable}`) but the provider had no way to reach it, so the mode could only be set through the `rundeck.executionMode` property — which is read at startup only, meaning a change required a restart and any manual switch went unnoticed until the next one. Managing it as a resource makes the intended mode explicit and surfaces out-of-band changes as drift. Removing the resource leaves the server untouched rather than flipping its mode.
+- **Fixed updates being resolved by name instead of UUID, which created duplicate jobs** - On update the provider sent the job's UUID under `id`, but Rundeck writes a job's UUID out under both `uuid` and `id` (`ScheduledExecution.toMap`) while only reading it back from `uuid` (`fromMap`). The identifier therefore never reached the import, and Rundeck fell back to resolving the job by name + group + project — a fallback that only matches when *exactly one* job carries that name (`1 == schedlist.size()` in `loadImportedJobs`).
+
+  Two consequences. **Renaming a job created a second one** — `name` is not `RequiresReplace`, so a rename goes through Update, the new name matched nothing, and Rundeck created a job while the original stayed behind under its old name. And **two jobs sharing a name could never be updated**: every apply added another duplicate, which guaranteed the name would never resolve again. The fallback could also update the *wrong* job when an unrelated one happened to share the name.
+
+  In both cases the apply then fails with `Provider produced inconsistent result after apply`, since the id returned is the job that was just created rather than the one in state. The error is visible; what is silent is the damage left in Rundeck — the duplicate stays, and the original is no longer referenced by Terraform.
+
+  The update payload now carries `uuid`, so Rundeck takes its UUID-first resolution path and the job is targeted unambiguously. **Behaviour change:** renaming a job now renames it in place and succeeds, where it previously failed after creating a duplicate. Duplicates left behind by the previous behaviour are not cleaned up automatically — Terraform no longer references them, so they have to be removed from Rundeck by hand. `group_name` and `project_name` are unaffected: both carry `RequiresReplace`, so changing either already destroys and recreates the job.
+
+- **Fixed a plugin-based `error_handler` being silently discarded** - The schema accepts `step_plugin` and `node_step_plugin` under `error_handler`, and `errorHandlerObjectType` declares both, but neither conversion handled them: the write side emitted only `description`, the script/command fields and `jobref`, and the read side never looked for `type`/`configuration`. A handler such as `flow-control` therefore serialized to an object carrying no action at all. Rundeck accepted the job and dropped the handler, so the read-back returned no block and the apply failed with `error_handler: block count changed from 1 to 0`.
+
+  The plan being perfectly valid, this only ever surfaced at apply time — and the job was left in Rundeck without its handler, so a workflow meant to stop on a condition simply ran on. Both directions now carry `type`, `configuration` and `nodeStep`, the latter distinguishing a workflow step from a node step (Rundeck answers it as a bool or as the string `"true"`, both accepted).
+
+  Note that Rundeck itself refuses a workflow-step handler on a node-oriented workflow (*"Error Handlers for Node Steps must also be Node Steps"*), so a job guarded this way needs `strategy = "sequential"`.
+
 
 ## 1.3.1
 

--- a/rundeck/provider_framework.go
+++ b/rundeck/provider_framework.go
@@ -215,6 +215,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewProjectResource,
 		NewJobResource,
 		NewWebhookResource,
+		NewSystemExecutionModeResource,
 	}
 }
 

--- a/rundeck/resource_system_execution_mode_framework.go
+++ b/rundeck/resource_system_execution_mode_framework.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -30,6 +32,16 @@ const (
 	// The mode is a property of the server, not of a named object, so there is
 	// only ever one of these per Rundeck instance and the id is a constant.
 	systemExecutionModeID = "system"
+
+	// minExecutionModeAPIVersion is the lowest API version on which
+	// GET .../system/executions/status reliably reports passive mode instead
+	// of returning HTTP 503 (rundeck/rundeck#5846).
+	minExecutionModeAPIVersion = 36
+
+	// executionModeRequestTimeout bounds how long a single request to the
+	// execution mode endpoints may take, so a hung server or network
+	// partition doesn't block terraform apply/plan/destroy indefinitely.
+	executionModeRequestTimeout = 30 * time.Second
 )
 
 // NewSystemExecutionModeResource is a helper function to simplify the provider implementation.
@@ -90,6 +102,21 @@ func (r *systemExecutionModeResource) Configure(_ context.Context, req resource.
 		return
 	}
 
+	// GET .../system/executions/status returns HTTP 503 instead of the
+	// expected JSON body when the server is passive on API versions below 36
+	// (rundeck/rundeck#5846), which would otherwise surface as a confusing raw
+	// API error on every plan/refresh/import instead of a clear diagnostic.
+	if version, err := strconv.Atoi(clients.APIVersion); err != nil || version < minExecutionModeAPIVersion {
+		resp.Diagnostics.AddError(
+			"Insufficient API Version",
+			fmt.Sprintf("rundeck_system_execution_mode requires API version %d or higher (currently configured: %s), "+
+				"since the status endpoint does not reliably report passive mode before then. "+
+				"Please update your provider configuration with api_version = \"%d\" or higher.",
+				minExecutionModeAPIVersion, clients.APIVersion, minExecutionModeAPIVersion),
+		)
+		return
+	}
+
 	r.client = clients
 }
 
@@ -105,7 +132,7 @@ func (r *systemExecutionModeResource) apiRequest(ctx context.Context, method, pa
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Rundeck-Auth-Token", r.client.Token)
 
-	httpResp, err := (&http.Client{}).Do(req)
+	httpResp, err := (&http.Client{Timeout: executionModeRequestTimeout}).Do(req)
 	if err != nil {
 		return "", fmt.Errorf("could not execute request: %w", err)
 	}
@@ -158,15 +185,23 @@ func (r *systemExecutionModeResource) Create(ctx context.Context, req resource.C
 		resp.Diagnostics.AddError("Error setting execution mode", err.Error())
 		return
 	}
+	plan.ID = types.StringValue(systemExecutionModeID)
 	if got != wanted {
+		// The POST already changed the live server even though the
+		// confirmation read didn't echo the requested mode back (e.g. a
+		// lagging read on a clustered/HA setup). Record what the server
+		// actually reports rather than erroring out with nothing saved to
+		// state: an untracked resource would otherwise re-issue the same
+		// POST against an already-changed server on the next apply.
+		plan.Mode = types.StringValue(got)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		resp.Diagnostics.AddError(
 			"Error setting execution mode",
-			fmt.Sprintf("Asked for %q but the server reports %q.", wanted, got),
+			fmt.Sprintf("Asked for %q but the server reports %q. Tracking the reported mode; re-apply once the server has settled.", wanted, got),
 		)
 		return
 	}
 
-	plan.ID = types.StringValue(systemExecutionModeID)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -203,15 +238,21 @@ func (r *systemExecutionModeResource) Update(ctx context.Context, req resource.U
 		resp.Diagnostics.AddError("Error setting execution mode", err.Error())
 		return
 	}
+	plan.ID = types.StringValue(systemExecutionModeID)
 	if got != wanted {
+		// See the identical comment in Create: persist what the server
+		// actually reports instead of leaving state stuck on the old mode,
+		// which would otherwise silently mask the fact that the POST already
+		// took effect.
+		plan.Mode = types.StringValue(got)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		resp.Diagnostics.AddError(
 			"Error setting execution mode",
-			fmt.Sprintf("Asked for %q but the server reports %q.", wanted, got),
+			fmt.Sprintf("Asked for %q but the server reports %q. Tracking the reported mode; re-apply once the server has settled.", wanted, got),
 		)
 		return
 	}
 
-	plan.ID = types.StringValue(systemExecutionModeID)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/rundeck/resource_system_execution_mode_framework.go
+++ b/rundeck/resource_system_execution_mode_framework.go
@@ -106,7 +106,16 @@ func (r *systemExecutionModeResource) Configure(_ context.Context, req resource.
 	// expected JSON body when the server is passive on API versions below 36
 	// (rundeck/rundeck#5846), which would otherwise surface as a confusing raw
 	// API error on every plan/refresh/import instead of a clear diagnostic.
-	if version, err := strconv.Atoi(clients.APIVersion); err != nil || version < minExecutionModeAPIVersion {
+	version, err := strconv.Atoi(clients.APIVersion)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid API Version",
+			fmt.Sprintf("Could not parse the configured api_version %q as an integer: %s. "+
+				"Please set api_version to a plain number (e.g. \"56\").", clients.APIVersion, err.Error()),
+		)
+		return
+	}
+	if version < minExecutionModeAPIVersion {
 		resp.Diagnostics.AddError(
 			"Insufficient API Version",
 			fmt.Sprintf("rundeck_system_execution_mode requires API version %d or higher (currently configured: %s), "+
@@ -269,6 +278,14 @@ func (r *systemExecutionModeResource) Delete(ctx context.Context, req resource.D
 }
 
 func (r *systemExecutionModeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if req.ID != systemExecutionModeID {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID %q (a Rundeck server has a single execution mode), got: %q.", systemExecutionModeID, req.ID),
+		)
+		return
+	}
+
 	mode, err := r.apiRequest(ctx, http.MethodGet, "status")
 	if err != nil {
 		resp.Diagnostics.AddError("Error importing execution mode", err.Error())

--- a/rundeck/resource_system_execution_mode_framework.go
+++ b/rundeck/resource_system_execution_mode_framework.go
@@ -1,0 +1,241 @@
+package rundeck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &systemExecutionModeResource{}
+	_ resource.ResourceWithConfigure   = &systemExecutionModeResource{}
+	_ resource.ResourceWithImportState = &systemExecutionModeResource{}
+)
+
+const (
+	executionModeActive  = "active"
+	executionModePassive = "passive"
+
+	// The mode is a property of the server, not of a named object, so there is
+	// only ever one of these per Rundeck instance and the id is a constant.
+	systemExecutionModeID = "system"
+)
+
+// NewSystemExecutionModeResource is a helper function to simplify the provider implementation.
+func NewSystemExecutionModeResource() resource.Resource {
+	return &systemExecutionModeResource{}
+}
+
+type systemExecutionModeResource struct {
+	client *RundeckClients
+}
+
+type systemExecutionModeResourceModel struct {
+	ID   types.String `tfsdk:"id"`
+	Mode types.String `tfsdk:"mode"`
+}
+
+func (r *systemExecutionModeResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_system_execution_mode"
+}
+
+func (r *systemExecutionModeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages whether a Rundeck server executes jobs. This is server-wide runtime state, " +
+			"not per-project configuration: in passive mode no job runs, whether scheduled or started by hand. " +
+			"Rundeck also reads a `rundeck.executionMode` property at startup; that property decides the mode " +
+			"a restarted server comes back in, and this resource decides the mode it runs in from the next apply " +
+			"onwards. Keep the two consistent unless a restart is meant to change the mode.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Always \"system\": a Rundeck server has a single execution mode.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"mode": schema.StringAttribute{
+				Description: "Either \"active\" (jobs run) or \"passive\" (no job runs).",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(executionModeActive, executionModePassive),
+				},
+			},
+		},
+	}
+}
+
+func (r *systemExecutionModeResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clients, ok := req.ProviderData.(*RundeckClients)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *RundeckClients, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = clients
+}
+
+// apiRequest issues a request against the system execution mode endpoints and
+// returns the executionMode the server reports back.
+func (r *systemExecutionModeResource) apiRequest(ctx context.Context, method, path string) (string, error) {
+	url := fmt.Sprintf("%s/api/%s/system/executions/%s", r.client.BaseURL, r.client.APIVersion, path)
+
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("could not create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Rundeck-Auth-Token", r.client.Token)
+
+	httpResp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("could not execute request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API returned status %d: %s", httpResp.StatusCode, string(body))
+	}
+
+	var result struct {
+		ExecutionMode string `json:"executionMode"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("could not parse response: %w", err)
+	}
+	if result.ExecutionMode == "" {
+		return "", fmt.Errorf("response carried no executionMode: %s", string(body))
+	}
+
+	return result.ExecutionMode, nil
+}
+
+// setMode switches the server to the requested mode and returns the mode it
+// reports afterwards.
+func (r *systemExecutionModeResource) setMode(ctx context.Context, mode string) (string, error) {
+	path := "disable"
+	if mode == executionModeActive {
+		path = "enable"
+	}
+	return r.apiRequest(ctx, http.MethodPost, path)
+}
+
+// Create does not create anything: the execution mode always exists. It brings
+// the server to the requested mode and starts tracking it.
+func (r *systemExecutionModeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan systemExecutionModeResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	wanted := plan.Mode.ValueString()
+	got, err := r.setMode(ctx, wanted)
+	if err != nil {
+		resp.Diagnostics.AddError("Error setting execution mode", err.Error())
+		return
+	}
+	if got != wanted {
+		resp.Diagnostics.AddError(
+			"Error setting execution mode",
+			fmt.Sprintf("Asked for %q but the server reports %q.", wanted, got),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(systemExecutionModeID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *systemExecutionModeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state systemExecutionModeResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mode, err := r.apiRequest(ctx, http.MethodGet, "status")
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading execution mode", err.Error())
+		return
+	}
+
+	state.ID = types.StringValue(systemExecutionModeID)
+	state.Mode = types.StringValue(mode)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *systemExecutionModeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan systemExecutionModeResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	wanted := plan.Mode.ValueString()
+	got, err := r.setMode(ctx, wanted)
+	if err != nil {
+		resp.Diagnostics.AddError("Error setting execution mode", err.Error())
+		return
+	}
+	if got != wanted {
+		resp.Diagnostics.AddError(
+			"Error setting execution mode",
+			fmt.Sprintf("Asked for %q but the server reports %q.", wanted, got),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(systemExecutionModeID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete stops tracking the mode and deliberately leaves the server as it is.
+// There is nothing to remove: a Rundeck server always has an execution mode,
+// and silently flipping it on `terraform destroy` would either halt a live
+// server or start jobs nobody asked to start.
+func (r *systemExecutionModeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddWarning(
+		"Execution mode left unchanged",
+		"Removing rundeck_system_execution_mode from state does not change the server: it keeps whatever mode it is in. "+
+			"Set the mode explicitly beforehand if the server should be left in a particular state.",
+	)
+}
+
+func (r *systemExecutionModeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	mode, err := r.apiRequest(ctx, http.MethodGet, "status")
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing execution mode", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, systemExecutionModeResourceModel{
+		ID:   types.StringValue(systemExecutionModeID),
+		Mode: types.StringValue(mode),
+	})...)
+}

--- a/rundeck/resource_system_execution_mode_test.go
+++ b/rundeck/resource_system_execution_mode_test.go
@@ -1,6 +1,7 @@
 package rundeck
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -36,6 +37,23 @@ func TestAccSystemExecutionMode(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
+				// Flip the mode out-of-band (directly against the API, not
+				// through this Terraform config) between the previous apply
+				// and this one, then confirm the next plan actually notices:
+				// the whole point of managing this as a resource rather than
+				// the startup-only rundeck.executionMode property is that an
+				// out-of-band change should surface as drift, not go unnoticed
+				// until someone happens to look.
+				// ExpectNonEmptyPlan defaults to false: the test framework's
+				// automatic post-apply "plan again, expect no diff" check
+				// only passes if this step's apply actually reconciled the
+				// drift Read() picked up, not merely flagged it.
+				PreConfig: func() { testAccFlipExecutionModeOutOfBand(t, "passive") },
+				Config:    testAccSystemExecutionModeConfig("active"),
+				Check: resource.TestCheckResourceAttr(
+					"rundeck_system_execution_mode.test", "mode", "active"),
+			},
+			{
 				ResourceName:      "rundeck_system_execution_mode.test",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -43,6 +61,24 @@ func TestAccSystemExecutionMode(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccFlipExecutionModeOutOfBand switches the server's execution mode
+// directly through the API, bypassing Terraform entirely, so the following
+// test step's plan/apply has to detect and correct real drift rather than
+// just replaying state it already wrote itself.
+func testAccFlipExecutionModeOutOfBand(t *testing.T, mode string) {
+	t.Helper()
+
+	clients, err := getTestClients()
+	if err != nil {
+		t.Fatalf("getTestClients: %v", err)
+	}
+
+	r := &systemExecutionModeResource{client: clients}
+	if _, err := r.setMode(context.Background(), mode); err != nil {
+		t.Fatalf("flipping execution mode out-of-band to %q: %v", mode, err)
+	}
 }
 
 func testAccSystemExecutionModeConfig(mode string) string {

--- a/rundeck/resource_system_execution_mode_test.go
+++ b/rundeck/resource_system_execution_mode_test.go
@@ -2,9 +2,12 @@ package rundeck
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // TestAccSystemExecutionMode covers the two things that matter for this
@@ -13,9 +16,23 @@ import (
 // managing it here rather than through a configuration file only read at
 // startup.
 func TestAccSystemExecutionMode(t *testing.T) {
+	// Captured lazily on first use inside PreCheck (once testAccPreCheck has
+	// confirmed the env vars this needs are set), and restored via
+	// CheckDestroy once the test's own steps are done - this resource's
+	// Delete deliberately never touches server state, so without this the
+	// test would leave the server in whatever mode its last apply set,
+	// regardless of what it started in.
+	var startingMode string
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			startingMode = testAccCurrentExecutionMode(t)
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy: func(*terraform.State) error {
+			return testAccFlipExecutionModeOutOfBand(startingMode)
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSystemExecutionModeConfig("passive"),
@@ -48,8 +65,12 @@ func TestAccSystemExecutionMode(t *testing.T) {
 				// automatic post-apply "plan again, expect no diff" check
 				// only passes if this step's apply actually reconciled the
 				// drift Read() picked up, not merely flagged it.
-				PreConfig: func() { testAccFlipExecutionModeOutOfBand(t, "passive") },
-				Config:    testAccSystemExecutionModeConfig("active"),
+				PreConfig: func() {
+					if err := testAccFlipExecutionModeOutOfBand("passive"); err != nil {
+						t.Fatalf("flipping execution mode out-of-band: %v", err)
+					}
+				},
+				Config: testAccSystemExecutionModeConfig("active"),
 				Check: resource.TestCheckResourceAttr(
 					"rundeck_system_execution_mode.test", "mode", "active"),
 			},
@@ -66,8 +87,26 @@ func TestAccSystemExecutionMode(t *testing.T) {
 // testAccFlipExecutionModeOutOfBand switches the server's execution mode
 // directly through the API, bypassing Terraform entirely, so the following
 // test step's plan/apply has to detect and correct real drift rather than
-// just replaying state it already wrote itself.
-func testAccFlipExecutionModeOutOfBand(t *testing.T, mode string) {
+// just replaying state it already wrote itself. Also used by CheckDestroy
+// to restore the server's starting mode once the test's own steps are done.
+func testAccFlipExecutionModeOutOfBand(mode string) error {
+	clients, err := getTestClients()
+	if err != nil {
+		return fmt.Errorf("getTestClients: %w", err)
+	}
+
+	r := &systemExecutionModeResource{client: clients}
+	if _, err := r.setMode(context.Background(), mode); err != nil {
+		return fmt.Errorf("flipping execution mode out-of-band to %q: %w", mode, err)
+	}
+	return nil
+}
+
+// testAccCurrentExecutionMode reads the server's current execution mode
+// directly through the API, so the test can restore it via CheckDestroy
+// once done - this resource's own Delete deliberately never touches server
+// state.
+func testAccCurrentExecutionMode(t *testing.T) string {
 	t.Helper()
 
 	clients, err := getTestClients()
@@ -76,9 +115,11 @@ func testAccFlipExecutionModeOutOfBand(t *testing.T, mode string) {
 	}
 
 	r := &systemExecutionModeResource{client: clients}
-	if _, err := r.setMode(context.Background(), mode); err != nil {
-		t.Fatalf("flipping execution mode out-of-band to %q: %v", mode, err)
+	mode, err := r.apiRequest(context.Background(), http.MethodGet, "status")
+	if err != nil {
+		t.Fatalf("reading current execution mode: %v", err)
 	}
+	return mode
 }
 
 func testAccSystemExecutionModeConfig(mode string) string {

--- a/rundeck/resource_system_execution_mode_test.go
+++ b/rundeck/resource_system_execution_mode_test.go
@@ -1,0 +1,54 @@
+package rundeck
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccSystemExecutionMode covers the two things that matter for this
+// resource: that it actually switches the server, and that it reports drift
+// when the mode is changed outside Terraform — which is the whole reason for
+// managing it here rather than through a configuration file only read at
+// startup.
+func TestAccSystemExecutionMode(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemExecutionModeConfig("passive"),
+				Check: resource.TestCheckResourceAttr(
+					"rundeck_system_execution_mode.test", "mode", "passive"),
+			},
+			{
+				// Re-apply unchanged: the mode must round-trip, with no diff.
+				Config:   testAccSystemExecutionModeConfig("passive"),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccSystemExecutionModeConfig("active"),
+				Check: resource.TestCheckResourceAttr(
+					"rundeck_system_execution_mode.test", "mode", "active"),
+			},
+			{
+				Config:   testAccSystemExecutionModeConfig("active"),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      "rundeck_system_execution_mode.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "system",
+			},
+		},
+	})
+}
+
+func testAccSystemExecutionModeConfig(mode string) string {
+	return `
+resource "rundeck_system_execution_mode" "test" {
+  mode = "` + mode + `"
+}
+`
+}

--- a/website/docs/r/system_execution_mode.html.md
+++ b/website/docs/r/system_execution_mode.html.md
@@ -12,7 +12,7 @@ Controls whether a Rundeck server executes jobs. In `passive` mode no job runs a
 
 This is **server-wide runtime state**, not per-project configuration. To stop only the scheduled runs of a project while still allowing manual ones, set `project.disable.schedule` on that project instead.
 
-Requires `api_version` 36 or higher: below that, the status endpoint this resource reads from does not reliably report passive mode.
+This resource's own requirement is `api_version` 36 or higher, since the status endpoint it reads from doesn't reliably report passive mode below that — in practice this is already covered by the provider's overall minimum of 46 (Rundeck 5.0.0+), so it isn't a separate constraint you need to configure for.
 
 ## Example Usage
 

--- a/website/docs/r/system_execution_mode.html.md
+++ b/website/docs/r/system_execution_mode.html.md
@@ -1,0 +1,58 @@
+---
+layout: "rundeck"
+page_title: "Rundeck: rundeck_system_execution_mode"
+sidebar_current: "docs-rundeck-resource-system-execution-mode"
+description: |-
+  The rundeck_system_execution_mode resource controls whether a Rundeck server executes jobs.
+---
+
+# rundeck\_system\_execution\_mode
+
+Controls whether a Rundeck server executes jobs. In `passive` mode no job runs at all — neither scheduled ones nor those started by hand — which makes it the switch to reach for during a migration, a maintenance window, or a database operation.
+
+This is **server-wide runtime state**, not per-project configuration. To stop only the scheduled runs of a project while still allowing manual ones, set `project.disable.schedule` on that project instead.
+
+## Example Usage
+
+```hcl
+resource "rundeck_system_execution_mode" "this" {
+  mode = "active"
+}
+```
+
+Holding a server passive while its catalogue is being built up:
+
+```hcl
+resource "rundeck_system_execution_mode" "staging" {
+  mode = "passive"
+}
+```
+
+## Argument Reference
+
+* `mode` - (Required) Either `active` (jobs run) or `passive` (no job runs).
+
+## Attributes Reference
+
+* `id` - Always `system`. A Rundeck server has a single execution mode, so there is only ever one of these resources per server.
+
+## Relationship with the `rundeck.executionMode` property
+
+Rundeck reads a `rundeck.executionMode` property from its configuration file **at startup**, and keeps the mode in its database afterwards. The two answer different questions:
+
+* the property decides the mode a **restarted** server comes back in;
+* this resource decides the mode the server runs in **from the next apply onwards**.
+
+Keeping them consistent is usually what you want: otherwise a restart silently reverts the mode until someone runs Terraform again. Note that when the property is absent entirely, Rundeck starts **passive** — `ConfigurationService` treats anything other than the literal `active` as inactive.
+
+## Behaviour on destroy
+
+Removing this resource stops Terraform tracking the mode and **deliberately leaves the server as it is**. There is nothing to delete — a server always has an execution mode — and flipping it on `terraform destroy` would either halt a live server or start jobs nobody asked to start. A warning is emitted to make the no-op explicit. Set the mode you want before removing the resource.
+
+## Import
+
+The execution mode always exists, so it can be imported with the constant id:
+
+```
+terraform import rundeck_system_execution_mode.this system
+```

--- a/website/docs/r/system_execution_mode.html.md
+++ b/website/docs/r/system_execution_mode.html.md
@@ -12,6 +12,8 @@ Controls whether a Rundeck server executes jobs. In `passive` mode no job runs a
 
 This is **server-wide runtime state**, not per-project configuration. To stop only the scheduled runs of a project while still allowing manual ones, set `project.disable.schedule` on that project instead.
 
+Requires `api_version` 36 or higher: below that, the status endpoint this resource reads from does not reliably report passive mode.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Independent of #284, #285 and #286 — new file, no overlap.

## What is missing today

Rundeck exposes the server execution mode over the API:

```
GET  /api/{v}/system/executions/status    -> {"executionMode":"active"}
POST /api/{v}/system/executions/enable
POST /api/{v}/system/executions/disable
```

The provider has no way to reach it. The only way to set the mode from code is the `rundeck.executionMode` property in `rundeck-config.properties`, and that has two consequences:

- **It is read at startup only.** Changing the mode means editing a file and restarting the server, which is a heavy operation for a switch whose whole point is to be flipped quickly during a migration or a maintenance window.
- **A change made outside that file is invisible.** Someone switches the mode through the UI or the API, and nothing records it. The next restart silently reverts it, and the next configuration-management run reverts it again — long after anyone remembers why it was switched.

That second point is what a resource fixes: an out-of-band change becomes drift, visible on the next plan, instead of a surprise weeks later.

## The resource

```hcl
resource "rundeck_system_execution_mode" "this" {
  mode = "active"   # or "passive"
}
```

`mode` is validated against the two accepted values. `id` is the constant `system`, since a server has exactly one execution mode.

## Two design points worth flagging

**Destroy is a deliberate no-op.** Removing the resource stops Terraform tracking the mode and leaves the server exactly as it is, with a warning. There is nothing to delete — a server always has an execution mode — and flipping it on `terraform destroy` would either halt a live server or start jobs nobody asked to start. Neither is a safe default.

**The resource does not touch `rundeck.executionMode`.** The property and the resource answer different questions: the property decides the mode a *restarted* server comes back in, the resource decides the mode it runs in from the next apply onwards. The documentation spells this out, including the fact that an absent property means Rundeck starts passive — `ConfigurationService.isExecutionModeActive()` treats anything other than the literal `active` as inactive.

## Tests

An acceptance test that switches to `passive`, asserts an empty plan, switches to `active`, asserts an empty plan again, then imports by the constant id with `ImportStateVerify`.

Verified against a live Rundeck 6.0.1: it passes, and the server ends in the mode it started in.
