### PR TITLE
Fix plugin steps being silently dropped from a command's error_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+**Bug Fixes**
+
+### Job Resource
+
+- **Fixed a plugin-based `error_handler` being silently discarded** - The schema accepts `step_plugin` and `node_step_plugin` under `error_handler`, and `errorHandlerObjectType` declares both, but neither conversion handled them: the write side emitted only `description`, the script/command fields and `jobref`, and the read side never looked for `type`/`configuration`. A handler such as `flow-control` therefore serialized to an object carrying no action at all. Rundeck accepted the job and dropped the handler, so the read-back returned no block and the apply failed with `error_handler: block count changed from 1 to 0`.
+
+  The plan being perfectly valid, this only ever surfaced at apply time — and the job was left in Rundeck without its handler, so a workflow meant to stop on a condition simply ran on. Both directions now carry `type`, `configuration` and `nodeStep`, the latter distinguishing a workflow step from a node step (Rundeck answers it as a bool or as the string `"true"`, both accepted).
+
+  Note that Rundeck itself refuses a workflow-step handler on a node-oriented workflow (*"Error Handlers for Node Steps must also be Node Steps"*), so a job guarded this way needs `strategy = "sequential"`.
+
 ## 1.3.1
 
 **Bug Fixes**

--- a/rundeck/resource_job_converters.go
+++ b/rundeck/resource_job_converters.go
@@ -411,6 +411,57 @@ func convertCommandsToJSON(ctx context.Context, commandsList types.List) ([]inte
 					}
 				}
 
+				// Handle step_plugin / node_step_plugin on the error handler.
+				//
+				// Same shape as on a command: "type" and "configuration" live at the
+				// handler level, and "nodeStep" tells Rundeck whether the step runs
+				// once for the workflow or once per node.
+				//
+				// Without this, a plugin-based handler serialized to an object holding
+				// no action at all. Rundeck accepted the job and silently dropped the
+				// handler, so the read-back returned no error_handler block and the
+				// apply failed with "block count changed from 1 to 0". The plan being
+				// valid, the problem only ever surfaced at apply time.
+				if v, ok := handlerAttrs["step_plugin"].(types.List); ok && !v.IsNull() && !v.IsUnknown() {
+					var plugins []types.Object
+					diags.Append(v.ElementsAs(ctx, &plugins, false)...)
+					if len(plugins) > 0 {
+						pluginAttrs := plugins[0].Attributes()
+
+						if ptype, ok := pluginAttrs["type"].(types.String); ok && !ptype.IsNull() {
+							handlerMap["type"] = ptype.ValueString()
+						}
+						if config, ok := pluginAttrs["config"].(types.Map); ok && !config.IsNull() {
+							var configMap map[string]string
+							diags.Append(config.ElementsAs(ctx, &configMap, false)...)
+							handlerMap["configuration"] = configMap
+						}
+
+						// Workflow steps run once, not per node.
+						handlerMap["nodeStep"] = false
+					}
+				}
+
+				if v, ok := handlerAttrs["node_step_plugin"].(types.List); ok && !v.IsNull() && !v.IsUnknown() {
+					var plugins []types.Object
+					diags.Append(v.ElementsAs(ctx, &plugins, false)...)
+					if len(plugins) > 0 {
+						pluginAttrs := plugins[0].Attributes()
+
+						if ptype, ok := pluginAttrs["type"].(types.String); ok && !ptype.IsNull() {
+							handlerMap["type"] = ptype.ValueString()
+						}
+						if config, ok := pluginAttrs["config"].(types.Map); ok && !config.IsNull() {
+							var configMap map[string]string
+							diags.Append(config.ElementsAs(ctx, &configMap, false)...)
+							handlerMap["configuration"] = configMap
+						}
+
+						// Node steps run on each node.
+						handlerMap["nodeStep"] = true
+					}
+				}
+
 				cmdMap["errorhandler"] = handlerMap
 			}
 		}
