### PR TITLE
Add runner data sources and fix system_runner project detachment

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,13 +40,15 @@ Forward-looking tasks for the Rundeck Terraform Provider.
 **Priority Order**:
 - `data.rundeck_project` - Look up project details, most requested
 - `data.rundeck_job` - Reference existing jobs by name/UUID
-- `data.rundeck_runner` - Look up runner details (Enterprise)
+- ~~`data.rundeck_runner` - Look up runner details (Enterprise)~~ Implemented,
+  along with `data.rundeck_runners` (list/filter) and `data.rundeck_runner_tags`
+  (tag discovery).
 - `data.rundeck_node` - Query nodes (lower priority)
 
 **Use Cases**:
 - Reference existing projects created outside Terraform
 - Build job dependencies without hardcoding UUIDs
-- Dynamic runner assignment
+- ~~Dynamic runner assignment~~ Covered by the new runner data sources above.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -40,15 +40,11 @@ Forward-looking tasks for the Rundeck Terraform Provider.
 **Priority Order**:
 - `data.rundeck_project` - Look up project details, most requested
 - `data.rundeck_job` - Reference existing jobs by name/UUID
-- ~~`data.rundeck_runner` - Look up runner details (Enterprise)~~ Implemented,
-  along with `data.rundeck_runners` (list/filter) and `data.rundeck_runner_tags`
-  (tag discovery).
 - `data.rundeck_node` - Query nodes (lower priority)
 
 **Use Cases**:
 - Reference existing projects created outside Terraform
 - Build job dependencies without hardcoding UUIDs
-- ~~Dynamic runner assignment~~ Covered by the new runner data sources above.
 
 ---
 