@@ -1863,6 +1914,47 @@ func convertCommandsFromJSON(ctx context.Context, commands []interface{}) (types
 				keepGoingOnSuccess = v
 			}
 			handlerAttrs["keep_going_on_success"] = types.BoolValue(keepGoingOnSuccess)
+
+			// A plugin-based handler carries "type" and "configuration" just like a
+			// plugin command, "nodeStep" telling a workflow step from a node step.
+			// Reading it back is what closes the round-trip: the write side may now
+			// send it, but without this the state would still come back empty.
+			if htype, ok := handler["type"].(string); ok && htype != "" {
+				pluginAttrs := map[string]attr.Value{
+					"type":   types.StringValue(htype),
+					"config": types.MapNull(types.StringType),
+				}
+				if configuration, ok := handler["configuration"].(map[string]interface{}); ok && len(configuration) > 0 {
+					configMap := make(map[string]attr.Value)
+					for k, v := range configuration {
+						if strVal, ok := v.(string); ok {
+							configMap[k] = types.StringValue(strVal)
+						}
+					}
+					if len(configMap) > 0 {
+						pluginAttrs["config"] = types.MapValueMust(types.StringType, configMap)
+					}
+				}
+
+				pluginObj, pluginDiags := types.ObjectValue(stepPluginObjectType.AttrTypes, pluginAttrs)
+				diags.Append(pluginDiags...)
+
+				// Rundeck returns nodeStep as a bool or as the string "true"/"false"
+				// depending on how the job was created; accept both.
+				isNodeStep := false
+				switch ns := handler["nodeStep"].(type) {
+				case bool:
+					isNodeStep = ns
+				case string:
+					isNodeStep = ns == "true"
+				}
+
+				if isNodeStep {
+					handlerAttrs["node_step_plugin"] = types.ListValueMust(stepPluginObjectType, []attr.Value{pluginObj})
+				} else {
+					handlerAttrs["step_plugin"] = types.ListValueMust(stepPluginObjectType, []attr.Value{pluginObj})
+				}
+			}
 
 			// Handle job reference in error_handler
 			if jobref, ok := handler["jobref"].(map[string]interface{}); ok {

--- a/rundeck/resource_job_error_handler_plugin_test.go
+++ b/rundeck/resource_job_error_handler_plugin_test.go
@@ -1,0 +1,183 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// An error handler may itself be a plugin step (flow-control, for instance).
+// Both directions used to drop it: the write side never emitted "type" and
+// "configuration", so Rundeck stored a handler with no action and silently
+// discarded it; the read side then returned no block at all and the apply
+// failed with `block count changed from 1 to 0` — while the plan looked fine.
+
+// testCommandWithPluginErrorHandler builds a command whose error handler is a
+// plugin step, using the shared object types so the shapes stay in sync with
+// the schema.
+func testCommandWithPluginErrorHandler(t *testing.T, nodeStepPlugin bool) types.List {
+	t.Helper()
+
+	plugin, diags := types.ObjectValue(stepPluginObjectType.AttrTypes, map[string]attr.Value{
+		"type": types.StringValue("flow-control"),
+		"config": types.MapValueMust(types.StringType, map[string]attr.Value{
+			"halt":   types.StringValue("true"),
+			"fail":   types.StringValue("false"),
+			"status": types.StringValue("inactive-region"),
+		}),
+	})
+	if diags.HasError() {
+		t.Fatalf("building plugin object: %v", diags)
+	}
+
+	handlerAttrs := map[string]attr.Value{
+		"description":                 types.StringNull(),
+		"shell_command":               types.StringNull(),
+		"inline_script":               types.StringNull(),
+		"script_url":                  types.StringNull(),
+		"script_file":                 types.StringNull(),
+		"script_file_args":            types.StringNull(),
+		"expand_token_in_script_file": types.BoolNull(),
+		"file_extension":              types.StringNull(),
+		"keep_going_on_success":       types.BoolNull(),
+		"script_interpreter":          types.ListNull(scriptInterpreterObjectType),
+		"job":                         types.ListNull(jobRefObjectType),
+		"step_plugin":                 types.ListNull(stepPluginObjectType),
+		"node_step_plugin":            types.ListNull(stepPluginObjectType),
+	}
+	if nodeStepPlugin {
+		handlerAttrs["node_step_plugin"] = types.ListValueMust(stepPluginObjectType, []attr.Value{plugin})
+	} else {
+		handlerAttrs["step_plugin"] = types.ListValueMust(stepPluginObjectType, []attr.Value{plugin})
+	}
+
+	handler, diags := types.ObjectValue(errorHandlerObjectType.AttrTypes, handlerAttrs)
+	if diags.HasError() {
+		t.Fatalf("building error handler object: %v", diags)
+	}
+
+	cmd, diags := types.ObjectValue(commandObjectType.AttrTypes, map[string]attr.Value{
+		"description":                 types.StringNull(),
+		"shell_command":               types.StringValue("false"),
+		"inline_script":               types.StringNull(),
+		"script_url":                  types.StringNull(),
+		"script_file":                 types.StringNull(),
+		"script_file_args":            types.StringNull(),
+		"expand_token_in_script_file": types.BoolNull(),
+		"file_extension":              types.StringNull(),
+		"keep_going_on_success":       types.BoolNull(),
+		"plugins":                     types.ListNull(commandPluginsObjectType),
+		"script_interpreter":          types.ListNull(scriptInterpreterObjectType),
+		"job":                         types.ListNull(jobRefObjectType),
+		"step_plugin":                 types.ListNull(stepPluginObjectType),
+		"node_step_plugin":            types.ListNull(stepPluginObjectType),
+		"error_handler":               types.ListValueMust(errorHandlerObjectType, []attr.Value{handler}),
+	})
+	if diags.HasError() {
+		t.Fatalf("building command object: %v", diags)
+	}
+
+	return types.ListValueMust(commandObjectType, []attr.Value{cmd})
+}
+
+func TestConvertCommandsToJSON_pluginErrorHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		nodeStep     bool
+		wantNodeStep bool
+	}{
+		{"workflow step", false, false},
+		{"node step", true, true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result, diags := convertCommandsToJSON(
+				context.Background(), testCommandWithPluginErrorHandler(t, tc.nodeStep))
+			if diags.HasError() {
+				t.Fatalf("convertCommandsToJSON: %v", diags)
+			}
+
+			cmd, ok := result[0].(map[string]interface{})
+			if !ok {
+				t.Fatalf("command is %T, want map", result[0])
+			}
+			handler, ok := cmd["errorhandler"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("errorhandler is %T, want map", cmd["errorhandler"])
+			}
+
+			if got := handler["type"]; got != "flow-control" {
+				t.Errorf("errorhandler type = %v, want flow-control", got)
+			}
+			if got := handler["nodeStep"]; got != tc.wantNodeStep {
+				t.Errorf("errorhandler nodeStep = %v, want %v", got, tc.wantNodeStep)
+			}
+
+			config, ok := handler["configuration"].(map[string]string)
+			if !ok {
+				t.Fatalf("errorhandler configuration is %T, want map[string]string", handler["configuration"])
+			}
+			for k, want := range map[string]string{
+				"halt": "true", "fail": "false", "status": "inactive-region",
+			} {
+				if config[k] != want {
+					t.Errorf("configuration[%q] = %q, want %q", k, config[k], want)
+				}
+			}
+		})
+	}
+}
+
+// The read side must recognise the same shape, otherwise the round-trip stays
+// broken even though the write side now emits it.
+func TestConvertCommandsFromJSON_pluginErrorHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		nodeStep interface{} // Rundeck answers with a bool or the string "true"
+		wantAttr string
+	}{
+		{"workflow step (bool)", false, "step_plugin"},
+		{"node step (bool)", true, "node_step_plugin"},
+		{"node step (string)", "true", "node_step_plugin"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			commands := []interface{}{
+				map[string]interface{}{
+					"exec": "false",
+					"errorhandler": map[string]interface{}{
+						"type":     "flow-control",
+						"nodeStep": tc.nodeStep,
+						"configuration": map[string]interface{}{
+							"halt": "true",
+						},
+					},
+				},
+			}
+
+			list, diags := convertCommandsFromJSON(context.Background(), commands)
+			if diags.HasError() {
+				t.Fatalf("convertCommandsFromJSON: %v", diags)
+			}
+
+			cmdAttrs := list.Elements()[0].(types.Object).Attributes()
+			handlers, ok := cmdAttrs["error_handler"].(types.List)
+			if !ok || len(handlers.Elements()) != 1 {
+				t.Fatalf("error_handler is %v, want one element", cmdAttrs["error_handler"])
+			}
+
+			handlerAttrs := handlers.Elements()[0].(types.Object).Attributes()
+			plugins, ok := handlerAttrs[tc.wantAttr].(types.List)
+			if !ok || plugins.IsNull() || len(plugins.Elements()) != 1 {
+				t.Fatalf("%s is %v, want one element", tc.wantAttr, handlerAttrs[tc.wantAttr])
+			}
+
+			pluginAttrs := plugins.Elements()[0].(types.Object).Attributes()
+			if got := pluginAttrs["type"].(types.String).ValueString(); got != "flow-control" {
+				t.Errorf("plugin type = %q, want flow-control", got)
+			}
+		})
+	}
+}