--- a/docs/runner_comparison.md
+++ b/docs/runner_comparison.md
@@ -66,15 +66,23 @@ resource "rundeck_project_runner" "specific" {
 
 ## API Endpoints Used
 
+Both resources (and the runner data sources below) require API version 56 or
+higher, enforced by the provider at `Configure` time.
+
 ### System Runner
-- **Create**: `POST /api/53/runner`
-- **Read**: `GET /api/53/runner/{id}`
+- **Create**: `POST /api/56/runner`
+- **Read**: `GET /api/56/runner/{id}`
 - **Delete**: Via project associations
 
 ### Project Runner
-- **Create**: `POST /api/53/project/{project}/runner`
-- **Read**: `GET /api/53/project/{project}/runners` (list and filter)
-- **Delete**: `DELETE /api/53/project/{project}/runner/{id}`
+- **Create**: `POST /api/56/project/{project}/runner`
+- **Read**: `GET /api/56/project/{project}/runners` (list and filter)
+- **Delete**: `DELETE /api/56/project/{project}/runner/{id}`
+
+### Data Sources
+- `data.rundeck_runner` - look up a single runner by `runner_id`
+- `data.rundeck_runners` - list/filter runners, optionally scoped to a project
+- `data.rundeck_runner_tags` - discover runner tags in use and their usage counts
 
 ## Import Syntax
 

--- a/rundeck/api_version.go
+++ b/rundeck/api_version.go
@@ -3,13 +3,15 @@ package rundeck
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
-// requireMinAPIVersion adds an "Insufficient API Version" error diagnostic
-// and returns false when configured is below min. subject names what's
-// being gated (e.g. "Runner data sources"), used in the diagnostic message.
+// requireMinAPIVersion adds an error diagnostic and returns false when
+// configured can't be parsed as an integer, or parses but is below min.
+// subject names what's being gated (e.g. "Runner data sources"), used in
+// the diagnostic message.
 //
 // Comparing the two version strings lexicographically, as several call sites
 // in this provider still do (`clients.APIVersion < "56"`), is wrong whenever
@@ -17,8 +19,21 @@ import (
 // ordering, so a genuinely older single-digit version incorrectly passes a
 // ">= 56" check. This compares them as integers instead.
 func requireMinAPIVersion(diags *diag.Diagnostics, configured string, min int, subject string) bool {
-	version, err := strconv.Atoi(configured)
-	if err == nil && version >= min {
+	// api_version commonly comes from an environment variable, which can
+	// carry leading/trailing whitespace (e.g. a trailing newline) without
+	// the user noticing; trim it before parsing so that doesn't fail here.
+	version, err := strconv.Atoi(strings.TrimSpace(configured))
+	if err != nil {
+		diags.AddError(
+			"Invalid API Version",
+			fmt.Sprintf(
+				"Could not parse the configured api_version %q as an integer: %s. Please set api_version to a plain number (e.g. \"%d\").",
+				configured, err.Error(), min,
+			),
+		)
+		return false
+	}
+	if version >= min {
 		return true
 	}
 	diags.AddError(

--- a/rundeck/api_version.go
+++ b/rundeck/api_version.go
@@ -1,0 +1,32 @@
+package rundeck
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// requireMinAPIVersion adds an "Insufficient API Version" error diagnostic
+// and returns false when configured is below min. subject names what's
+// being gated (e.g. "Runner data sources"), used in the diagnostic message.
+//
+// Comparing the two version strings lexicographically, as several call sites
+// in this provider still do (`clients.APIVersion < "56"`), is wrong whenever
+// they differ in digit count: "9" < "56" is false under Go's string
+// ordering, so a genuinely older single-digit version incorrectly passes a
+// ">= 56" check. This compares them as integers instead.
+func requireMinAPIVersion(diags *diag.Diagnostics, configured string, min int, subject string) bool {
+	version, err := strconv.Atoi(configured)
+	if err == nil && version >= min {
+		return true
+	}
+	diags.AddError(
+		"Insufficient API Version",
+		fmt.Sprintf(
+			"%s require API version %d or higher (currently configured: %s). Please update your provider configuration with api_version = \"%d\" or higher.",
+			subject, min, configured, min,
+		),
+	)
+	return false
+}

--- a/rundeck/api_version_test.go
+++ b/rundeck/api_version_test.go
@@ -1,0 +1,59 @@
+package rundeck
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func TestRequireMinAPIVersion_sufficient(t *testing.T) {
+	var diags diag.Diagnostics
+	if !requireMinAPIVersion(&diags, "56", 44, "Test resources") {
+		t.Error("got false, want true for a sufficient version")
+	}
+	if diags.HasError() {
+		t.Errorf("unexpected diagnostics: %v", diags)
+	}
+}
+
+func TestRequireMinAPIVersion_insufficient(t *testing.T) {
+	var diags diag.Diagnostics
+	if requireMinAPIVersion(&diags, "20", 44, "Test resources") {
+		t.Error("got true, want false for an insufficient version")
+	}
+	if !diags.HasError() {
+		t.Fatal("want an error diagnostic for an insufficient version")
+	}
+	if summary := diags[0].Summary(); summary != "Insufficient API Version" {
+		t.Errorf("summary = %q, want %q", summary, "Insufficient API Version")
+	}
+}
+
+// A numeric-but-too-low version and a non-numeric one are different
+// problems and should produce different diagnostics: the first is a real
+// version mismatch, the second is a configuration mistake.
+func TestRequireMinAPIVersion_invalid(t *testing.T) {
+	var diags diag.Diagnostics
+	if requireMinAPIVersion(&diags, "v56", 44, "Test resources") {
+		t.Error("got true, want false for a non-numeric version")
+	}
+	if !diags.HasError() {
+		t.Fatal("want an error diagnostic for a non-numeric version")
+	}
+	if summary := diags[0].Summary(); summary != "Invalid API Version" {
+		t.Errorf("summary = %q, want %q", summary, "Invalid API Version")
+	}
+}
+
+// api_version commonly comes from an environment variable, which can carry
+// leading/trailing whitespace (e.g. a trailing newline) without the user
+// noticing.
+func TestRequireMinAPIVersion_trimsWhitespace(t *testing.T) {
+	var diags diag.Diagnostics
+	if !requireMinAPIVersion(&diags, " 56\n", 44, "Test resources") {
+		t.Error("got false, want true for a sufficient version with surrounding whitespace")
+	}
+	if diags.HasError() {
+		t.Errorf("unexpected diagnostics: %v", diags)
+	}
+}

--- a/rundeck/data_source_runner_framework.go
+++ b/rundeck/data_source_runner_framework.go
@@ -1,0 +1,372 @@
+package rundeck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	openapi "github.com/rundeck/go-rundeck/rundeck-v2"
+)
+
+var (
+	_ datasource.DataSource              = &runnerDataSource{}
+	_ datasource.DataSourceWithConfigure = &runnerDataSource{}
+)
+
+func NewRunnerDataSource() datasource.DataSource {
+	return &runnerDataSource{}
+}
+
+type runnerDataSource struct {
+	clients *RundeckClients
+}
+
+type runnerProjectAssociationModel struct {
+	ProjectName         types.String `tfsdk:"project_name"`
+	NodeFilter          types.String `tfsdk:"node_filter"`
+	RunnerAsNodeEnabled types.Bool   `tfsdk:"runner_as_node_enabled"`
+	RemoteNodeDispatch  types.Bool   `tfsdk:"remote_node_dispatch"`
+	RunnerNodeFilter    types.String `tfsdk:"runner_node_filter"`
+}
+
+type runnerDataSourceModel struct {
+	ID                  types.String                    `tfsdk:"id"`
+	RunnerID            types.String                    `tfsdk:"runner_id"`
+	Name                types.String                    `tfsdk:"name"`
+	Description         types.String                    `tfsdk:"description"`
+	Status              types.String                    `tfsdk:"status"`
+	Version             types.String                    `tfsdk:"version"`
+	TagNames            RunnerTagsValue                 `tfsdk:"tag_names"`
+	RunnerAsNodeEnabled types.Bool                      `tfsdk:"runner_as_node_enabled"`
+	RemoteNodeDispatch  types.Bool                      `tfsdk:"remote_node_dispatch"`
+	RunnerNodeFilter    types.String                    `tfsdk:"runner_node_filter"`
+	Hostname            types.String                    `tfsdk:"hostname"`
+	OsFamily            types.String                    `tfsdk:"os_family"`
+	ReplicaType         types.String                    `tfsdk:"replica_type"`
+	InstallationType    types.String                    `tfsdk:"installation_type"`
+	DateCreated         types.String                    `tfsdk:"date_created"`
+	LastUpdated         types.String                    `tfsdk:"last_updated"`
+	LastCheckin         types.String                    `tfsdk:"last_checkin"`
+	Uptime              types.Int64                     `tfsdk:"uptime"`
+	RunningOperations   types.Int64                     `tfsdk:"running_operations"`
+	ProjectAssociations []runnerProjectAssociationModel `tfsdk:"project_associations"`
+}
+
+func (d *runnerDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_runner"
+}
+
+func (d *runnerDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieves information about a single Rundeck runner (system or project scoped).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of this data source (same as runner_id).",
+				Computed:    true,
+			},
+			"runner_id": schema.StringAttribute{
+				Description: "ID of the runner to look up.",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the runner.",
+				Computed:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "Description of the runner.",
+				Computed:    true,
+			},
+			"status": schema.StringAttribute{
+				Description: "Current status of the runner.",
+				Computed:    true,
+			},
+			"version": schema.StringAttribute{
+				Description: "Runner software version.",
+				Computed:    true,
+			},
+			"tag_names": schema.StringAttribute{
+				Description: "Comma separated tags for the runner.",
+				Computed:    true,
+				CustomType:  RunnerTagsType{},
+			},
+			"runner_as_node_enabled": schema.BoolAttribute{
+				Description: "Whether the runner acts as a node.",
+				Computed:    true,
+			},
+			"remote_node_dispatch": schema.BoolAttribute{
+				Description: "Whether remote node dispatch is enabled for the runner.",
+				Computed:    true,
+			},
+			"runner_node_filter": schema.StringAttribute{
+				Description: "Node filter string for the runner.",
+				Computed:    true,
+			},
+			"hostname": schema.StringAttribute{
+				Description: "Hostname the runner is running on.",
+				Computed:    true,
+			},
+			"os_family": schema.StringAttribute{
+				Description: "Operating system family of the runner host.",
+				Computed:    true,
+			},
+			"replica_type": schema.StringAttribute{
+				Description: "Replica type of the runner (manual or ephemeral).",
+				Computed:    true,
+			},
+			"installation_type": schema.StringAttribute{
+				Description: "Installation type of the runner (linux, windows, kubernetes, docker).",
+				Computed:    true,
+			},
+			"date_created": schema.StringAttribute{
+				Description: "Timestamp the runner was created, in RFC3339 format.",
+				Computed:    true,
+			},
+			"last_updated": schema.StringAttribute{
+				Description: "Timestamp the runner was last updated, in RFC3339 format.",
+				Computed:    true,
+			},
+			"last_checkin": schema.StringAttribute{
+				Description: "Timestamp of the runner's last check-in.",
+				Computed:    true,
+			},
+			"uptime": schema.Int64Attribute{
+				Description: "Runner uptime, in seconds.",
+				Computed:    true,
+			},
+			"running_operations": schema.Int64Attribute{
+				Description: "Number of operations currently running on the runner.",
+				Computed:    true,
+			},
+			"project_associations": schema.ListNestedAttribute{
+				Description: "Per-project dispatch settings associated with this runner.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"project_name": schema.StringAttribute{
+							Description: "Name of the associated project.",
+							Computed:    true,
+						},
+						"node_filter": schema.StringAttribute{
+							Description: "Node filter configured for this project association.",
+							Computed:    true,
+						},
+						"runner_as_node_enabled": schema.BoolAttribute{
+							Description: "Whether the runner acts as a node for this project.",
+							Computed:    true,
+						},
+						"remote_node_dispatch": schema.BoolAttribute{
+							Description: "Whether remote node dispatch is enabled for this project.",
+							Computed:    true,
+						},
+						"runner_node_filter": schema.StringAttribute{
+							Description: "Runner node filter configured for this project.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *runnerDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clients, ok := req.ProviderData.(*RundeckClients)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *RundeckClients, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	// Runner management requires API v56+ (Enterprise feature)
+	if clients.APIVersion < "56" {
+		resp.Diagnostics.AddError(
+			"Insufficient API Version",
+			fmt.Sprintf("Runner data sources require API version 56 or higher (currently configured: %s). Please update your provider configuration with api_version = \"56\" or higher.", clients.APIVersion),
+		)
+		return
+	}
+
+	d.clients = clients
+}
+
+func (d *runnerDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config runnerDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := d.clients.V2
+	apiCtx := d.clients.ctx
+	runnerId := config.RunnerID.ValueString()
+
+	// Use the general RunnerInfo endpoint rather than ProjectRunnerInfo, matching
+	// the precedent set by rundeck_project_runner (ProjectRunnerInfo is unreliable).
+	runnerInfo, apiResp, err := client.RunnerAPI.RunnerInfo(apiCtx, runnerId).Execute()
+
+	if apiResp != nil && apiResp.StatusCode == 404 {
+		resp.Diagnostics.AddError(
+			"Runner Not Found",
+			fmt.Sprintf("No runner found with ID %s.", runnerId),
+		)
+		return
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading runner",
+			fmt.Sprintf("Could not read runner %s: %s", runnerId, err.Error()),
+		)
+		return
+	}
+
+	if runnerInfo == nil {
+		resp.Diagnostics.AddError(
+			"Runner Not Found",
+			fmt.Sprintf("No runner found with ID %s.", runnerId),
+		)
+		return
+	}
+
+	state := runnerDataSourceModel{
+		ID:       config.RunnerID,
+		RunnerID: config.RunnerID,
+	}
+
+	if runnerInfo.Id != nil {
+		state.ID = types.StringValue(*runnerInfo.Id)
+		state.RunnerID = types.StringValue(*runnerInfo.Id)
+	}
+	if runnerInfo.Name != nil {
+		state.Name = types.StringValue(*runnerInfo.Name)
+	}
+	if runnerInfo.Description != nil {
+		state.Description = types.StringValue(*runnerInfo.Description)
+	}
+	if runnerInfo.Status != nil {
+		state.Status = types.StringValue(*runnerInfo.Status)
+	}
+	if runnerInfo.Version != nil {
+		state.Version = types.StringValue(*runnerInfo.Version)
+	}
+	if runnerInfo.TagNames != nil {
+		state.TagNames = RunnerTagsValue{
+			StringValue: types.StringValue(normalizeRunnerTags(strings.Join(runnerInfo.TagNames, ","))),
+		}
+	} else {
+		state.TagNames = RunnerTagsValue{StringValue: types.StringValue("")}
+	}
+	if runnerInfo.RunnerAsNodeEnabled != nil {
+		state.RunnerAsNodeEnabled = types.BoolValue(*runnerInfo.RunnerAsNodeEnabled)
+	}
+	if runnerInfo.RemoteNodeDispatch != nil {
+		state.RemoteNodeDispatch = types.BoolValue(*runnerInfo.RemoteNodeDispatch)
+	}
+	if runnerInfo.RunnerNodeFilter != nil {
+		state.RunnerNodeFilter = types.StringValue(*runnerInfo.RunnerNodeFilter)
+	}
+	if runnerInfo.Hostname != nil {
+		state.Hostname = types.StringValue(*runnerInfo.Hostname)
+	}
+	if runnerInfo.OsFamily != nil {
+		state.OsFamily = types.StringValue(*runnerInfo.OsFamily)
+	}
+	if runnerInfo.ReplicaType != nil {
+		state.ReplicaType = types.StringValue(string(*runnerInfo.ReplicaType))
+	}
+	if runnerInfo.InstallationType != nil {
+		state.InstallationType = types.StringValue(string(*runnerInfo.InstallationType))
+	}
+	if runnerInfo.DateCreated != nil {
+		state.DateCreated = types.StringValue(runnerInfo.DateCreated.Format("2006-01-02T15:04:05Z07:00"))
+	}
+	if runnerInfo.LastUpdated != nil {
+		state.LastUpdated = types.StringValue(runnerInfo.LastUpdated.Format("2006-01-02T15:04:05Z07:00"))
+	}
+	if runnerInfo.LastCheckin != nil {
+		state.LastCheckin = types.StringValue(*runnerInfo.LastCheckin)
+	}
+	if runnerInfo.Uptime != nil {
+		state.Uptime = types.Int64Value(*runnerInfo.Uptime)
+	}
+	if runnerInfo.RunningOperations != nil {
+		state.RunningOperations = types.Int64Value(int64(*runnerInfo.RunningOperations))
+	}
+
+	state.ProjectAssociations = flattenRunnerProjectAssociations(runnerInfo.ProjectAssociations)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// flattenRunnerProjectAssociations unions the keys across the API's four
+// parallel per-project maps into a single list of per-project objects.
+func flattenRunnerProjectAssociations(assoc *openapi.RunnerProjectAssociations) []runnerProjectAssociationModel {
+	if assoc == nil {
+		return nil
+	}
+
+	projectNames := map[string]struct{}{}
+	if assoc.ProjectNodeFilters != nil {
+		for k := range *assoc.ProjectNodeFilters {
+			projectNames[k] = struct{}{}
+		}
+	}
+	if assoc.ProjectRunnerAsNodeEnabled != nil {
+		for k := range *assoc.ProjectRunnerAsNodeEnabled {
+			projectNames[k] = struct{}{}
+		}
+	}
+	if assoc.ProjectRemoteNodeDispatch != nil {
+		for k := range *assoc.ProjectRemoteNodeDispatch {
+			projectNames[k] = struct{}{}
+		}
+	}
+	if assoc.ProjectRunnerNodeFilter != nil {
+		for k := range *assoc.ProjectRunnerNodeFilter {
+			projectNames[k] = struct{}{}
+		}
+	}
+
+	if len(projectNames) == 0 {
+		return nil
+	}
+
+	result := make([]runnerProjectAssociationModel, 0, len(projectNames))
+	for name := range projectNames {
+		item := runnerProjectAssociationModel{ProjectName: types.StringValue(name)}
+		if assoc.ProjectNodeFilters != nil {
+			if v, ok := (*assoc.ProjectNodeFilters)[name]; ok {
+				item.NodeFilter = types.StringValue(v)
+			}
+		}
+		if assoc.ProjectRunnerAsNodeEnabled != nil {
+			if v, ok := (*assoc.ProjectRunnerAsNodeEnabled)[name]; ok {
+				item.RunnerAsNodeEnabled = types.BoolValue(v)
+			}
+		}
+		if assoc.ProjectRemoteNodeDispatch != nil {
+			if v, ok := (*assoc.ProjectRemoteNodeDispatch)[name]; ok {
+				item.RemoteNodeDispatch = types.BoolValue(v)
+			}
+		}
+		if assoc.ProjectRunnerNodeFilter != nil {
+			if v, ok := (*assoc.ProjectRunnerNodeFilter)[name]; ok {
+				item.RunnerNodeFilter = types.StringValue(v)
+			}
+		}
+		result = append(result, item)
+	}
+
+	return result
+}

--- a/rundeck/data_source_runner_framework.go
+++ b/rundeck/data_source_runner_framework.go
@@ -188,11 +188,7 @@ func (d *runnerDataSource) Configure(_ context.Context, req datasource.Configure
 	}
 
 	// Runner management requires API v56+ (Enterprise feature)
-	if clients.APIVersion < "56" {
-		resp.Diagnostics.AddError(
-			"Insufficient API Version",
-			fmt.Sprintf("Runner data sources require API version 56 or higher (currently configured: %s). Please update your provider configuration with api_version = \"56\" or higher.", clients.APIVersion),
-		)
+	if !requireMinAPIVersion(&resp.Diagnostics, clients.APIVersion, 56, "Runner data sources") {
 		return
 	}
 

--- a/rundeck/data_source_runner_framework.go
+++ b/rundeck/data_source_runner_framework.go
@@ -3,6 +3,7 @@ package rundeck
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -338,8 +339,18 @@ func flattenRunnerProjectAssociations(assoc *openapi.RunnerProjectAssociations) 
 		return nil
 	}
 
-	result := make([]runnerProjectAssociationModel, 0, len(projectNames))
+	// Sort project names before building the list: ranging over a map
+	// directly would make the resulting list's order nondeterministic
+	// between reads, showing up as a noisy diff on every refresh even when
+	// the underlying associations haven't changed.
+	sortedNames := make([]string, 0, len(projectNames))
 	for name := range projectNames {
+		sortedNames = append(sortedNames, name)
+	}
+	sort.Strings(sortedNames)
+
+	result := make([]runnerProjectAssociationModel, 0, len(projectNames))
+	for _, name := range sortedNames {
 		item := runnerProjectAssociationModel{ProjectName: types.StringValue(name)}
 		if assoc.ProjectNodeFilters != nil {
 			if v, ok := (*assoc.ProjectNodeFilters)[name]; ok {

--- a/rundeck/data_source_runner_helpers_test.go
+++ b/rundeck/data_source_runner_helpers_test.go
@@ -1,0 +1,42 @@
+package rundeck
+
+import (
+	"testing"
+
+	openapi "github.com/rundeck/go-rundeck/rundeck-v2"
+)
+
+// flattenRunnerProjectAssociations previously ranged over a map to build its
+// result, making the list order nondeterministic between reads - a noisy
+// diff for a data source even when nothing about the associations changed.
+func TestFlattenRunnerProjectAssociations_sortedByProjectName(t *testing.T) {
+	nodeFilters := map[string]string{
+		"zebra": "tag:z",
+		"alpha": "tag:a",
+		"mike":  "tag:m",
+	}
+	assoc := &openapi.RunnerProjectAssociations{
+		ProjectNodeFilters: &nodeFilters,
+	}
+
+	result := flattenRunnerProjectAssociations(assoc)
+
+	if len(result) != 3 {
+		t.Fatalf("got %d entries, want 3", len(result))
+	}
+	want := []string{"alpha", "mike", "zebra"}
+	for i, name := range want {
+		if got := result[i].ProjectName.ValueString(); got != name {
+			t.Errorf("result[%d].ProjectName = %q, want %q (result not sorted: %v)", i, got, name, result)
+		}
+	}
+}
+
+func TestFlattenRunnerProjectAssociations_nilWhenEmpty(t *testing.T) {
+	if got := flattenRunnerProjectAssociations(nil); got != nil {
+		t.Errorf("got %v, want nil for a nil association", got)
+	}
+	if got := flattenRunnerProjectAssociations(&openapi.RunnerProjectAssociations{}); got != nil {
+		t.Errorf("got %v, want nil when no project has any association", got)
+	}
+}

--- a/rundeck/data_source_runner_tags_framework.go
+++ b/rundeck/data_source_runner_tags_framework.go
@@ -69,11 +69,7 @@ func (d *runnerTagsDataSource) Configure(_ context.Context, req datasource.Confi
 	}
 
 	// Runner management requires API v56+ (Enterprise feature)
-	if clients.APIVersion < "56" {
-		resp.Diagnostics.AddError(
-			"Insufficient API Version",
-			fmt.Sprintf("Runner data sources require API version 56 or higher (currently configured: %s). Please update your provider configuration with api_version = \"56\" or higher.", clients.APIVersion),
-		)
+	if !requireMinAPIVersion(&resp.Diagnostics, clients.APIVersion, 56, "Runner data sources") {
 		return
 	}
 

--- a/rundeck/data_source_runner_tags_framework.go
+++ b/rundeck/data_source_runner_tags_framework.go
@@ -1,0 +1,125 @@
+package rundeck
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ datasource.DataSource              = &runnerTagsDataSource{}
+	_ datasource.DataSourceWithConfigure = &runnerTagsDataSource{}
+)
+
+func NewRunnerTagsDataSource() datasource.DataSource {
+	return &runnerTagsDataSource{}
+}
+
+type runnerTagsDataSource struct {
+	clients *RundeckClients
+}
+
+type runnerTagsDataSourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	ProjectName types.String `tfsdk:"project_name"`
+	Tags        types.Map    `tfsdk:"tags"`
+}
+
+func (d *runnerTagsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_runner_tags"
+}
+
+func (d *runnerTagsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Looks up runner tags in use and their usage counts for a project. The underlying Rundeck API requires a project scope; there is no system-wide mode for this endpoint.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of this data source (same as project_name).",
+				Computed:    true,
+			},
+			"project_name": schema.StringAttribute{
+				Description: "Scope tag discovery to runners associated with this project.",
+				Required:    true,
+			},
+			"tags": schema.MapAttribute{
+				Description: "Map of tag name to the number of runners using that tag.",
+				Computed:    true,
+				ElementType: types.Int64Type,
+			},
+		},
+	}
+}
+
+func (d *runnerTagsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clients, ok := req.ProviderData.(*RundeckClients)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *RundeckClients, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	// Runner management requires API v56+ (Enterprise feature)
+	if clients.APIVersion < "56" {
+		resp.Diagnostics.AddError(
+			"Insufficient API Version",
+			fmt.Sprintf("Runner data sources require API version 56 or higher (currently configured: %s). Please update your provider configuration with api_version = \"56\" or higher.", clients.APIVersion),
+		)
+		return
+	}
+
+	d.clients = clients
+}
+
+func (d *runnerTagsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config runnerTagsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := d.clients.V2
+	apiCtx := d.clients.ctx
+
+	tagsReq := client.RunnerAPI.ListProjectAssociatedTags(apiCtx).Project(config.ProjectName.ValueString())
+
+	tagCounts, _, err := tagsReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing runner tags",
+			fmt.Sprintf("Could not list runner tags: %s", err.Error()),
+		)
+		return
+	}
+
+	tagValues := make(map[string]attr.Value)
+	if tagCounts != nil && tagCounts.Tags != nil {
+		for name, count := range *tagCounts.Tags {
+			tagValues[name] = types.Int64Value(int64(count))
+		}
+	}
+
+	tagsMap, diags := types.MapValue(types.Int64Type, tagValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state := runnerTagsDataSourceModel{
+		ID:          config.ProjectName,
+		ProjectName: config.ProjectName,
+		Tags:        tagsMap,
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/rundeck/data_source_runner_test.go
+++ b/rundeck/data_source_runner_test.go
@@ -1,0 +1,137 @@
+package rundeck
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	openapi "github.com/rundeck/go-rundeck/rundeck-v2"
+)
+
+func TestAccRundeckRunnerDataSource_basic(t *testing.T) {
+	if os.Getenv("RUNDECK_ENTERPRISE_TESTS") != "1" {
+		t.Skip("ENTERPRISE ONLY: Runners (requires Rundeck 5.17.0+, API v56+) - set RUNDECK_ENTERPRISE_TESTS=1")
+	}
+
+	var runner openapi.RunnerInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccSystemRunnerCheckDestroy(&runner),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckRunnerDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckResourceAttrPair("data.rundeck_runner.test", "runner_id", "rundeck_system_runner.test", "runner_id"),
+					resource.TestCheckResourceAttr("data.rundeck_runner.test", "name", "test-datasource-runner"),
+					resource.TestCheckResourceAttr("data.rundeck_runner.test", "description", "Test runner for data source"),
+					resource.TestCheckResourceAttr("data.rundeck_runner.test", "tag_names", "terraform,test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRundeckRunnersDataSource_basic(t *testing.T) {
+	if os.Getenv("RUNDECK_ENTERPRISE_TESTS") != "1" {
+		t.Skip("ENTERPRISE ONLY: Runners (requires Rundeck 5.17.0+, API v56+) - set RUNDECK_ENTERPRISE_TESTS=1")
+	}
+
+	var runner openapi.RunnerInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccSystemRunnerCheckDestroy(&runner),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckRunnersDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckResourceAttrSet("data.rundeck_runners.test", "runners.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRundeckRunnerTagsDataSource_basic(t *testing.T) {
+	if os.Getenv("RUNDECK_ENTERPRISE_TESTS") != "1" {
+		t.Skip("ENTERPRISE ONLY: Runners (requires Rundeck 5.17.0+, API v56+) - set RUNDECK_ENTERPRISE_TESTS=1")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckRunnerTagsDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.rundeck_runner_tags.test", "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+const testAccRundeckRunnerDataSourceConfig_basic = `
+resource "rundeck_system_runner" "test" {
+  name              = "test-datasource-runner"
+  description       = "Test runner for data source"
+  tag_names         = "terraform,test"
+  installation_type = "linux"
+  replica_type      = "manual"
+}
+
+data "rundeck_runner" "test" {
+  runner_id = rundeck_system_runner.test.runner_id
+}
+`
+
+const testAccRundeckRunnersDataSourceConfig_basic = `
+resource "rundeck_system_runner" "test" {
+  name              = "test-datasource-runners"
+  description       = "Test runner for runners data source"
+  tag_names         = "terraform,test"
+  installation_type = "linux"
+  replica_type      = "manual"
+}
+
+data "rundeck_runners" "test" {
+  tags = "terraform"
+
+  depends_on = [rundeck_system_runner.test]
+}
+`
+
+const testAccRundeckRunnerTagsDataSourceConfig_basic = `
+resource "rundeck_project" "test" {
+  name        = "test-project-runner-tags"
+  description = "Terraform acceptance test project for runner_tags data source"
+
+  resource_model_source {
+    type   = "local"
+    config = {}
+  }
+}
+
+resource "rundeck_system_runner" "test" {
+  name              = "test-datasource-runner-tags"
+  description       = "Test runner for runner_tags data source"
+  tag_names         = "terraform,test"
+  installation_type = "linux"
+  replica_type      = "manual"
+
+  assigned_projects = {
+    (rundeck_project.test.name) = "read"
+  }
+}
+
+data "rundeck_runner_tags" "test" {
+  project_name = rundeck_project.test.name
+
+  depends_on = [rundeck_system_runner.test]
+}
+`

--- a/rundeck/data_source_runners_framework.go
+++ b/rundeck/data_source_runners_framework.go
@@ -166,11 +166,7 @@ func (d *runnersDataSource) Configure(_ context.Context, req datasource.Configur
 	}
 
 	// Runner management requires API v56+ (Enterprise feature)
-	if clients.APIVersion < "56" {
-		resp.Diagnostics.AddError(
-			"Insufficient API Version",
-			fmt.Sprintf("Runner data sources require API version 56 or higher (currently configured: %s). Please update your provider configuration with api_version = \"56\" or higher.", clients.APIVersion),
-		)
+	if !requireMinAPIVersion(&resp.Diagnostics, clients.APIVersion, 56, "Runner data sources") {
 		return
 	}
 

--- a/rundeck/data_source_runners_framework.go
+++ b/rundeck/data_source_runners_framework.go
@@ -1,0 +1,346 @@
+package rundeck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	openapi "github.com/rundeck/go-rundeck/rundeck-v2"
+)
+
+var (
+	_ datasource.DataSource              = &runnersDataSource{}
+	_ datasource.DataSourceWithConfigure = &runnersDataSource{}
+)
+
+func NewRunnersDataSource() datasource.DataSource {
+	return &runnersDataSource{}
+}
+
+type runnersDataSource struct {
+	clients *RundeckClients
+}
+
+type runnerProviderModel struct {
+	Provider    types.String `tfsdk:"provider"`
+	ServiceName types.String `tfsdk:"service_name"`
+	PluginName  types.String `tfsdk:"plugin_name"`
+}
+
+type runnerSummaryModel struct {
+	ID                    types.String          `tfsdk:"id"`
+	Name                  types.String          `tfsdk:"name"`
+	Description           types.String          `tfsdk:"description"`
+	Status                types.String          `tfsdk:"status"`
+	Version               types.String          `tfsdk:"version"`
+	AssociatedProjects    types.Int64           `tfsdk:"associated_projects"`
+	LastCheckin           types.String          `tfsdk:"last_checkin"`
+	RunnerAsNodeEnabled   types.Bool            `tfsdk:"runner_as_node_enabled"`
+	TagNames              RunnerTagsValue       `tfsdk:"tag_names"`
+	RunnerNodeFilter      types.String          `tfsdk:"runner_node_filter"`
+	RemoteNodeDispatch    types.Bool            `tfsdk:"remote_node_dispatch"`
+	Hostname              types.String          `tfsdk:"hostname"`
+	OsFamily              types.String          `tfsdk:"os_family"`
+	ReplicaType           types.String          `tfsdk:"replica_type"`
+	InstallationType      types.String          `tfsdk:"installation_type"`
+	Providers             []runnerProviderModel `tfsdk:"providers"`
+	RunnerReplicas        types.Int64           `tfsdk:"runner_replicas"`
+	HealthyRunnerReplicas types.Int64           `tfsdk:"healthy_runner_replicas"`
+	RunningOperations     types.Int64           `tfsdk:"running_operations"`
+	Uptime                types.Int64           `tfsdk:"uptime"`
+	DateCreated           types.String          `tfsdk:"date_created"`
+	LastUpdated           types.String          `tfsdk:"last_updated"`
+}
+
+type runnersDataSourceModel struct {
+	ID          types.String         `tfsdk:"id"`
+	ProjectName types.String         `tfsdk:"project_name"`
+	Tags        types.String         `tfsdk:"tags"`
+	Status      types.String         `tfsdk:"status"`
+	Filter      types.String         `tfsdk:"filter"`
+	LocalOnly   types.Bool           `tfsdk:"local_only"`
+	Runners     []runnerSummaryModel `tfsdk:"runners"`
+}
+
+func (d *runnersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_runners"
+}
+
+func (d *runnersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	runnerSummaryAttributes := map[string]schema.Attribute{
+		"id":          schema.StringAttribute{Computed: true, Description: "ID of the runner."},
+		"name":        schema.StringAttribute{Computed: true, Description: "Name of the runner."},
+		"description": schema.StringAttribute{Computed: true, Description: "Description of the runner."},
+		"status":      schema.StringAttribute{Computed: true, Description: "Current status of the runner."},
+		"version":     schema.StringAttribute{Computed: true, Description: "Runner software version."},
+		"associated_projects": schema.Int64Attribute{
+			Computed:    true,
+			Description: "Number of projects this runner is associated with.",
+		},
+		"last_checkin":           schema.StringAttribute{Computed: true, Description: "Timestamp of the runner's last check-in."},
+		"runner_as_node_enabled": schema.BoolAttribute{Computed: true, Description: "Whether the runner acts as a node."},
+		"tag_names": schema.StringAttribute{
+			Computed:    true,
+			Description: "Comma separated tags for the runner.",
+			CustomType:  RunnerTagsType{},
+		},
+		"runner_node_filter":   schema.StringAttribute{Computed: true, Description: "Node filter string for the runner."},
+		"remote_node_dispatch": schema.BoolAttribute{Computed: true, Description: "Whether remote node dispatch is enabled."},
+		"hostname":             schema.StringAttribute{Computed: true, Description: "Hostname the runner is running on."},
+		"os_family":            schema.StringAttribute{Computed: true, Description: "Operating system family of the runner host."},
+		"replica_type":         schema.StringAttribute{Computed: true, Description: "Replica type of the runner (manual or ephemeral)."},
+		"installation_type":    schema.StringAttribute{Computed: true, Description: "Installation type of the runner."},
+		"providers": schema.ListNestedAttribute{
+			Computed:    true,
+			Description: "Plugin providers (node/step/etc) this runner handles.",
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"provider":     schema.StringAttribute{Computed: true, Description: "Provider name."},
+					"service_name": schema.StringAttribute{Computed: true, Description: "Service name."},
+					"plugin_name":  schema.StringAttribute{Computed: true, Description: "Plugin name."},
+				},
+			},
+		},
+		"runner_replicas":         schema.Int64Attribute{Computed: true, Description: "Number of replicas registered for this runner."},
+		"healthy_runner_replicas": schema.Int64Attribute{Computed: true, Description: "Number of healthy replicas registered for this runner."},
+		"running_operations":      schema.Int64Attribute{Computed: true, Description: "Number of operations currently running on the runner."},
+		"uptime":                  schema.Int64Attribute{Computed: true, Description: "Runner uptime, in seconds."},
+		"date_created":            schema.StringAttribute{Computed: true, Description: "Timestamp the runner was created, in RFC3339 format."},
+		"last_updated":            schema.StringAttribute{Computed: true, Description: "Timestamp the runner was last updated, in RFC3339 format."},
+	}
+
+	resp.Schema = schema.Schema{
+		Description: "Lists Rundeck runners, optionally scoped to a project and filtered by tags/status/filter string.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of this data source, derived from the given filters.",
+				Computed:    true,
+			},
+			"project_name": schema.StringAttribute{
+				Description: "If set, list runners assigned to this project instead of all system runners.",
+				Optional:    true,
+			},
+			"tags": schema.StringAttribute{
+				Description: "Comma separated list of tags to filter runners by.",
+				Optional:    true,
+			},
+			"status": schema.StringAttribute{
+				Description: "Filter runners by status.",
+				Optional:    true,
+			},
+			"filter": schema.StringAttribute{
+				Description: "Generic filter string passed through to the Rundeck API.",
+				Optional:    true,
+			},
+			"local_only": schema.BoolAttribute{
+				Description: "If true, only include the local runner.",
+				Optional:    true,
+			},
+			"runners": schema.ListNestedAttribute{
+				Description: "Runners matching the given filters.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: runnerSummaryAttributes,
+				},
+			},
+		},
+	}
+}
+
+func (d *runnersDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clients, ok := req.ProviderData.(*RundeckClients)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *RundeckClients, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	// Runner management requires API v56+ (Enterprise feature)
+	if clients.APIVersion < "56" {
+		resp.Diagnostics.AddError(
+			"Insufficient API Version",
+			fmt.Sprintf("Runner data sources require API version 56 or higher (currently configured: %s). Please update your provider configuration with api_version = \"56\" or higher.", clients.APIVersion),
+		)
+		return
+	}
+
+	d.clients = clients
+}
+
+func (d *runnersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config runnersDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := d.clients.V2
+	apiCtx := d.clients.ctx
+
+	var runnerList *openapi.RunnerList
+	var err error
+
+	if !config.ProjectName.IsNull() && !config.ProjectName.IsUnknown() && config.ProjectName.ValueString() != "" {
+		listReq := client.RunnerAPI.ListProjectRunners(apiCtx, config.ProjectName.ValueString())
+		if !config.Tags.IsNull() && !config.Tags.IsUnknown() {
+			listReq = listReq.Tags(config.Tags.ValueString())
+		}
+		if !config.Status.IsNull() && !config.Status.IsUnknown() {
+			listReq = listReq.Status(config.Status.ValueString())
+		}
+		if !config.Filter.IsNull() && !config.Filter.IsUnknown() {
+			listReq = listReq.Filter(config.Filter.ValueString())
+		}
+		if !config.LocalOnly.IsNull() && !config.LocalOnly.IsUnknown() {
+			listReq = listReq.LocalOnly(config.LocalOnly.ValueBool())
+		}
+		runnerList, _, err = listReq.Execute()
+	} else {
+		listReq := client.RunnerAPI.ListRunners(apiCtx)
+		if !config.Tags.IsNull() && !config.Tags.IsUnknown() {
+			listReq = listReq.Tags(config.Tags.ValueString())
+		}
+		if !config.Status.IsNull() && !config.Status.IsUnknown() {
+			listReq = listReq.Status(config.Status.ValueString())
+		}
+		if !config.Filter.IsNull() && !config.Filter.IsUnknown() {
+			listReq = listReq.Filter(config.Filter.ValueString())
+		}
+		if !config.LocalOnly.IsNull() && !config.LocalOnly.IsUnknown() {
+			listReq = listReq.LocalOnly(config.LocalOnly.ValueBool())
+		}
+		runnerList, _, err = listReq.Execute()
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error listing runners",
+			fmt.Sprintf("Could not list runners: %s", err.Error()),
+		)
+		return
+	}
+
+	state := config
+	state.Runners = nil
+
+	idParts := []string{}
+	for _, v := range []types.String{config.ProjectName, config.Tags, config.Status, config.Filter} {
+		if !v.IsNull() && !v.IsUnknown() && v.ValueString() != "" {
+			idParts = append(idParts, v.ValueString())
+		}
+	}
+	if !config.LocalOnly.IsNull() && !config.LocalOnly.IsUnknown() && config.LocalOnly.ValueBool() {
+		idParts = append(idParts, "local_only")
+	}
+	if len(idParts) == 0 {
+		state.ID = types.StringValue("all")
+	} else {
+		state.ID = types.StringValue(strings.Join(idParts, "/"))
+	}
+
+	if runnerList != nil {
+		for _, summary := range runnerList.Runners {
+			state.Runners = append(state.Runners, flattenRunnerSummary(summary))
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func flattenRunnerSummary(summary openapi.RunnerSummary) runnerSummaryModel {
+	item := runnerSummaryModel{
+		TagNames: RunnerTagsValue{StringValue: types.StringValue("")},
+	}
+
+	if summary.Id != nil {
+		item.ID = types.StringValue(*summary.Id)
+	}
+	if summary.Name != nil {
+		item.Name = types.StringValue(*summary.Name)
+	}
+	if summary.Description != nil {
+		item.Description = types.StringValue(*summary.Description)
+	}
+	if summary.Status != nil {
+		item.Status = types.StringValue(*summary.Status)
+	}
+	if summary.Version != nil {
+		item.Version = types.StringValue(*summary.Version)
+	}
+	if summary.AssociatedProjects != nil {
+		item.AssociatedProjects = types.Int64Value(int64(*summary.AssociatedProjects))
+	}
+	if summary.LastCheckin != nil {
+		item.LastCheckin = types.StringValue(*summary.LastCheckin)
+	}
+	if summary.RunnerAsNodeEnabled != nil {
+		item.RunnerAsNodeEnabled = types.BoolValue(*summary.RunnerAsNodeEnabled)
+	}
+	if summary.TagNames != nil {
+		item.TagNames = RunnerTagsValue{
+			StringValue: types.StringValue(normalizeRunnerTags(strings.Join(summary.TagNames, ","))),
+		}
+	}
+	if summary.RunnerNodeFilter != nil {
+		item.RunnerNodeFilter = types.StringValue(*summary.RunnerNodeFilter)
+	}
+	if summary.RemoteNodeDispatch != nil {
+		item.RemoteNodeDispatch = types.BoolValue(*summary.RemoteNodeDispatch)
+	}
+	if summary.Hostname != nil {
+		item.Hostname = types.StringValue(*summary.Hostname)
+	}
+	if summary.OsFamily != nil {
+		item.OsFamily = types.StringValue(*summary.OsFamily)
+	}
+	if summary.ReplicaType != nil {
+		item.ReplicaType = types.StringValue(string(*summary.ReplicaType))
+	}
+	if summary.InstallationType != nil {
+		item.InstallationType = types.StringValue(string(*summary.InstallationType))
+	}
+	for _, p := range summary.Providers {
+		provider := runnerProviderModel{}
+		if p.Provider != nil {
+			provider.Provider = types.StringValue(*p.Provider)
+		}
+		if p.ServiceName != nil {
+			provider.ServiceName = types.StringValue(*p.ServiceName)
+		}
+		if p.PluginName != nil {
+			provider.PluginName = types.StringValue(*p.PluginName)
+		}
+		item.Providers = append(item.Providers, provider)
+	}
+	if summary.RunnerReplicas != nil {
+		item.RunnerReplicas = types.Int64Value(int64(*summary.RunnerReplicas))
+	}
+	if summary.HealthyRunnerReplicas != nil {
+		item.HealthyRunnerReplicas = types.Int64Value(int64(*summary.HealthyRunnerReplicas))
+	}
+	if summary.RunningOperations != nil {
+		item.RunningOperations = types.Int64Value(int64(*summary.RunningOperations))
+	}
+	if summary.Uptime != nil {
+		item.Uptime = types.Int64Value(*summary.Uptime)
+	}
+	if summary.DateCreated != nil {
+		item.DateCreated = types.StringValue(summary.DateCreated.Format("2006-01-02T15:04:05Z07:00"))
+	}
+	if summary.LastUpdated != nil {
+		item.LastUpdated = types.StringValue(summary.LastUpdated.Format("2006-01-02T15:04:05Z07:00"))
+	}
+
+	return item
+}

--- a/rundeck/provider_framework.go
+++ b/rundeck/provider_framework.go
@@ -220,6 +220,8 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 
 func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		// Data sources will be added here if needed
+		NewRunnerDataSource,
+		NewRunnersDataSource,
+		NewRunnerTagsDataSource,
 	}
 }

--- a/rundeck/resource_project_framework.go
+++ b/rundeck/resource_project_framework.go
@@ -439,11 +439,20 @@ func (r *projectResource) readProject(ctx context.Context, apiCtx context.Contex
 	// result after apply" error and refresh drift (#248). Keyed by source number
 	// (list position + 1), matching how sources are written as resources.source.N.
 	priorNullConfigKeys := map[int][]string{}
+	// Likewise, remember which sources had an explicitly-configured empty map
+	// (config = {}) as opposed to an omitted/null config, so an empty result
+	// below is preserved as an empty map rather than collapsed to null (#248
+	// only handles omitted vs. present; a known-empty map is neither).
+	priorEmptyConfig := map[int]bool{}
 	if !state.ResourceModelSource.IsNull() && !state.ResourceModelSource.IsUnknown() {
 		var priorSources []resourceModelSourceModel
 		if d := state.ResourceModelSource.ElementsAs(ctx, &priorSources, false); !d.HasError() {
 			for i, ps := range priorSources {
 				if ps.Config.IsNull() || ps.Config.IsUnknown() {
+					continue
+				}
+				if len(ps.Config.Elements()) == 0 {
+					priorEmptyConfig[i+1] = true
 					continue
 				}
 				var nullKeys []string
@@ -531,10 +540,16 @@ func (r *projectResource) readProject(ctx context.Context, apiCtx context.Contex
 			Type: types.StringValue(source["type"].(string)),
 		}
 
-		// Only set Config if there are actual config values
-		// This prevents null != {} drift when config is omitted
+		// Only collapse an empty result to null when config was actually omitted.
+		// If the user explicitly wrote config = {}, preserve it as an empty map -
+		// collapsing it to null here caused "inconsistent result after apply"
+		// since the plan had a known (non-null) empty map.
 		if len(configMap) == 0 {
-			sourceModel.Config = types.MapNull(types.StringType)
+			if priorEmptyConfig[index] {
+				sourceModel.Config = types.MapValueMust(types.StringType, configMap)
+			} else {
+				sourceModel.Config = types.MapNull(types.StringType)
+			}
 		} else {
 			sourceModel.Config = types.MapValueMust(types.StringType, configMap)
 		}

--- a/rundeck/resource_system_runner_detach_test.go
+++ b/rundeck/resource_system_runner_detach_test.go
@@ -1,0 +1,114 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// removeMapKeys is what Update relies on to keep assigned_projects/
+// assigned_projects_config in state accurate for the projects it already
+// detached via RemoveProjectAssociation, even when a later SaveRunner call
+// in the same Update fails. These are plain unit tests for that pure
+// function: no live server is needed to exercise the partial-failure
+// correction path itself, only the (TF_ACC-gated) end-to-end behavior it
+// supports.
+
+func TestRemoveMapKeys_dropsGivenKeys(t *testing.T) {
+	ctx := context.Background()
+
+	m, diags := types.MapValue(types.StringType, map[string]attr.Value{
+		"proj-a": types.StringValue("read"),
+		"proj-b": types.StringValue("write"),
+		"proj-c": types.StringValue("admin"),
+	})
+	if diags.HasError() {
+		t.Fatalf("building test map: %v", diags)
+	}
+
+	got, diags := removeMapKeys(ctx, m, map[string]struct{}{"proj-b": {}})
+	if diags.HasError() {
+		t.Fatalf("removeMapKeys: %v", diags)
+	}
+
+	elements := got.Elements()
+	if _, exists := elements["proj-b"]; exists {
+		t.Errorf("proj-b still present, want it dropped")
+	}
+	if len(elements) != 2 {
+		t.Errorf("len(elements) = %d, want 2 (proj-a and proj-c preserved)", len(elements))
+	}
+	if _, ok := elements["proj-a"]; !ok {
+		t.Errorf("proj-a missing, want it preserved")
+	}
+	if _, ok := elements["proj-c"]; !ok {
+		t.Errorf("proj-c missing, want it preserved")
+	}
+}
+
+func TestRemoveMapKeys_noKeysIsNoOp(t *testing.T) {
+	ctx := context.Background()
+
+	m, diags := types.MapValue(types.StringType, map[string]attr.Value{
+		"proj-a": types.StringValue("read"),
+	})
+	if diags.HasError() {
+		t.Fatalf("building test map: %v", diags)
+	}
+
+	got, diags := removeMapKeys(ctx, m, map[string]struct{}{})
+	if diags.HasError() {
+		t.Fatalf("removeMapKeys: %v", diags)
+	}
+	if len(got.Elements()) != 1 {
+		t.Errorf("len(elements) = %d, want 1 (unchanged)", len(got.Elements()))
+	}
+}
+
+func TestRemoveMapKeys_nullMapStaysNull(t *testing.T) {
+	ctx := context.Background()
+
+	got, diags := removeMapKeys(ctx, types.MapNull(types.StringType), map[string]struct{}{"proj-a": {}})
+	if diags.HasError() {
+		t.Fatalf("removeMapKeys: %v", diags)
+	}
+	if !got.IsNull() {
+		t.Errorf("got = %v, want it to stay null", got)
+	}
+}
+
+// removeMapKeys works on any element type, since AssignedProjectsConfig's
+// element type is a nested object rather than a plain string.
+func TestRemoveMapKeys_nestedObjectElementType(t *testing.T) {
+	ctx := context.Background()
+
+	elemType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"access_level": types.StringType,
+	}}
+	objA, diags := types.ObjectValue(elemType.AttrTypes, map[string]attr.Value{
+		"access_level": types.StringValue("read"),
+	})
+	if diags.HasError() {
+		t.Fatalf("building object: %v", diags)
+	}
+
+	m, diags := types.MapValue(elemType, map[string]attr.Value{
+		"proj-a": objA,
+	})
+	if diags.HasError() {
+		t.Fatalf("building test map: %v", diags)
+	}
+
+	got, diags := removeMapKeys(ctx, m, map[string]struct{}{"proj-a": {}})
+	if diags.HasError() {
+		t.Fatalf("removeMapKeys: %v", diags)
+	}
+	if len(got.Elements()) != 0 {
+		t.Errorf("len(elements) = %d, want 0", len(got.Elements()))
+	}
+	if got.ElementType(ctx).String() != elemType.String() {
+		t.Errorf("element type = %v, want it preserved as %v", got.ElementType(ctx), elemType)
+	}
+}

--- a/rundeck/resource_system_runner_framework.go
+++ b/rundeck/resource_system_runner_framework.go
@@ -272,8 +272,11 @@ func (r *systemRunnerResource) Create(ctx context.Context, req resource.CreateRe
 	if err != nil {
 		errorMsg := err.Error()
 		if httpResp != nil {
-			bodyBytes, _ := io.ReadAll(httpResp.Body)
-			errorMsg = fmt.Sprintf("%s - Response: %s", err.Error(), string(bodyBytes))
+			bodyBytes, readErr := io.ReadAll(httpResp.Body)
+			httpResp.Body.Close()
+			if readErr == nil {
+				errorMsg = fmt.Sprintf("%s - Response: %s", err.Error(), string(bodyBytes))
+			}
 		}
 		resp.Diagnostics.AddError(
 			"Error creating system runner",

--- a/rundeck/resource_system_runner_framework.go
+++ b/rundeck/resource_system_runner_framework.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -195,11 +197,7 @@ func (r *systemRunnerResource) Configure(_ context.Context, req resource.Configu
 	}
 
 	// System runner requires API v56+ (Enterprise feature)
-	if clients.APIVersion < "56" {
-		resp.Diagnostics.AddError(
-			"Insufficient API Version",
-			fmt.Sprintf("System runner resources require API version 56 or higher (currently configured: %s). Please update your provider configuration with api_version = \"56\" or higher.", clients.APIVersion),
-		)
+	if !requireMinAPIVersion(&resp.Diagnostics, clients.APIVersion, 56, "System runner resources") {
 		return
 	}
 
@@ -491,6 +489,27 @@ func (r *systemRunnerResource) Read(ctx context.Context, req resource.ReadReques
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
+// removeMapKeys returns m with the given keys dropped, preserving its
+// original element type. Used to correct assigned_projects/
+// assigned_projects_config in state when a project was already detached
+// server-side via RemoveProjectAssociation but a later step in the same
+// Update call fails, so state doesn't keep claiming that project is still
+// assigned when the server has already dropped it.
+func removeMapKeys(ctx context.Context, m types.Map, keys map[string]struct{}) (types.Map, diag.Diagnostics) {
+	if m.IsNull() || m.IsUnknown() || len(keys) == 0 {
+		return m, nil
+	}
+	elements := m.Elements()
+	remaining := make(map[string]attr.Value, len(elements))
+	for k, v := range elements {
+		if _, drop := keys[k]; drop {
+			continue
+		}
+		remaining[k] = v
+	}
+	return types.MapValue(m.ElementType(ctx), remaining)
+}
+
 func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan systemRunnerResourceModel
 	var state systemRunnerResourceModel
@@ -573,6 +592,11 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 	// of the runner's project assignments.
 	assignedProjectsKnown := !plan.AssignedProjects.IsNull() && !plan.AssignedProjects.IsUnknown()
 	assignedProjectsConfigKnown := !plan.AssignedProjectsConfig.IsNull() && !plan.AssignedProjectsConfig.IsUnknown()
+	// Projects successfully detached via RemoveProjectAssociation below, before
+	// SaveRunner runs. If SaveRunner then fails, these are still gone
+	// server-side, so state has to reflect that even though nothing else in
+	// this Update took effect (see the SaveRunner error handling below).
+	detachedProjects := make(map[string]struct{})
 	if assignedProjectsKnown || assignedProjectsConfigKnown {
 		saveRequest.SetAssignedProjects(mergedProjects)
 
@@ -613,7 +637,9 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 					"Warning detaching project",
 					fmt.Sprintf("Failed to cleanly detach runner %s from project %s: %s", runnerId, projectName, err.Error()),
 				)
+				continue
 			}
+			detachedProjects[projectName] = struct{}{}
 		}
 	}
 
@@ -626,6 +652,22 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	if err != nil {
+		// SaveRunner failed, but any projects in detachedProjects were already
+		// detached server-side above. Update's response state is pre-seeded
+		// with the prior state, and returning without touching it here would
+		// leave those projects listed as still assigned even though the
+		// server has already dropped them.
+		if len(detachedProjects) > 0 {
+			correctedProjects, projDiags := removeMapKeys(ctx, state.AssignedProjects, detachedProjects)
+			resp.Diagnostics.Append(projDiags...)
+			correctedConfig, configDiags := removeMapKeys(ctx, state.AssignedProjectsConfig, detachedProjects)
+			resp.Diagnostics.Append(configDiags...)
+			if !projDiags.HasError() && !configDiags.HasError() {
+				state.AssignedProjects = correctedProjects
+				state.AssignedProjectsConfig = correctedConfig
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+			}
+		}
 		resp.Diagnostics.AddError(
 			"Error updating system runner",
 			fmt.Sprintf("Could not update system runner %s: %s", runnerId, err.Error()),

--- a/rundeck/resource_system_runner_framework.go
+++ b/rundeck/resource_system_runner_framework.go
@@ -634,6 +634,29 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 			if _, stillAssigned := mergedProjects[projectName]; stillAssigned {
 				continue
 			}
+
+			// RemoveProjectAssociation only clears the access-level
+			// association (confirmed against a live server: the resulting
+			// RunnerInfo's ProjectNodeFilters map loses the project, but
+			// ProjectRunnerAsNodeEnabled/ProjectRemoteNodeDispatch/
+			// ProjectRunnerNodeFilter are all left completely untouched -
+			// still at whatever they were last explicitly set to, not even
+			// reset to false). Explicitly reset those first, or a "detached"
+			// project can still have runner_as_node_enabled/
+			// remote_node_dispatch actively true server-side.
+			clearRequest := openapi.NewSaveProjectRunnerNodeDispatchSettingsRequest(runnerId)
+			clearRequest.SetRunnerAsNodeEnabled(false)
+			clearRequest.SetRemoteNodeDispatch(false)
+			clearRequest.SetRunnerNodeFilter("")
+			_, _, dispatchErr := client.RunnerAPI.SaveProjectRunnerNodeDispatchSettings(apiCtx, projectName).SaveProjectRunnerNodeDispatchSettingsRequest(*clearRequest).Execute()
+			if dispatchErr != nil {
+				resp.Diagnostics.AddWarning(
+					"Warning detaching project",
+					fmt.Sprintf("Failed to clear node dispatch settings for runner %s in project %s: %s", runnerId, projectName, dispatchErr.Error()),
+				)
+				continue
+			}
+
 			_, _, err := client.RunnerAPI.RemoveProjectAssociation(apiCtx, projectName, runnerId).Execute()
 			if err != nil {
 				resp.Diagnostics.AddWarning(

--- a/rundeck/resource_system_runner_framework.go
+++ b/rundeck/resource_system_runner_framework.go
@@ -270,11 +270,16 @@ func (r *systemRunnerResource) Create(ctx context.Context, req resource.CreateRe
 	runnerRequest.SetReplicaType(strings.ToLower(replicaType))
 
 	// Create the system runner
-	response, _, err := client.RunnerAPI.CreateRunner(apiCtx).CreateProjectRunnerRequest(*runnerRequest).Execute()
+	response, httpResp, err := client.RunnerAPI.CreateRunner(apiCtx).CreateProjectRunnerRequest(*runnerRequest).Execute()
 	if err != nil {
+		errorMsg := err.Error()
+		if httpResp != nil {
+			bodyBytes, _ := io.ReadAll(httpResp.Body)
+			errorMsg = fmt.Sprintf("%s - Response: %s", err.Error(), string(bodyBytes))
+		}
 		resp.Diagnostics.AddError(
 			"Error creating system runner",
-			fmt.Sprintf("Could not create system runner: %s", err.Error()),
+			fmt.Sprintf("Could not create system runner: %s", errorMsg),
 		)
 		return
 	}
@@ -570,6 +575,46 @@ func (r *systemRunnerResource) Update(ctx context.Context, req resource.UpdateRe
 	assignedProjectsConfigKnown := !plan.AssignedProjectsConfig.IsNull() && !plan.AssignedProjectsConfig.IsUnknown()
 	if assignedProjectsKnown || assignedProjectsConfigKnown {
 		saveRequest.SetAssignedProjects(mergedProjects)
+
+		// SaveRunner's AssignedProjects is a single map[string]string, and there is no
+		// confirmed guarantee it also clears the other three per-project dispatch-setting
+		// maps (RunnerProjectAssociations) server-side for a project that's being dropped.
+		// Explicitly detach any project that was previously assigned but is no longer in
+		// the merged set, via RemoveProjectAssociation, before saving the smaller map.
+		priorProjects := make(map[string]struct{})
+		if !state.AssignedProjects.IsNull() && !state.AssignedProjects.IsUnknown() {
+			prior := make(map[string]types.String)
+			resp.Diagnostics.Append(state.AssignedProjects.ElementsAs(ctx, &prior, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			for k := range prior {
+				priorProjects[k] = struct{}{}
+			}
+		}
+		if !state.AssignedProjectsConfig.IsNull() && !state.AssignedProjectsConfig.IsUnknown() {
+			priorConfigs := make(map[string]projectRunnerConfig)
+			resp.Diagnostics.Append(state.AssignedProjectsConfig.ElementsAs(ctx, &priorConfigs, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			for k := range priorConfigs {
+				priorProjects[k] = struct{}{}
+			}
+		}
+
+		for projectName := range priorProjects {
+			if _, stillAssigned := mergedProjects[projectName]; stillAssigned {
+				continue
+			}
+			_, _, err := client.RunnerAPI.RemoveProjectAssociation(apiCtx, projectName, runnerId).Execute()
+			if err != nil {
+				resp.Diagnostics.AddWarning(
+					"Warning detaching project",
+					fmt.Sprintf("Failed to cleanly detach runner %s from project %s: %s", runnerId, projectName, err.Error()),
+				)
+			}
+		}
 	}
 
 	// Execute the save request

--- a/rundeck/resource_system_runner_test.go
+++ b/rundeck/resource_system_runner_test.go
@@ -358,6 +358,112 @@ resource "rundeck_system_runner" "test" {
 }
 `
 
+func TestAccRundeckSystemRunner_detachProject(t *testing.T) {
+	if os.Getenv("RUNDECK_ENTERPRISE_TESTS") != "1" {
+		t.Skip("ENTERPRISE ONLY: System runners (requires Rundeck 5.17.0+, API v56+) - set RUNDECK_ENTERPRISE_TESTS=1")
+	}
+
+	var runner openapi.RunnerInfo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccSystemRunnerCheckDestroy(&runner),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckSystemRunnerConfig_withAssignedProjectsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.access_level", "admin"),
+				),
+			},
+			{
+				// Remove the project from assigned_projects_config entirely and confirm
+				// the runner is actually detached server-side (RemoveProjectAssociation),
+				// not just dropped from Terraform state.
+				Config: testAccRundeckSystemRunnerConfig_detachedProject,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSystemRunnerCheckExists("rundeck_system_runner.test", &runner),
+					resource.TestCheckNoResourceAttr("rundeck_system_runner.test", "assigned_projects_config.test-project.access_level"),
+					testAccSystemRunnerCheckProjectDetached("test-project"),
+				),
+			},
+		},
+	})
+}
+
+// testAccSystemRunnerCheckProjectDetached verifies the given project no longer
+// appears in any of the runner's per-project dispatch-setting maps server-side.
+func testAccSystemRunnerCheckProjectDetached(project string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["rundeck_system_runner.test"]
+		if !ok {
+			return fmt.Errorf("resource not found: rundeck_system_runner.test")
+		}
+
+		clients, err := getTestClients()
+		if err != nil {
+			return fmt.Errorf("failed to create test client: %s", err)
+		}
+
+		runnerInfo, _, err := clients.V2.RunnerAPI.RunnerInfo(clients.ctx, rs.Primary.ID).Execute()
+		if err != nil {
+			return fmt.Errorf("failed to get runner info: %s", err)
+		}
+
+		if runnerInfo.ProjectAssociations == nil {
+			return nil
+		}
+
+		assoc := runnerInfo.ProjectAssociations
+		if assoc.ProjectNodeFilters != nil {
+			if _, ok := (*assoc.ProjectNodeFilters)[project]; ok {
+				return fmt.Errorf("project %s still present in ProjectNodeFilters after detach", project)
+			}
+		}
+		if assoc.ProjectRunnerAsNodeEnabled != nil {
+			if _, ok := (*assoc.ProjectRunnerAsNodeEnabled)[project]; ok {
+				return fmt.Errorf("project %s still present in ProjectRunnerAsNodeEnabled after detach", project)
+			}
+		}
+		if assoc.ProjectRemoteNodeDispatch != nil {
+			if _, ok := (*assoc.ProjectRemoteNodeDispatch)[project]; ok {
+				return fmt.Errorf("project %s still present in ProjectRemoteNodeDispatch after detach", project)
+			}
+		}
+		if assoc.ProjectRunnerNodeFilter != nil {
+			if _, ok := (*assoc.ProjectRunnerNodeFilter)[project]; ok {
+				return fmt.Errorf("project %s still present in ProjectRunnerNodeFilter after detach", project)
+			}
+		}
+
+		return nil
+	}
+}
+
+const testAccRundeckSystemRunnerConfig_detachedProject = `
+resource "rundeck_project" "test" {
+  name        = "test-project"
+  description = "Terraform acceptance test project for system runner"
+
+  resource_model_source {
+    type = "local"
+    config = {
+    }
+  }
+}
+
+resource "rundeck_system_runner" "test" {
+  name             = "test-runner-with-config"
+  description      = "Test runner with project config"
+  tag_names        = "terraform,test"
+  installation_type = "kubernetes"
+  replica_type     = "ephemeral"
+
+  assigned_projects_config = {}
+}
+`
+
 const testAccRundeckSystemRunnerConfig_precedence = `
 resource "rundeck_project" "test" {
   name        = "test-project"

--- a/rundeck/resource_system_runner_test.go
+++ b/rundeck/resource_system_runner_test.go
@@ -392,8 +392,19 @@ func TestAccRundeckSystemRunner_detachProject(t *testing.T) {
 	})
 }
 
-// testAccSystemRunnerCheckProjectDetached verifies the given project no longer
-// appears in any of the runner's per-project dispatch-setting maps server-side.
+// testAccSystemRunnerCheckProjectDetached verifies the given project's
+// dispatch settings are actually inert server-side after detaching.
+//
+// Confirmed directly against a live server: RemoveProjectAssociation only
+// clears the access-level association (ProjectNodeFilters); it never
+// touches ProjectRunnerAsNodeEnabled/ProjectRemoteNodeDispatch, and those
+// two booleans are never removed from their map even when explicitly reset
+// - Rundeck keeps the key with value false rather than deleting it. Only
+// string-valued settings (ProjectRunnerNodeFilter) and the access-level map
+// actually lose the key when cleared. So "detached" here means: the
+// access-level and node-filter maps have no entry for the project, and the
+// two boolean maps either have no entry or an entry that's false - not
+// "no entry at all" for every map, which this API doesn't make possible.
 func testAccSystemRunnerCheckProjectDetached(project string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources["rundeck_system_runner.test"]
@@ -422,13 +433,13 @@ func testAccSystemRunnerCheckProjectDetached(project string) resource.TestCheckF
 			}
 		}
 		if assoc.ProjectRunnerAsNodeEnabled != nil {
-			if _, ok := (*assoc.ProjectRunnerAsNodeEnabled)[project]; ok {
-				return fmt.Errorf("project %s still present in ProjectRunnerAsNodeEnabled after detach", project)
+			if v, ok := (*assoc.ProjectRunnerAsNodeEnabled)[project]; ok && v {
+				return fmt.Errorf("project %s still has ProjectRunnerAsNodeEnabled=true after detach", project)
 			}
 		}
 		if assoc.ProjectRemoteNodeDispatch != nil {
-			if _, ok := (*assoc.ProjectRemoteNodeDispatch)[project]; ok {
-				return fmt.Errorf("project %s still present in ProjectRemoteNodeDispatch after detach", project)
+			if v, ok := (*assoc.ProjectRemoteNodeDispatch)[project]; ok && v {
+				return fmt.Errorf("project %s still has ProjectRemoteNodeDispatch=true after detach", project)
 			}
 		}
 		if assoc.ProjectRunnerNodeFilter != nil {

--- a/website/docs/d/runner.html.md
+++ b/website/docs/d/runner.html.md
@@ -1,0 +1,55 @@
+---
+layout: "rundeck"
+page_title: "Rundeck: rundeck_runner"
+sidebar_current: "docs-rundeck-datasource-runner"
+description: |-
+  The rundeck_runner data source retrieves information about a single Rundeck Enterprise runner.
+---
+
+# rundeck\_runner
+
+Retrieves information about a single Rundeck Enterprise runner (system or project scoped) by its runner ID.
+
+**Requirements:** Requires Rundeck Enterprise 5.17.0+ (API v56). Configure the provider with `api_version = "56"` or higher.
+
+## Example Usage
+
+```hcl
+data "rundeck_runner" "example" {
+  runner_id = "12345678-1234-1234-1234-123456789abc"
+}
+
+output "runner_status" {
+  value = data.rundeck_runner.example.status
+}
+```
+
+## Argument Reference
+
+* `runner_id` - (Required) ID of the runner to look up.
+
+## Attributes Reference
+
+* `name` - Name of the runner.
+* `description` - Description of the runner.
+* `status` - Current status of the runner.
+* `version` - Runner software version.
+* `tag_names` - Comma separated tags for the runner.
+* `runner_as_node_enabled` - Whether the runner acts as a node.
+* `remote_node_dispatch` - Whether remote node dispatch is enabled for the runner.
+* `runner_node_filter` - Node filter string for the runner.
+* `hostname` - Hostname the runner is running on.
+* `os_family` - Operating system family of the runner host.
+* `replica_type` - Replica type of the runner (`manual` or `ephemeral`).
+* `installation_type` - Installation type of the runner (`linux`, `windows`, `kubernetes`, `docker`).
+* `date_created` - Timestamp the runner was created, in RFC3339 format.
+* `last_updated` - Timestamp the runner was last updated, in RFC3339 format.
+* `last_checkin` - Timestamp of the runner's last check-in.
+* `uptime` - Runner uptime, in seconds.
+* `running_operations` - Number of operations currently running on the runner.
+* `project_associations` - List of per-project dispatch settings associated with this runner. Each entry has:
+  * `project_name` - Name of the associated project.
+  * `node_filter` - Node filter configured for this project association.
+  * `runner_as_node_enabled` - Whether the runner acts as a node for this project.
+  * `remote_node_dispatch` - Whether remote node dispatch is enabled for this project.
+  * `runner_node_filter` - Runner node filter configured for this project.

--- a/website/docs/d/runner_tags.html.md
+++ b/website/docs/d/runner_tags.html.md
@@ -1,0 +1,37 @@
+---
+layout: "rundeck"
+page_title: "Rundeck: rundeck_runner_tags"
+sidebar_current: "docs-rundeck-datasource-runner-tags"
+description: |-
+  The rundeck_runner_tags data source discovers runner tags in use and their usage counts.
+---
+
+# rundeck\_runner\_tags
+
+Discovers runner tags currently in use for a project and how many runners use each one. Useful for validating tag names before assigning them consistently across a large runner set.
+
+**Requirements:** Requires Rundeck Enterprise 5.17.0+ (API v56). Configure the provider with `api_version = "56"` or higher. The underlying Rundeck API (`ListProjectAssociatedTags`) requires a project scope — there is no system-wide mode for this endpoint, despite what its name might suggest.
+
+## Example Usage
+
+```hcl
+data "rundeck_runner_tags" "project_scoped" {
+  project_name = "my-project"
+}
+
+output "known_tags" {
+  value = keys(data.rundeck_runner_tags.project_scoped.tags)
+}
+```
+
+## Argument Reference
+
+* `project_name` - (Required) Scope tag discovery to runners associated with this project.
+
+## Attributes Reference
+
+* `tags` - Map of tag name to the number of runners using that tag.
+
+## Notes
+
+This data source deliberately does not expose keyword search or pagination (the underlying `SearchTags` API) — it's intended for tag discovery/validation, not autocomplete. It also does not duplicate `data.rundeck_runner`'s `tag_names` attribute, which already covers listing tags for a single, specific runner.

--- a/website/docs/d/runners.html.md
+++ b/website/docs/d/runners.html.md
@@ -1,0 +1,67 @@
+---
+layout: "rundeck"
+page_title: "Rundeck: rundeck_runners"
+sidebar_current: "docs-rundeck-datasource-runners"
+description: |-
+  The rundeck_runners data source lists Rundeck Enterprise runners, optionally filtered by project, tags, status, or a generic filter string.
+---
+
+# rundeck\_runners
+
+Lists Rundeck Enterprise runners, optionally scoped to a project and filtered by tags, status, or a generic filter string.
+
+**Requirements:** Requires Rundeck Enterprise 5.17.0+ (API v56). Configure the provider with `api_version = "56"` or higher.
+
+## Example Usage
+
+```hcl
+# All system runners tagged "production"
+data "rundeck_runners" "production" {
+  tags = "production"
+}
+
+# Runners assigned to a specific project
+data "rundeck_runners" "project_scoped" {
+  project_name = "my-project"
+}
+
+output "runner_ids" {
+  value = [for r in data.rundeck_runners.production.runners : r.id]
+}
+```
+
+## Argument Reference
+
+* `project_name` - (Optional) If set, list runners assigned to this project instead of all system runners.
+* `tags` - (Optional) Comma separated list of tags to filter runners by.
+* `status` - (Optional) Filter runners by status.
+* `filter` - (Optional) Generic filter string passed through to the Rundeck API.
+* `local_only` - (Optional) If `true`, only include the local runner.
+
+There is no pagination on this endpoint — the full matching result set is always returned.
+
+## Attributes Reference
+
+* `runners` - List of runners matching the given filters. Each entry has:
+  * `id` - ID of the runner.
+  * `name` - Name of the runner.
+  * `description` - Description of the runner.
+  * `status` - Current status of the runner.
+  * `version` - Runner software version.
+  * `associated_projects` - Number of projects this runner is associated with.
+  * `last_checkin` - Timestamp of the runner's last check-in.
+  * `runner_as_node_enabled` - Whether the runner acts as a node.
+  * `tag_names` - Comma separated tags for the runner.
+  * `runner_node_filter` - Node filter string for the runner.
+  * `remote_node_dispatch` - Whether remote node dispatch is enabled.
+  * `hostname` - Hostname the runner is running on.
+  * `os_family` - Operating system family of the runner host.
+  * `replica_type` - Replica type of the runner (`manual` or `ephemeral`).
+  * `installation_type` - Installation type of the runner.
+  * `providers` - List of plugin providers (node/step/etc) this runner handles, each with `provider`, `service_name`, and `plugin_name`.
+  * `runner_replicas` - Number of replicas registered for this runner.
+  * `healthy_runner_replicas` - Number of healthy replicas registered for this runner.
+  * `running_operations` - Number of operations currently running on the runner.
+  * `uptime` - Runner uptime, in seconds.
+  * `date_created` - Timestamp the runner was created, in RFC3339 format.
+  * `last_updated` - Timestamp the runner was last updated, in RFC3339 format.

--- a/website/rundeck.erb
+++ b/website/rundeck.erb
@@ -48,6 +48,21 @@
             </li>
           </ul>
         </li>
+
+        <li<%= sidebar_current("docs-rundeck-datasource") %>>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-rundeck-datasource-runner") %>>
+              <a href="/docs/providers/rundeck/d/runner.html">rundeck_runner</a>
+            </li>
+            <li<%= sidebar_current("docs-rundeck-datasource-runners") %>>
+              <a href="/docs/providers/rundeck/d/runners.html">rundeck_runners</a>
+            </li>
+            <li<%= sidebar_current("docs-rundeck-datasource-runner-tags") %>>
+              <a href="/docs/providers/rundeck/d/runner_tags.html">rundeck_runner_tags</a>
+            </li>
+          </ul>
+        </li>
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
## Summary
- Adds `data.rundeck_runner`, `data.rundeck_runners`, and `data.rundeck_runner_tags` for looking up/enumerating Enterprise runners without managing them, closing the long-standing `data.rundeck_runner` TODO item.
- Fixes `rundeck_system_runner`'s `Update` to explicitly call `RemoveProjectAssociation` when a project is dropped from `assigned_projects`/`assigned_projects_config`, instead of relying on `SaveRunner`'s overwrite semantics to clear the other per-project dispatch-setting maps server-side.
- Fixes an unrelated, pre-existing bug in `rundeck_project`: an explicit `resource_model_source { config = {} }` was being collapsed to `null` on read, causing "Provider produced inconsistent result after apply". This was blocking test coverage for the runner detachment fix above, since the fixtures needed a project resource with that pattern.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` all clean
- [x] All 9 runner-related acceptance tests pass against a real Rundeck Enterprise instance, including a new `TestAccRundeckSystemRunner_detachProject` that verifies the detachment fix directly against the API (not just Terraform state)
- [x] New data source acceptance tests for all three data sources

Note: this branch and #<scm-integration PR, once opened> both independently include the same `resource_model_source` fix (found and needed in each while adding unrelated features) - whichever merges first will absorb it for the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)