--- a/rundeck/resource_job_error_handler_plugin_test.go
+++ b/rundeck/resource_job_error_handler_plugin_test.go
@@ -2,10 +2,12 @@ package rundeck
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // An error handler may itself be a plugin step (flow-control, for instance).
@@ -181,3 +183,122 @@ func TestConvertCommandsFromJSON_pluginErrorHandler(t *testing.T) {
 		})
 	}
 }
+
+// The converter tests above would still have passed while the handler was being
+// dropped, because the drop happened on Rundeck's side: it accepted the job,
+// stored no handler, and only the read-back revealed it. This acceptance test
+// closes that gap by reading the stored job straight from the API.
+//
+// The workflow is `sequential` on purpose: Rundeck refuses a workflow-step
+// handler on a node-oriented workflow ("Error Handlers for Node Steps must also
+// be Node Steps"), which is a constraint of the server, not of the provider.
+func TestAccJob_pluginErrorHandler(t *testing.T) {
+	var jobID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccJobCheckDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_pluginErrorHandler,
+				Check: resource.ComposeTestCheckFunc(
+					testAccJobGetID("rundeck_job.error_handler_plugin", &jobID),
+
+					resource.TestCheckResourceAttr("rundeck_job.error_handler_plugin",
+						"command.0.error_handler.0.step_plugin.0.type", "flow-control"),
+					resource.TestCheckResourceAttr("rundeck_job.error_handler_plugin",
+						"command.0.error_handler.0.step_plugin.0.config.halt", "true"),
+
+					// What actually reached Rundeck, which is the point of the fix.
+					testAccJobValidateAPI(&jobID, func(jobData map[string]interface{}) error {
+						sequence, ok := jobData["sequence"].(map[string]interface{})
+						if !ok {
+							return fmt.Errorf("sequence is %T, want map", jobData["sequence"])
+						}
+						commands, ok := sequence["commands"].([]interface{})
+						if !ok || len(commands) == 0 {
+							return fmt.Errorf("sequence.commands is %T, want a non-empty list", sequence["commands"])
+						}
+						command, ok := commands[0].(map[string]interface{})
+						if !ok {
+							return fmt.Errorf("command is %T, want map", commands[0])
+						}
+
+						handler, ok := command["errorhandler"].(map[string]interface{})
+						if !ok {
+							return fmt.Errorf("error handler missing from the stored job: %v", command)
+						}
+						if got := handler["type"]; got != "flow-control" {
+							return fmt.Errorf("error handler type = %v, want flow-control", got)
+						}
+
+						// A workflow step: it runs once, not per node.
+						switch nodeStep := handler["nodeStep"].(type) {
+						case bool:
+							if nodeStep {
+								return fmt.Errorf("error handler nodeStep = true, want false")
+							}
+						case string:
+							if nodeStep == "true" {
+								return fmt.Errorf("error handler nodeStep = %q, want false", nodeStep)
+							}
+						}
+
+						config, ok := handler["configuration"].(map[string]interface{})
+						if !ok {
+							return fmt.Errorf("error handler configuration is %T, want map", handler["configuration"])
+						}
+						for key, want := range map[string]string{"halt": "true", "fail": "false"} {
+							if got := config[key]; got != want {
+								return fmt.Errorf("error handler configuration[%q] = %v, want %q", key, got, want)
+							}
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+const testAccJobConfig_pluginErrorHandler = `
+resource "rundeck_project" "test" {
+  name = "terraform-acc-test-error-handler-plugin"
+  description = "Plugin error handler test project"
+
+  resource_model_source {
+    type = "file"
+    config = {
+      format = "resourceyaml"
+      file = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+
+resource "rundeck_job" "error_handler_plugin" {
+  project_name = rundeck_project.test.name
+  name = "error-handler-plugin-test"
+  description = "Job whose error handler is a plugin step"
+  execution_enabled = true
+
+  # Sequential: Rundeck rejects a workflow-step handler on a node-oriented
+  # workflow.
+  command_ordering_strategy = "sequential"
+
+  command {
+    shell_command = "false"
+
+    error_handler {
+      step_plugin {
+        type = "flow-control"
+        config = {
+          halt   = "true"
+          fail   = "false"
+          status = "halted-by-handler"
+        }
+      }
+    }
+  }
+}
+`


### PR DESCRIPTION
### Problem

The job schema accepts `step_plugin` and `node_step_plugin` under `error_handler`, and `errorHandlerObjectType` declares both — but neither conversion handles them.

`convertCommandsToJSON` emits only `description`, the script/command fields and `jobref`. `convertCommandsFromJSON` never looks for `type`/`configuration`. A plugin-based handler therefore serializes to an object carrying no action at all. Rundeck accepts the job, drops the handler, and the read-back returns no block — so the apply fails with:

```
Provider produced inconsistent result after apply
… .command[0].error_handler: block count changed from 1 to 0
```

The plan is perfectly valid, so this only ever surfaces at apply time. Worse, the failure is not inert: the job is left in Rundeck **without** its handler, so a workflow meant to halt on a condition simply runs on.

### Reproduction

```hcl
command {
  inline_script = "exit 1"

  error_handler {
    step_plugin {
      type = "flow-control"
      config = {
        halt   = "true"
        fail   = "false"
        status = "custom-status"
      }
    }
  }
}
```

`terraform plan` succeeds; `terraform apply` fails with the error above, and the job exists in Rundeck with no error handler.

### Fix

Both directions now carry `type`, `configuration` and `nodeStep`, mirroring how plugin steps are already handled at the command level. `nodeStep` distinguishes a workflow step from a node step; Rundeck answers it as a bool or as the string `"true"` depending on how the job was created, so the read accepts both.

### Tests

Added `rundeck/resource_job_error_handler_plugin_test.go`, covering both conversions in both directions, for workflow steps and node steps, including the string form of `nodeStep`.

Verified end to end against Rundeck 6.1.0: the handler is created, read back, and halts the workflow with its own status instead of failing it.

### Note for users

Rundeck itself refuses a workflow-step handler on a node-oriented workflow:

> The Error Handler for Step 1 is of the wrong type. Error Handlers for Node Steps must also be Node Steps when the Workflow is Node-oriented.

So a job guarded with `flow-control` needs `strategy = "sequential"`. This is Rundeck's own validation, not a provider limitation — mentioned in the changelog so the next person does not have to find out at apply time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)