### PR TITLE
Add rundeck_scm_import/rundeck_scm_export resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ $ make testacc
 
 Without `RUNDECK_PROJECT_SCHEDULES_CONFIGURED=1`, the project schedule tests will be skipped even when `RUNDECK_ENTERPRISE_TESTS=1` is set.
 
+**SCM Integration Tests (Additional Setup Required):**
+
+`TestAccRundeckScmExport_basic` exercises `rundeck_scm_export` against a real git remote. Unlike the Enterprise tests above, this isn't Enterprise-gated (git/svn SCM plugins ship with core Rundeck, API v15+) - what it needs instead is a git server your Rundeck *server* can reach over the network (not just wherever you run `go test`), plus write credentials. Any git host works - a self-hosted Gitea/GitLab/Gitea-alike instance, GitHub, or a plain bare repo served over SSH.
+
+To run it:
+
+1. Create an empty repository on a git host reachable from your Rundeck server.
+2. Generate an SSH keypair dedicated to this test (e.g. `ssh-keygen -t ed25519 -f /tmp/rundeck-scm-test-key -N ""`).
+3. Add the public key to that repository as a deploy key (or an account key) with write/push access.
+4. Set both environment variables, then run the test:
+
+```sh
+$ export RUNDECK_SCM_TEST_GIT_URL="git@your-git-host:your-org/your-repo.git"
+$ export RUNDECK_SCM_TEST_SSH_KEY_PATH="/tmp/rundeck-scm-test-key"
+$ go test ./rundeck/... -run TestAccRundeckScmExport_basic -v
+```
+
+The private key's contents are never passed through Go code or Terraform variables - `RUNDECK_SCM_TEST_SSH_KEY_PATH` only supplies a local file path, and the generated test config reads it directly via Terraform's `file()` function at apply time, uploading it into Rundeck's key storage via `rundeck_private_key`.
+
 **In CI/CD pipelines:**
 
 By default, Enterprise tests are skipped unless `RUNDECK_ENTERPRISE_TESTS=1` is set. To enable them in GitHub Actions or other CI:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Without `RUNDECK_PROJECT_SCHEDULES_CONFIGURED=1`, the project schedule tests wil
 
 To run it:
 
-1. Create an empty repository on a git host reachable from your Rundeck server.
+1. Create a repository on a git host reachable from your Rundeck server, **with at least one initial commit on its default branch** (e.g. a README committed via the host's own "initialize this repository" option). The test fixture sets `branch = "main"` with `createBranch = "true"`, and `createBranch` creates that branch *from* the repository's current default branch - a genuinely empty repository (zero commits) has no branch to create it from, and setup fails.
 2. Generate an SSH keypair dedicated to this test (e.g. `ssh-keygen -t ed25519 -f /tmp/rundeck-scm-test-key -N ""`).
 3. Add the public key to that repository as a deploy key (or an account key) with write/push access.
 4. Set both environment variables, then run the test:

--- a/TODO.md
+++ b/TODO.md
@@ -195,34 +195,13 @@ After:  Error creating job "my-job" in project "prod": Rundeck returned validati
 
 ---
 
-### SCM Integration Support
-**Status**: ✅ Implemented - `rundeck_scm_import` and `rundeck_scm_export`
-(`rundeck/resource_scm_framework.go`). Config is a generic `map(string)`
-since the valid/required keys are dynamic per plugin type (discoverable via
-the SCM API's plugin-input-schema endpoint, not modeled by this provider).
-Gated at API v15+ (bundled with core Rundeck, not Enterprise-only). No
-delete/clear-config endpoint exists - destroying the resource disables the
-plugin (closest available operation); config may persist server-side in a
-disabled state.
-**GitHub Issue**: [#76](https://github.com/rundeck/terraform-provider-rundeck/issues/76) -
-demand picked back up via a direct customer request; the "low demand"
-reasoning below is stale.
+### SCM Action Triggering
+**GitHub Issue**: [#76](https://github.com/rundeck/terraform-provider-rundeck/issues/76)
 
-**Not yet covered**: triggering SCM actions (import/commit/synch) - this
-provider only configures and enables/disables the plugin, it doesn't expose
-an "action" resource/data-source for the commit/synch workflow. Consider as
-a follow-up if needed.
-
-<details>
-<summary>Original triage notes (superseded)</summary>
-
-**Priority Justification**:
-- Low demand (only 1 GitHub issue in 3 years)
-- Complex implementation
-- Workaround exists (manual SCM setup in Rundeck UI)
-
-**Recommendation**: Consider for future release if user demand increases
-</details>
+`rundeck_scm_import`/`rundeck_scm_export` (`rundeck/resource_scm_framework.go`)
+configure and enable/disable a project's SCM plugin, but don't trigger an
+SCM action (the actual import/commit/synch). Consider an "action"
+resource/data-source for that workflow as a follow-up if needed.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -196,21 +196,25 @@ After:  Error creating job "my-job" in project "prod": Rundeck returned validati
 ---
 
 ### SCM Integration Support
-**Effort**: Large (1-2 weeks)  
-**Why Important**: Users want to manage SCM configurations via Terraform.  
-**GitHub Issue**: [#76](https://github.com/rundeck/terraform-provider-rundeck/issues/76)
+**Status**: ✅ Implemented - `rundeck_scm_import` and `rundeck_scm_export`
+(`rundeck/resource_scm_framework.go`). Config is a generic `map(string)`
+since the valid/required keys are dynamic per plugin type (discoverable via
+the SCM API's plugin-input-schema endpoint, not modeled by this provider).
+Gated at API v15+ (bundled with core Rundeck, not Enterprise-only). No
+delete/clear-config endpoint exists - destroying the resource disables the
+plugin (closest available operation); config may persist server-side in a
+disabled state.
+**GitHub Issue**: [#76](https://github.com/rundeck/terraform-provider-rundeck/issues/76) -
+demand picked back up via a direct customer request; the "low demand"
+reasoning below is stale.
 
-**Feature Request**:
-Add support for Rundeck's Source Control Management (SCM) integration, allowing Terraform to configure Git import/export for projects.
+**Not yet covered**: triggering SCM actions (import/commit/synch) - this
+provider only configures and enables/disables the plugin, it doesn't expose
+an "action" resource/data-source for the commit/synch workflow. Consider as
+a follow-up if needed.
 
-**Proposed Resources**:
-- `rundeck_scm_import` - Configure Git import for a project
-- `rundeck_scm_export` - Configure Git export for a project
-
-**API Support**:
-- Rundeck API v14+ supports SCM endpoints
-- Complex configuration schema varies by plugin
-- Authentication methods (SSH keys, tokens)
+<details>
+<summary>Original triage notes (superseded)</summary>
 
 **Priority Justification**:
 - Low demand (only 1 GitHub issue in 3 years)
@@ -218,6 +222,7 @@ Add support for Rundeck's Source Control Management (SCM) integration, allowing 
 - Workaround exists (manual SCM setup in Rundeck UI)
 
 **Recommendation**: Consider for future release if user demand increases
+</details>
 
 ---
 

--- a/rundeck/provider_framework.go
+++ b/rundeck/provider_framework.go
@@ -215,6 +215,8 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewProjectResource,
 		NewJobResource,
 		NewWebhookResource,
+		NewScmImportResource,
+		NewScmExportResource,
 	}
 }
 

--- a/rundeck/resource_project_framework.go
+++ b/rundeck/resource_project_framework.go
@@ -439,11 +439,20 @@ func (r *projectResource) readProject(ctx context.Context, apiCtx context.Contex
 	// result after apply" error and refresh drift (#248). Keyed by source number
 	// (list position + 1), matching how sources are written as resources.source.N.
 	priorNullConfigKeys := map[int][]string{}
+	// Likewise, remember which sources had an explicitly-configured empty map
+	// (config = {}) as opposed to an omitted/null config, so an empty result
+	// below is preserved as an empty map rather than collapsed to null (#248
+	// only handles omitted vs. present; a known-empty map is neither).
+	priorEmptyConfig := map[int]bool{}
 	if !state.ResourceModelSource.IsNull() && !state.ResourceModelSource.IsUnknown() {
 		var priorSources []resourceModelSourceModel
 		if d := state.ResourceModelSource.ElementsAs(ctx, &priorSources, false); !d.HasError() {
 			for i, ps := range priorSources {
 				if ps.Config.IsNull() || ps.Config.IsUnknown() {
+					continue
+				}
+				if len(ps.Config.Elements()) == 0 {
+					priorEmptyConfig[i+1] = true
 					continue
 				}
 				var nullKeys []string
@@ -531,10 +540,16 @@ func (r *projectResource) readProject(ctx context.Context, apiCtx context.Contex
 			Type: types.StringValue(source["type"].(string)),
 		}
 
-		// Only set Config if there are actual config values
-		// This prevents null != {} drift when config is omitted
+		// Only collapse an empty result to null when config was actually omitted.
+		// If the user explicitly wrote config = {}, preserve it as an empty map -
+		// collapsing it to null here caused "inconsistent result after apply"
+		// since the plan had a known (non-null) empty map.
 		if len(configMap) == 0 {
-			sourceModel.Config = types.MapNull(types.StringType)
+			if priorEmptyConfig[index] {
+				sourceModel.Config = types.MapValueMust(types.StringType, configMap)
+			} else {
+				sourceModel.Config = types.MapNull(types.StringType)
+			}
 		} else {
 			sourceModel.Config = types.MapValueMust(types.StringType, configMap)
 		}

--- a/rundeck/resource_project_test.go
+++ b/rundeck/resource_project_test.go
@@ -135,6 +135,50 @@ resource "rundeck_project" "test" {
 }
 `
 
+// TestAccProject_localSourceEmptyConfig covers a different case than
+// TestAccProject_localSourceNoConfig above: explicitly setting
+// resource_model_source.config = {} (a known, empty map) rather than
+// omitting config entirely (which reads back as null). config is
+// Optional-only, not Computed, so an explicitly-configured empty map used
+// to collapse to null on read, failing apply with "Provider produced
+// inconsistent result after apply" (config was {} became null).
+func TestAccProject_localSourceEmptyConfig(t *testing.T) {
+	var project rundeck.Project
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccProjectCheckDestroy(&project),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectConfig_localSourceEmptyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccProjectCheckExists("rundeck_project.test", &project),
+					resource.TestCheckResourceAttr("rundeck_project.test", "resource_model_source.0.config.%", "0"),
+				),
+			},
+			// Verify no plan drift on refresh - this is exactly what the
+			// empty-map-collapsing-to-null bug broke.
+			{
+				RefreshState: true,
+				PlanOnly:     true,
+			},
+		},
+	})
+}
+
+const testAccProjectConfig_localSourceEmptyConfig = `
+resource "rundeck_project" "test" {
+  name        = "terraform-acc-test-local-empty-config"
+  description = "Test project for local source with an explicit empty config map"
+
+  resource_model_source {
+    type   = "local"
+    config = {}
+  }
+}
+`
+
 // TestAccProject_SSHKeyFilePath tests that ssh_key_file_path is correctly stored
 // and does not produce drift after apply (regression for project.ssh-keypath mapping bug).
 func TestAccProject_SSHKeyFilePath(t *testing.T) {

--- a/rundeck/resource_scm_framework.go
+++ b/rundeck/resource_scm_framework.go
@@ -80,6 +80,7 @@ func (r *scmIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Description: "Plugin-specific configuration key/value pairs. The set of required/valid keys is dynamic per plugin type - see Rundeck's SCM plugin input schema for the plugin type in use. Reference external secret storage for any credential-like values rather than embedding raw secrets here.",
 				Required:    true,
 				ElementType: types.StringType,
+				Sensitive:   true,
 			},
 			"enabled": schema.BoolAttribute{
 				Description: "Whether the SCM plugin is currently enabled for the project.",
@@ -440,12 +441,31 @@ func (r *scmIntegrationResource) Delete(ctx context.Context, req resource.Delete
 	// the closest available operation. The plugin's configuration may still
 	// persist server-side in a disabled state; there's no way from this API
 	// to fully remove it.
-	_, _, err := client.SCMAPI.ApiProjectDisable(apiCtx, project, r.integration, pluginType).Execute()
+	disableResult, apiResp, err := client.SCMAPI.ApiProjectDisable(apiCtx, project, r.integration, pluginType).Execute()
+	if apiResp != nil && apiResp.StatusCode == 404 {
+		// Already gone (e.g. the project itself was removed) - nothing left
+		// to disable, so this is success, not failure.
+		return
+	}
 	if err != nil {
-		resp.Diagnostics.AddWarning(
-			fmt.Sprintf("Warning disabling SCM %s plugin", r.integration),
-			fmt.Sprintf("Failed to disable %s plugin for project %s: %s", r.integration, project, scmErrorDetail(err)),
+		// A failed disable leaves the plugin enabled server-side. Erroring
+		// here (rather than only warning) keeps the resource in Terraform
+		// state - the framework only removes it from state when Delete
+		// returns without an error diagnostic - so the next apply retries
+		// instead of Terraform silently treating an unmanaged, still-enabled
+		// integration as gone.
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error disabling SCM %s plugin", r.integration),
+			fmt.Sprintf("Could not disable %s plugin for project %s: %s", r.integration, project, scmErrorDetail(err)),
 		)
+		return
+	}
+	if disableResult != nil && disableResult.Success != nil && !*disableResult.Success {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error disabling SCM %s plugin", r.integration),
+			fmt.Sprintf("Rundeck did not disable the %s plugin for project %s: %s", r.integration, project, scmActionErrorMessage(disableResult)),
+		)
+		return
 	}
 }
 

--- a/rundeck/resource_scm_framework.go
+++ b/rundeck/resource_scm_framework.go
@@ -1,0 +1,429 @@
+package rundeck
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	openapi "github.com/rundeck/go-rundeck/rundeck-v2"
+)
+
+// scmIntegrationResource implements both rundeck_scm_import and
+// rundeck_scm_export, which are identical except for the fixed "integration"
+// value ("import"/"export") passed to the shared SCM API calls.
+var (
+	_ resource.Resource                = &scmIntegrationResource{}
+	_ resource.ResourceWithConfigure   = &scmIntegrationResource{}
+	_ resource.ResourceWithImportState = &scmIntegrationResource{}
+)
+
+func NewScmImportResource() resource.Resource {
+	return &scmIntegrationResource{integration: "import"}
+}
+
+func NewScmExportResource() resource.Resource {
+	return &scmIntegrationResource{integration: "export"}
+}
+
+type scmIntegrationResource struct {
+	clients     *RundeckClients
+	integration string // "import" or "export"
+}
+
+type scmIntegrationResourceModel struct {
+	ID      types.String `tfsdk:"id"`
+	Project types.String `tfsdk:"project"`
+	Type    types.String `tfsdk:"type"`
+	Config  types.Map    `tfsdk:"config"`
+	Enabled types.Bool   `tfsdk:"enabled"`
+}
+
+func (r *scmIntegrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scm_" + r.integration
+}
+
+func (r *scmIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: fmt.Sprintf("Manages a Rundeck project's SCM %s plugin configuration (e.g. git-%s, svn-%s).", r.integration, r.integration, r.integration),
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of this resource, in the form \"project:type\".",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project": schema.StringAttribute{
+				Description: "Name of the project to configure SCM for.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"type": schema.StringAttribute{
+				Description: fmt.Sprintf("SCM plugin type name (e.g. \"git-%s\", \"svn-%s\"). Changing this requires replacing the resource, since it amounts to reconfiguring from scratch.", r.integration, r.integration),
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"config": schema.MapAttribute{
+				Description: "Plugin-specific configuration key/value pairs. The set of required/valid keys is dynamic per plugin type - see Rundeck's SCM plugin input schema for the plugin type in use. Reference external secret storage for any credential-like values rather than embedding raw secrets here.",
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the SCM plugin is currently enabled for the project.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (r *scmIntegrationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clients, ok := req.ProviderData.(*RundeckClients)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *RundeckClients, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.clients = clients
+}
+
+// buildScmSetupBody builds the request body for ApiProjectSetup. Rundeck
+// expects the plugin's properties nested under a "config" key
+// (confirmed against a live instance - "json: expected 'config' property"
+// when the properties are sent flattened at the top level), not as the
+// top-level body itself.
+func buildScmSetupBody(ctx context.Context, config types.Map) (map[string]interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	configMap := make(map[string]types.String)
+	diags.Append(config.ElementsAs(ctx, &configMap, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	pluginConfig := make(map[string]interface{})
+	for k, v := range configMap {
+		pluginConfig[k] = v.ValueString()
+	}
+
+	return map[string]interface{}{
+		"config": pluginConfig,
+	}, diags
+}
+
+// scmActionErrorMessage formats a non-successful ScmActionResult into a
+// human-readable message, including any per-field validation errors.
+func scmActionErrorMessage(result *openapi.ScmActionResult) string {
+	msg := "unknown error"
+	if result != nil && result.Message != nil {
+		msg = *result.Message
+	}
+	if result != nil && result.ValidationErrors != nil && len(*result.ValidationErrors) > 0 {
+		var fields []string
+		for k, v := range *result.ValidationErrors {
+			fields = append(fields, fmt.Sprintf("%s: %s", k, v))
+		}
+		sort.Strings(fields)
+		msg = fmt.Sprintf("%s (validation errors: %s)", msg, strings.Join(fields, "; "))
+	}
+	return msg
+}
+
+// scmErrorDetail extracts the most useful detail available from an SCM API
+// error. On a 400, the generated SDK decodes the response body into a
+// ScmActionResult and stores it as the error's Model - but its own
+// Error() string only surfaces RFC7807 Title/Detail fields, which
+// ScmActionResult doesn't have, so err.Error() alone is just the bare
+// status line. Prefer the decoded model's Message/ValidationErrors; fall
+// back to the raw response body, then to err.Error().
+func scmErrorDetail(err error) string {
+	apiErr, ok := err.(*openapi.GenericOpenAPIError)
+	if !ok {
+		return err.Error()
+	}
+	if model, ok := apiErr.Model().(openapi.ScmActionResult); ok {
+		if detail := scmActionErrorMessage(&model); detail != "unknown error" {
+			return fmt.Sprintf("%s - %s", err.Error(), detail)
+		}
+	}
+	if body := apiErr.Body(); len(body) > 0 {
+		return fmt.Sprintf("%s - Response: %s", err.Error(), string(body))
+	}
+	return err.Error()
+}
+
+func (r *scmIntegrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan scmIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.clients.V2
+	apiCtx := r.clients.ctx
+	project := plan.Project.ValueString()
+	pluginType := plan.Type.ValueString()
+
+	configBody, diags := buildScmSetupBody(ctx, plan.Config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	setupResult, _, err := client.SCMAPI.ApiProjectSetup(apiCtx, project, r.integration, pluginType).Body(configBody).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error configuring SCM %s plugin", r.integration),
+			fmt.Sprintf("Could not configure %s plugin %s for project %s: %s", r.integration, pluginType, project, scmErrorDetail(err)),
+		)
+		return
+	}
+	if setupResult != nil && setupResult.Success != nil && !*setupResult.Success {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error configuring SCM %s plugin", r.integration),
+			fmt.Sprintf("Rundeck rejected the %s plugin configuration for project %s: %s", r.integration, project, scmActionErrorMessage(setupResult)),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(fmt.Sprintf("%s:%s", project, pluginType))
+
+	// Seed state immediately after successful setup, before the enable call
+	// below - if enabling fails, the configured plugin must still be tracked
+	// in Terraform state rather than left orphaned (same class of bug fixed
+	// in rundeck_local_role's Create).
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// ApiProjectSetup's own documentation says it configures AND enables the
+	// plugin, but ApiProjectEnable is documented as idempotent - call it
+	// explicitly anyway rather than relying on that possibly-imprecise
+	// description, since it's a harmless no-op if already enabled.
+	enableResult, _, err := client.SCMAPI.ApiProjectEnable(apiCtx, project, r.integration, pluginType).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error enabling SCM %s plugin", r.integration),
+			fmt.Sprintf("Plugin was configured but could not be enabled for project %s: %s", project, scmErrorDetail(err)),
+		)
+		return
+	}
+	if enableResult != nil && enableResult.Success != nil && !*enableResult.Success {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error enabling SCM %s plugin", r.integration),
+			fmt.Sprintf("Plugin was configured but Rundeck did not enable it for project %s: %s", project, scmActionErrorMessage(enableResult)),
+		)
+		return
+	}
+
+	readReq := resource.ReadRequest{State: resp.State}
+	readResp := resource.ReadResponse{State: resp.State}
+	r.Read(ctx, readReq, &readResp)
+	resp.Diagnostics.Append(readResp.Diagnostics...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.State = readResp.State
+}
+
+func (r *scmIntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state scmIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.clients.V2
+	apiCtx := r.clients.ctx
+
+	idParts := strings.SplitN(state.ID.ValueString(), ":", 2)
+	if len(idParts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid ID format",
+			fmt.Sprintf("Expected ID format 'project:type', got: %s", state.ID.ValueString()),
+		)
+		return
+	}
+	project := idParts[0]
+
+	config, apiResp, err := client.SCMAPI.ApiProjectConfig(apiCtx, project, r.integration).Execute()
+	if apiResp != nil && apiResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error reading SCM %s configuration", r.integration),
+			fmt.Sprintf("Could not read %s configuration for project %s: %s", r.integration, project, scmErrorDetail(err)),
+		)
+		return
+	}
+	if config == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.Project = types.StringValue(project)
+	if config.Type != nil {
+		state.Type = types.StringValue(*config.Type)
+		state.ID = types.StringValue(fmt.Sprintf("%s:%s", project, *config.Type))
+	}
+	if config.Enabled != nil {
+		state.Enabled = types.BoolValue(*config.Enabled)
+	}
+
+	configValues := make(map[string]types.String)
+	if config.Config != nil {
+		for k, v := range *config.Config {
+			configValues[k] = types.StringValue(v)
+		}
+	}
+	configMap, diags := types.MapValueFrom(ctx, types.StringType, configValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Config = configMap
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *scmIntegrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan scmIntegrationResourceModel
+	var state scmIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.clients.V2
+	apiCtx := r.clients.ctx
+	plan.ID = state.ID
+
+	idParts := strings.SplitN(state.ID.ValueString(), ":", 2)
+	if len(idParts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid ID format",
+			fmt.Sprintf("Expected ID format 'project:type', got: %s", state.ID.ValueString()),
+		)
+		return
+	}
+	project := idParts[0]
+	pluginType := plan.Type.ValueString()
+
+	configBody, diags := buildScmSetupBody(ctx, plan.Config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Re-invoke Setup with the new config - there's no separate "update"
+	// endpoint, and Setup's own semantics are configure-or-reconfigure.
+	setupResult, _, err := client.SCMAPI.ApiProjectSetup(apiCtx, project, r.integration, pluginType).Body(configBody).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error updating SCM %s plugin", r.integration),
+			fmt.Sprintf("Could not update %s plugin configuration for project %s: %s", r.integration, project, scmErrorDetail(err)),
+		)
+		return
+	}
+	if setupResult != nil && setupResult.Success != nil && !*setupResult.Success {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error updating SCM %s plugin", r.integration),
+			fmt.Sprintf("Rundeck rejected the updated %s plugin configuration for project %s: %s", r.integration, project, scmActionErrorMessage(setupResult)),
+		)
+		return
+	}
+
+	readReq := resource.ReadRequest{State: resp.State}
+	readResp := resource.ReadResponse{State: resp.State}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	readReq.State = resp.State
+	r.Read(ctx, readReq, &readResp)
+	resp.Diagnostics.Append(readResp.Diagnostics...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.State = readResp.State
+}
+
+func (r *scmIntegrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state scmIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client := r.clients.V2
+	apiCtx := r.clients.ctx
+
+	idParts := strings.SplitN(state.ID.ValueString(), ":", 2)
+	if len(idParts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid ID format",
+			fmt.Sprintf("Expected ID format 'project:type', got: %s", state.ID.ValueString()),
+		)
+		return
+	}
+	project := idParts[0]
+	pluginType := state.Type.ValueString()
+
+	// There is no delete/clear-config endpoint for SCM plugins - Disable is
+	// the closest available operation. The plugin's configuration may still
+	// persist server-side in a disabled state; there's no way from this API
+	// to fully remove it.
+	_, _, err := client.SCMAPI.ApiProjectDisable(apiCtx, project, r.integration, pluginType).Execute()
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			fmt.Sprintf("Warning disabling SCM %s plugin", r.integration),
+			fmt.Sprintf("Failed to disable %s plugin for project %s: %s", r.integration, project, scmErrorDetail(err)),
+		)
+	}
+}
+
+func (r *scmIntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// The ID should be in format "project:type"
+	idParts := strings.SplitN(req.ID, ":", 2)
+	if len(idParts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be in format 'project:type', got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), idParts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("type"), idParts[1])...)
+}

--- a/rundeck/resource_scm_framework.go
+++ b/rundeck/resource_scm_framework.go
@@ -231,6 +231,17 @@ func (r *scmIntegrationResource) Create(ctx context.Context, req resource.Create
 	// description, since it's a harmless no-op if already enabled.
 	enableResult, _, err := client.SCMAPI.ApiProjectEnable(apiCtx, project, r.integration, pluginType).Execute()
 	if err != nil {
+		// enabled is Computed-only, so plan.Enabled is still Unknown at this
+		// point (req.Plan.Get never populates it - only a real read does).
+		// The state.Set above already persisted that Unknown value; returning
+		// an error without correcting it leaves the *final* state Unknown,
+		// which the framework rejects outright ("Provider returned invalid
+		// result object after apply") on top of the real error underneath -
+		// confirmed live, against Rundeck Enterprise 6.2.0-SNAPSHOT, when
+		// ApiProjectEnable failed after a successful ApiProjectSetup. Setup
+		// succeeded but enabling didn't, so the plugin isn't enabled.
+		plan.Enabled = types.BoolValue(false)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error enabling SCM %s plugin", r.integration),
 			fmt.Sprintf("Plugin was configured but could not be enabled for project %s: %s", project, scmErrorDetail(err)),
@@ -238,6 +249,8 @@ func (r *scmIntegrationResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 	if enableResult != nil && enableResult.Success != nil && !*enableResult.Success {
+		plan.Enabled = types.BoolValue(false)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error enabling SCM %s plugin", r.integration),
 			fmt.Sprintf("Plugin was configured but Rundeck did not enable it for project %s: %s", project, scmActionErrorMessage(enableResult)),

--- a/rundeck/resource_scm_framework.go
+++ b/rundeck/resource_scm_framework.go
@@ -122,6 +122,13 @@ func buildScmSetupBody(ctx context.Context, config types.Map) (map[string]interf
 
 	pluginConfig := make(map[string]interface{})
 	for k, v := range configMap {
+		// A null map value (e.g. `config = { pathTemplate = null }`, leaving
+		// an optional plugin property unset) must be omitted, not sent as an
+		// empty string - the plugin may treat "" as an explicit, invalid
+		// value rather than "not provided".
+		if v.IsNull() {
+			continue
+		}
 		pluginConfig[k] = v.ValueString()
 	}
 
@@ -294,9 +301,39 @@ func (r *scmIntegrationResource) Read(ctx context.Context, req resource.ReadRequ
 		state.Enabled = types.BoolValue(*config.Enabled)
 	}
 
+	// config is Required, not Computed, so anything reflected back here that
+	// wasn't already known would fail apply with "inconsistent result after
+	// apply" - the schema has no way to say "this key is fine to appear on
+	// its own." Restrict the read-back to keys already in state (the ones
+	// last configured/planned) and drop anything the plugin adds beyond
+	// that, rather than reporting every key Rundeck happens to return.
+	//
+	// State has no known config yet right after ImportState (which only
+	// sets id/project/type), so there's nothing to filter against there -
+	// take the full config as-is in that case, or the resource would import
+	// as if nothing were configured.
+	//
+	// This doesn't cover a plugin normalizing the *value* of a key that was
+	// already configured (e.g. rewriting a relative path to an absolute
+	// one) - that would still surface as inconsistent, and would need
+	// config to become Optional+Computed to tolerate, which changes the
+	// "must configure something" contract this resource is meant to have.
+	hasKnownConfig := !state.Config.IsNull() && !state.Config.IsUnknown()
+	knownKeys := make(map[string]struct{})
+	if hasKnownConfig {
+		for k := range state.Config.Elements() {
+			knownKeys[k] = struct{}{}
+		}
+	}
+
 	configValues := make(map[string]types.String)
 	if config.Config != nil {
 		for k, v := range *config.Config {
+			if hasKnownConfig {
+				if _, known := knownKeys[k]; !known {
+					continue
+				}
+			}
 			configValues[k] = types.StringValue(v)
 		}
 	}

--- a/rundeck/resource_scm_helpers_test.go
+++ b/rundeck/resource_scm_helpers_test.go
@@ -1,0 +1,91 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// buildScmSetupBody is a pure function; these are plain unit tests that
+// don't need a live server to exercise it.
+
+func TestBuildScmSetupBody_wrapsConfigKey(t *testing.T) {
+	ctx := context.Background()
+
+	config, diags := types.MapValue(types.StringType, map[string]attr.Value{
+		"url": types.StringValue("git@example.com:org/repo.git"),
+		"dir": types.StringValue(".rundeck-scm"),
+	})
+	if diags.HasError() {
+		t.Fatalf("building test config: %v", diags)
+	}
+
+	body, diags := buildScmSetupBody(ctx, config)
+	if diags.HasError() {
+		t.Fatalf("buildScmSetupBody: %v", diags)
+	}
+
+	pluginConfig, ok := body["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body[\"config\"] = %T, want map[string]interface{}", body["config"])
+	}
+	if pluginConfig["url"] != "git@example.com:org/repo.git" {
+		t.Errorf("url = %v, want the configured value", pluginConfig["url"])
+	}
+	if pluginConfig["dir"] != ".rundeck-scm" {
+		t.Errorf("dir = %v, want the configured value", pluginConfig["dir"])
+	}
+}
+
+// A null map value (e.g. `config = { pathTemplate = null }`, leaving an
+// optional plugin property unset) must be omitted from the request body
+// entirely, not sent as an empty string - the plugin may treat "" as an
+// explicit, invalid value rather than "not provided".
+func TestBuildScmSetupBody_omitsNullValues(t *testing.T) {
+	ctx := context.Background()
+
+	config, diags := types.MapValue(types.StringType, map[string]attr.Value{
+		"url":          types.StringValue("git@example.com:org/repo.git"),
+		"pathTemplate": types.StringNull(),
+	})
+	if diags.HasError() {
+		t.Fatalf("building test config: %v", diags)
+	}
+
+	body, diags := buildScmSetupBody(ctx, config)
+	if diags.HasError() {
+		t.Fatalf("buildScmSetupBody: %v", diags)
+	}
+
+	pluginConfig := body["config"].(map[string]interface{})
+	if _, exists := pluginConfig["pathTemplate"]; exists {
+		t.Errorf("pathTemplate = %q, want it omitted when null", pluginConfig["pathTemplate"])
+	}
+	if _, exists := pluginConfig["url"]; !exists {
+		t.Errorf("url missing, want it present")
+	}
+}
+
+func TestBuildScmSetupBody_emptyConfig(t *testing.T) {
+	ctx := context.Background()
+
+	config, diags := types.MapValue(types.StringType, map[string]attr.Value{})
+	if diags.HasError() {
+		t.Fatalf("building test config: %v", diags)
+	}
+
+	body, diags := buildScmSetupBody(ctx, config)
+	if diags.HasError() {
+		t.Fatalf("buildScmSetupBody: %v", diags)
+	}
+
+	pluginConfig, ok := body["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("body[\"config\"] = %T, want map[string]interface{}", body["config"])
+	}
+	if len(pluginConfig) != 0 {
+		t.Errorf("pluginConfig = %v, want empty", pluginConfig)
+	}
+}

--- a/rundeck/resource_scm_test.go
+++ b/rundeck/resource_scm_test.go
@@ -35,13 +35,28 @@ func TestAccRundeckScmExport_basic(t *testing.T) {
 		CheckDestroy:             testAccScmCheckDestroy("export"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRundeckScmExportConfig_basic(gitURL, keyPath),
+				Config: testAccRundeckScmExportConfig_basic(gitURL, keyPath, "main"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccScmCheckExists("rundeck_scm_export.test", "export", &config),
 					resource.TestCheckResourceAttr("rundeck_scm_export.test", "type", "git-export"),
 					resource.TestCheckResourceAttr("rundeck_scm_export.test", "config.url", gitURL),
 					resource.TestCheckResourceAttr("rundeck_scm_export.test", "enabled", "true"),
 				),
+			},
+			{
+				// Update: re-invoke Setup with a changed config value
+				// (there's no separate update endpoint) and confirm it
+				// actually takes effect rather than being a no-op.
+				Config: testAccRundeckScmExportConfig_basic(gitURL, keyPath, "develop"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccScmCheckExists("rundeck_scm_export.test", "export", &config),
+					resource.TestCheckResourceAttr("rundeck_scm_export.test", "config.branch", "develop"),
+				),
+			},
+			{
+				ResourceName:      "rundeck_scm_export.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -72,9 +87,17 @@ func testAccScmCheckDestroy(integration string) resource.TestCheckFunc {
 
 			got, resp, err := clients.V2.SCMAPI.ApiProjectConfig(clients.ctx, project, integration).Execute()
 			if resp != nil && resp.StatusCode == 404 {
+				// The plugin config is gone entirely - definitely not
+				// still enabled.
 				continue
 			}
-			if err == nil && got != nil && got.Enabled != nil && *got.Enabled {
+			if err != nil {
+				// Any other error (auth, network, server failure) means
+				// destruction was never actually verified - don't let that
+				// pass silently as if it had been.
+				return fmt.Errorf("failed to verify scm %s plugin destroyed for project %s: %w", integration, project, err)
+			}
+			if got != nil && got.Enabled != nil && *got.Enabled {
 				return fmt.Errorf("scm %s plugin still enabled for project: %s", integration, project)
 			}
 		}
@@ -88,18 +111,43 @@ func testAccScmCheckExists(rn string, integration string, config *openapi.ScmPro
 		if !ok {
 			return fmt.Errorf("resource not found: %s", rn)
 		}
-		if rs.Primary.Attributes["project"] == "" {
+		project := rs.Primary.Attributes["project"]
+		if project == "" {
 			return fmt.Errorf("project not set")
 		}
+		wantType := rs.Primary.Attributes["type"]
 
 		clients, err := getTestClients()
 		if err != nil {
 			return fmt.Errorf("failed to create test client: %s", err)
 		}
 
-		got, resp, err := clients.V2.SCMAPI.ApiProjectConfig(clients.ctx, rs.Primary.Attributes["project"], integration).Execute()
-		if resp.StatusCode != 200 {
-			return fmt.Errorf("failed to get scm %s config: %v", integration, err)
+		got, resp, err := clients.V2.SCMAPI.ApiProjectConfig(clients.ctx, project, integration).Execute()
+		if err != nil {
+			return fmt.Errorf("failed to get scm %s config: %w", integration, err)
+		}
+		if resp == nil || resp.StatusCode != 200 {
+			return fmt.Errorf("failed to get scm %s config: unexpected response %v", integration, resp)
+		}
+
+		// Assert directly against what the API returned, not just against
+		// Terraform state - the state values in the Check list right after
+		// this one are populated by this same provider code, so on their
+		// own they can't catch a serialization bug that's consistent
+		// between write and read.
+		if got.Type == nil || *got.Type != wantType {
+			return fmt.Errorf("api type = %v, want %q", got.Type, wantType)
+		}
+		if got.Enabled == nil || !*got.Enabled {
+			return fmt.Errorf("api enabled = %v, want true", got.Enabled)
+		}
+		if got.Config == nil {
+			return fmt.Errorf("api config is nil, want a populated config map")
+		}
+		if wantURL := rs.Primary.Attributes["config.url"]; wantURL != "" {
+			if gotURL := (*got.Config)["url"]; gotURL != wantURL {
+				return fmt.Errorf("api config.url = %q, want %q", gotURL, wantURL)
+			}
 		}
 
 		*config = *got
@@ -107,7 +155,7 @@ func testAccScmCheckExists(rn string, integration string, config *openapi.ScmPro
 	}
 }
 
-func testAccRundeckScmExportConfig_basic(gitURL string, keyPath string) string {
+func testAccRundeckScmExportConfig_basic(gitURL string, keyPath string, branch string) string {
 	return fmt.Sprintf(`
 resource "rundeck_private_key" "test" {
   path         = "terraform_acceptance_tests/scm_export_key"
@@ -131,7 +179,7 @@ resource "rundeck_scm_export" "test" {
   config = {
     url                   = %q
     dir                   = "/tmp/rundeck-scm-test-export"
-    branch                = "main"
+    branch                = %q
     createBranch          = "true"
     committerName         = "terraform-test"
     committerEmail        = "terraform-test@example.com"
@@ -143,5 +191,5 @@ resource "rundeck_scm_export" "test" {
 
   depends_on = [rundeck_private_key.test]
 }
-`, keyPath, gitURL)
+`, keyPath, gitURL, branch)
 }

--- a/rundeck/resource_scm_test.go
+++ b/rundeck/resource_scm_test.go
@@ -32,7 +32,7 @@ func TestAccRundeckScmExport_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
-		CheckDestroy:             testAccScmCheckDestroy("export", &config),
+		CheckDestroy:             testAccScmCheckDestroy("export"),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRundeckScmExportConfig_basic(gitURL, keyPath),
@@ -47,27 +47,36 @@ func TestAccRundeckScmExport_basic(t *testing.T) {
 	})
 }
 
-func testAccScmCheckDestroy(integration string, config *openapi.ScmProjectPluginConfig) resource.TestCheckFunc {
+// testAccScmCheckDestroy reads the project to verify straight from Terraform
+// state, rather than from a side-channel pointer populated by
+// testAccScmCheckExists - that pointer is only set if the exists check ran
+// and succeeded, so if an earlier step's apply/Check failed first, a
+// destroy-time check keyed on it would silently pass without ever asking the
+// API whether the plugin was actually disabled.
+func testAccScmCheckDestroy(integration string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		clients, err := getTestClients()
 		if err != nil {
 			return fmt.Errorf("failed to create test client: %s", err)
 		}
 
-		project := ""
-		if config.Project != nil {
-			project = *config.Project
-		}
-		if project == "" {
-			return nil
-		}
+		resourceType := "rundeck_scm_" + integration
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != resourceType {
+				continue
+			}
+			project := rs.Primary.Attributes["project"]
+			if project == "" {
+				return fmt.Errorf("%s %s has no project attribute in state to verify destruction against", resourceType, rs.Primary.ID)
+			}
 
-		got, resp, err := clients.V2.SCMAPI.ApiProjectConfig(clients.ctx, project, integration).Execute()
-		if resp != nil && resp.StatusCode == 404 {
-			return nil
-		}
-		if err == nil && got != nil && got.Enabled != nil && *got.Enabled {
-			return fmt.Errorf("scm %s plugin still enabled for project: %s", integration, project)
+			got, resp, err := clients.V2.SCMAPI.ApiProjectConfig(clients.ctx, project, integration).Execute()
+			if resp != nil && resp.StatusCode == 404 {
+				continue
+			}
+			if err == nil && got != nil && got.Enabled != nil && *got.Enabled {
+				return fmt.Errorf("scm %s plugin still enabled for project: %s", integration, project)
+			}
 		}
 		return nil
 	}

--- a/rundeck/resource_scm_test.go
+++ b/rundeck/resource_scm_test.go
@@ -1,0 +1,138 @@
+package rundeck
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	openapi "github.com/rundeck/go-rundeck/rundeck-v2"
+)
+
+// TestAccRundeckScmExport_basic requires a git remote reachable from the
+// Rundeck *server* itself (not from wherever `go test` runs) - e.g. a bare
+// repo over SSH - and an SSH private key (readable locally, on the machine
+// running `go test`) authorized to push to it. Set RUNDECK_SCM_TEST_GIT_URL
+// (an SSH-form git URL, e.g. git@host:org/repo.git) and
+// RUNDECK_SCM_TEST_SSH_KEY_PATH (a local path to the matching PEM private
+// key) to run this; it's skipped if either is unset. The key's contents are
+// read by Terraform's own file() function at apply time, straight from
+// disk - never interpolated through this Go test code. There is no
+// Enterprise gate here - git/svn SCM plugins ship with OSS Rundeck (v15+).
+func TestAccRundeckScmExport_basic(t *testing.T) {
+	gitURL := os.Getenv("RUNDECK_SCM_TEST_GIT_URL")
+	keyPath := os.Getenv("RUNDECK_SCM_TEST_SSH_KEY_PATH")
+	if gitURL == "" || keyPath == "" {
+		t.Skip("Skipping TestAccRundeckScmExport_basic: RUNDECK_SCM_TEST_GIT_URL and RUNDECK_SCM_TEST_SSH_KEY_PATH must both be set")
+	}
+
+	var config openapi.ScmProjectPluginConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccScmCheckDestroy("export", &config),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRundeckScmExportConfig_basic(gitURL, keyPath),
+				Check: resource.ComposeTestCheckFunc(
+					testAccScmCheckExists("rundeck_scm_export.test", "export", &config),
+					resource.TestCheckResourceAttr("rundeck_scm_export.test", "type", "git-export"),
+					resource.TestCheckResourceAttr("rundeck_scm_export.test", "config.url", gitURL),
+					resource.TestCheckResourceAttr("rundeck_scm_export.test", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccScmCheckDestroy(integration string, config *openapi.ScmProjectPluginConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		clients, err := getTestClients()
+		if err != nil {
+			return fmt.Errorf("failed to create test client: %s", err)
+		}
+
+		project := ""
+		if config.Project != nil {
+			project = *config.Project
+		}
+		if project == "" {
+			return nil
+		}
+
+		got, resp, err := clients.V2.SCMAPI.ApiProjectConfig(clients.ctx, project, integration).Execute()
+		if resp != nil && resp.StatusCode == 404 {
+			return nil
+		}
+		if err == nil && got != nil && got.Enabled != nil && *got.Enabled {
+			return fmt.Errorf("scm %s plugin still enabled for project: %s", integration, project)
+		}
+		return nil
+	}
+}
+
+func testAccScmCheckExists(rn string, integration string, config *openapi.ScmProjectPluginConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+		if rs.Primary.Attributes["project"] == "" {
+			return fmt.Errorf("project not set")
+		}
+
+		clients, err := getTestClients()
+		if err != nil {
+			return fmt.Errorf("failed to create test client: %s", err)
+		}
+
+		got, resp, err := clients.V2.SCMAPI.ApiProjectConfig(clients.ctx, rs.Primary.Attributes["project"], integration).Execute()
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("failed to get scm %s config: %v", integration, err)
+		}
+
+		*config = *got
+		return nil
+	}
+}
+
+func testAccRundeckScmExportConfig_basic(gitURL string, keyPath string) string {
+	return fmt.Sprintf(`
+resource "rundeck_private_key" "test" {
+  path         = "terraform_acceptance_tests/scm_export_key"
+  key_material = file(%q)
+}
+
+resource "rundeck_project" "test" {
+  name        = "test-project-scm"
+  description = "Terraform acceptance test project for SCM export"
+
+  resource_model_source {
+    type   = "local"
+    config = {}
+  }
+}
+
+resource "rundeck_scm_export" "test" {
+  project = rundeck_project.test.name
+  type    = "git-export"
+
+  config = {
+    url                   = %q
+    dir                   = "/tmp/rundeck-scm-test-export"
+    branch                = "main"
+    createBranch          = "true"
+    committerName         = "terraform-test"
+    committerEmail        = "terraform-test@example.com"
+    pathTemplate          = "$${job.group}$${job.name}-$${job.id}.xml"
+    format                = "xml"
+    sshPrivateKeyPath     = "keys/${rundeck_private_key.test.path}"
+    strictHostKeyChecking = "no"
+  }
+
+  depends_on = [rundeck_private_key.test]
+}
+`, keyPath, gitURL)
+}

--- a/test/enterprise/README.md
+++ b/test/enterprise/README.md
@@ -256,6 +256,7 @@ rm -f terraform-provider-rundeck .terraformrc
 | `comprehensive.tf` | Complete test configuration with 9 test jobs |
 | `comprehensive.sh` | Automated comprehensive test runner |
 | `test-custom.sh` | **NEW** - Test your own Terraform plans |
+| `scm-testing.md` | Prerequisites and setup for `rundeck_scm_import`/`rundeck_scm_export` acceptance testing (`TestAccRundeckScmExport_basic`) - a real git remote reachable from the Rundeck server, plus a known GitHub/SSHJ compatibility issue and a recommended self-hosted alternative |
 | `README.md` | This file |
 
 ## Test Configuration

--- a/test/enterprise/scm-testing.md
+++ b/test/enterprise/scm-testing.md
@@ -1,0 +1,112 @@
+# SCM Integration Testing (`rundeck_scm_import` / `rundeck_scm_export`)
+
+`TestAccRundeckScmExport_basic` (in `rundeck/resource_scm_test.go`) exercises `rundeck_scm_export` against a
+real git remote and a real Rundeck server. This isn't Enterprise-gated - git/svn SCM plugins ship with core
+Rundeck (API v15+) - but it does need real network infrastructure the other acceptance tests don't, so it's
+self-skipping unless two env vars are set.
+
+## What the test needs
+
+1. **A git remote reachable from the Rundeck *server* process itself** - not from wherever `go test` runs.
+   If Rundeck is in Docker, the remote has to be reachable from inside that container's network namespace,
+   not just from the Docker host.
+2. **SSH auth only.** The test config uses `sshPrivateKeyPath`; no HTTPS path is exercised.
+3. **A deploy key (or account key) with write/push access** to that remote.
+4. **At least one existing commit on the remote's default branch.** The fixture sets `createBranch = "true"`
+   for `branch = "main"`, and `createBranch` creates that branch *from* the current default - a genuinely
+   empty (zero-commit) repository has no branch to base off of, and setup fails. (This was documented
+   incorrectly before - the old instructions said to create an *empty* repo. Fixed.)
+5. Two env vars:
+   - `RUNDECK_SCM_TEST_GIT_URL` - SSH-form git URL, e.g. `git@host:org/repo.git`
+   - `RUNDECK_SCM_TEST_SSH_KEY_PATH` - local path to the private key, readable from wherever `go test` runs
+     (not from inside the Rundeck container - Terraform's `file()` reads it directly and uploads it into
+     Rundeck's key storage via `rundeck_private_key`)
+
+## Known issue: GitHub doesn't currently work against this Rundeck build
+
+Tried this against a live Rundeck Enterprise 6.2.0-SNAPSHOT (API v59) container with a real private GitHub
+repo (`git@github.com:<owner>/<repo>.git`, one commit on `main`, a dedicated deploy key with write access).
+
+Confirmed independently, from inside the Rundeck container:
+- DNS resolves `github.com` fine.
+- Plain OpenSSH (`ssh -T git@github.com`) completes the handshake and authenticates successfully with the
+  deploy key - both an ed25519 key and an RSA-4096 key.
+
+But every `terraform apply` of `rundeck_scm_export` failed inside Rundeck's own git-fetch step:
+
+```
+400 Bad Request - Failed fetch from the repository:
+net.schmizz.sshj.connection.ConnectionException: Stream closed
+```
+
+Rundeck's server log shows its bundled SSH client (SSHJ 0.40.0) disconnecting itself
+(`Disconnected - BY_APPLICATION`) within about a second of the banner exchange, before any authentication is
+attempted - consistent with an algorithm-negotiation mismatch between SSHJ 0.40.0 and GitHub's current SSH
+server, not a key, network, or credentials problem. Identical failure with both key types, ruling out key
+type as the cause.
+
+This is generated entirely inside Rundeck's server (the `net.schmizz.sshj` package) - not something the
+Terraform provider produces or can influence. **Worth reporting to the Rundeck team** if it reproduces on a
+non-snapshot build; in the meantime, don't spend time debugging it further from this repo, and don't assume
+a failure against GitHub means the provider is broken - `TestAccProject_localSourceEmptyConfig` (no git
+involved) and the rest of the suite pass fine against the same server.
+
+## Recommended path: a self-hosted git server on the same Docker network
+
+Since the SSHJ/GitHub incompatibility is specific to GitHub's SSH server, testing against a self-hosted git
+server on the same Docker network as Rundeck sidesteps it entirely, and is more in keeping with this
+project's `test/oss` pattern (everything self-contained in Docker, no external dependencies or credentials
+to manage). Gitea is a good fit - lightweight, has an SSH git server built in.
+
+Sketch (adjust the network name to match whatever your Rundeck container is actually on -
+`docker network ls` / `docker inspect <rundeck-container> --format '{{json .NetworkSettings.Networks}}'`
+will show it):
+
+```yaml
+# test/enterprise/docker-compose.scm.yml (or add to whatever compose file brings up Rundeck)
+services:
+  gitea:
+    image: gitea/gitea:latest
+    environment:
+      - GITEA__server__DISABLE_SSH=false
+      - GITEA__security__INSTALL_LOCK=true
+    ports:
+      - "3000:3000"   # web UI, for creating the repo/deploy key from the host
+      - "2222:22"     # SSH, for you to push the initial commit from the host
+    networks:
+      - default        # same network Rundeck is on
+
+networks:
+  default:
+    name: <rundeck's-network-name>
+    external: true
+```
+
+Then, from the host (via the mapped `2222` port) or via Gitea's web UI:
+1. Create a repo, push one commit to its default branch.
+2. Add a deploy key with write access (Gitea supports this natively, same as GitHub).
+3. Point the test at Gitea's address **as reachable from inside the Rundeck container** - since Gitea is on
+   the same Docker network, that's the Gitea service's container name/port (e.g. `git@gitea:22`), not
+   `localhost:2222` (that mapping is only reachable from the host, not from inside another container on the
+   same network).
+
+```bash
+export RUNDECK_SCM_TEST_GIT_URL="git@gitea:<owner>/<repo>.git"
+export RUNDECK_SCM_TEST_SSH_KEY_PATH="/path/to/deploy-key"
+go test ./rundeck/... -run TestAccRundeckScmExport_basic -v
+```
+
+## Cleanup
+
+The test's own `CheckDestroy` disables the SCM plugin and Terraform destroys the project it creates
+(`test-project-scm`) as part of the normal test lifecycle. If a run is interrupted mid-test, clean up
+manually:
+
+```bash
+curl -X DELETE -H "X-Rundeck-Auth-Token: $RUNDECK_AUTH_TOKEN" \
+     "$RUNDECK_URL/api/59/project/test-project-scm"
+```
+
+If you added a GitHub deploy key while investigating the issue above and don't intend to keep debugging it,
+remove it (`gh repo deploy-key list --repo <owner>/<repo>` / `gh repo deploy-key delete <id>`) rather than
+leaving unused write-access keys around.

--- a/website/docs/r/scm_export.html.md
+++ b/website/docs/r/scm_export.html.md
@@ -1,0 +1,74 @@
+---
+layout: "rundeck"
+page_title: "Rundeck: rundeck_scm_export"
+sidebar_current: "docs-rundeck-resource-scm-export"
+description: |-
+  The rundeck_scm_export resource configures a Rundeck project's SCM export plugin (e.g. git-export, svn-export).
+---
+
+# rundeck\_scm\_export
+
+Configures and enables a project's SCM **export** plugin (e.g. `git-export`, `svn-export`) - job definitions committed from Rundeck out to a version control repository.
+
+**Requirements:** API v15+ (bundled with core Rundeck, not Enterprise-gated - git/svn SCM plugins ship with OSS Rundeck).
+
+## Example Usage
+
+```hcl
+resource "rundeck_private_key" "scm" {
+  path         = "terraform/scm_export_key"
+  key_material = file("~/.ssh/rundeck_scm_deploy_key")
+}
+
+resource "rundeck_project" "example" {
+  name        = "example"
+  description = "Example project"
+
+  resource_model_source {
+    type   = "local"
+    config = {}
+  }
+}
+
+resource "rundeck_scm_export" "example" {
+  project = rundeck_project.example.name
+  type    = "git-export"
+
+  config = {
+    url                   = "git@github.com:myorg/myproject-rundeck.git"
+    dir                   = "/var/rundeck/scm/example"
+    branch                = "main"
+    createBranch          = "true" # only needed if "main" doesn't exist yet on the remote
+    committerName         = "rundeck"
+    committerEmail        = "rundeck@example.com"
+    pathTemplate          = "$${job.group}$${job.name}-$${job.id}.xml"
+    format                = "xml"
+    sshPrivateKeyPath     = "keys/${rundeck_private_key.scm.path}"
+    strictHostKeyChecking = "no"
+  }
+}
+```
+
+## Argument Reference
+
+* `project` - (Required, Forces new resource) Name of the project to configure SCM export for.
+* `type` - (Required, Forces new resource) SCM plugin type name (e.g. `git-export`, `svn-export`). Changing this requires replacing the resource, since it amounts to reconfiguring from scratch.
+* `config` - (Required) Plugin-specific configuration key/value pairs. The set of required/valid keys is dynamic per plugin type - check Rundeck's SCM plugin setup page in the UI, or the plugin's documentation, for the exact keys it expects. Reference external secret storage for credential-like values (e.g. SSH key paths, not raw key material) rather than embedding secrets directly.
+
+  For the bundled `git-export` plugin specifically, confirmed against a live instance: `dir` (a local checkout directory on the Rundeck server) is required in addition to `url`; an SSH key referenced via `sshPrivateKeyPath` must use the **full** Rundeck key storage path including the `keys/` prefix (e.g. `keys/${rundeck_private_key.example.path}`, not just `${rundeck_private_key.example.path}`); and if `branch` doesn't already exist on the remote, you also need `createBranch = "true"`. `createBranch` creates the new branch based on `baseBranch` (default `master`) - a genuinely empty repository (zero commits) has no branch for it to base off of at all, so the remote repository needs at least one existing commit on some branch before `createBranch` can work.
+
+## Attributes Reference
+
+* `id` - The ID of this resource, in the form `"project:type"`.
+* `enabled` - Whether the plugin is currently enabled for the project.
+
+## Import
+
+```
+terraform import rundeck_scm_export.example my-project:git-export
+```
+
+## Notes
+
+- There is no dedicated "delete" operation for SCM plugin configuration - destroying this resource disables the plugin (`ApiProjectDisable`), which is the closest available operation. The configuration may still persist server-side in a disabled state; there's no API to fully remove it.
+- Rundeck has no validation/dry-run endpoint for SCM plugin config - invalid configuration is only caught at apply time, surfaced as a Rundeck-reported validation error.

--- a/website/docs/r/scm_export.html.md
+++ b/website/docs/r/scm_export.html.md
@@ -10,14 +10,16 @@ description: |-
 
 Configures and enables a project's SCM **export** plugin (e.g. `git-export`, `svn-export`) - job definitions committed from Rundeck out to a version control repository.
 
-**Requirements:** API v15+ (bundled with core Rundeck, not Enterprise-gated - git/svn SCM plugins ship with OSS Rundeck).
+**Requirements:** none beyond the provider's own minimum. The SCM API endpoints this resource uses have shipped with core Rundeck (not Enterprise-gated) since API v15, well below the provider's documented overall minimum of v46 (Rundeck 5.0.0+), so there's no separate version constraint to configure for.
 
 ## Example Usage
 
 ```hcl
 resource "rundeck_private_key" "scm" {
   path         = "terraform/scm_export_key"
-  key_material = file("~/.ssh/rundeck_scm_deploy_key")
+  # Terraform's file() does not expand a leading "~" - use an absolute
+  # path, or one relative to this module (e.g. "${path.module}/rundeck_scm_deploy_key").
+  key_material = file("/home/youruser/.ssh/rundeck_scm_deploy_key")
 }
 
 resource "rundeck_project" "example" {
@@ -72,3 +74,4 @@ terraform import rundeck_scm_export.example my-project:git-export
 
 - There is no dedicated "delete" operation for SCM plugin configuration - destroying this resource disables the plugin (`ApiProjectDisable`), which is the closest available operation. The configuration may still persist server-side in a disabled state; there's no API to fully remove it.
 - Rundeck has no validation/dry-run endpoint for SCM plugin config - invalid configuration is only caught at apply time, surfaced as a Rundeck-reported validation error.
+- This resource only configures the export plugin; it does not trigger an export action (committing job definitions out to the repository). Triggering SCM actions (e.g. export/commit/synch) is not currently supported by this provider - a successful `terraform apply` means the plugin is configured and enabled, not that anything has been committed.

--- a/website/docs/r/scm_import.html.md
+++ b/website/docs/r/scm_import.html.md
@@ -1,0 +1,61 @@
+---
+layout: "rundeck"
+page_title: "Rundeck: rundeck_scm_import"
+sidebar_current: "docs-rundeck-resource-scm-import"
+description: |-
+  The rundeck_scm_import resource configures a Rundeck project's SCM import plugin (e.g. git-import, svn-import).
+---
+
+# rundeck\_scm\_import
+
+Configures and enables a project's SCM **import** plugin (e.g. `git-import`, `svn-import`) - job definitions pulled into Rundeck from a version control repository.
+
+**Requirements:** API v15+ (bundled with core Rundeck, not Enterprise-gated - git/svn SCM plugins ship with OSS Rundeck).
+
+## Example Usage
+
+```hcl
+resource "rundeck_project" "example" {
+  name        = "example"
+  description = "Example project"
+
+  resource_model_source {
+    type   = "local"
+    config = {}
+  }
+}
+
+resource "rundeck_scm_import" "example" {
+  project = rundeck_project.example.name
+  type    = "git-import"
+
+  config = {
+    url    = "git@github.com:myorg/myproject-rundeck.git"
+    branch = "main"
+    format = "xml"
+  }
+}
+```
+
+## Argument Reference
+
+* `project` - (Required, Forces new resource) Name of the project to configure SCM import for.
+* `type` - (Required, Forces new resource) SCM plugin type name (e.g. `git-import`, `svn-import`). Changing this requires replacing the resource, since it amounts to reconfiguring from scratch.
+* `config` - (Required) Plugin-specific configuration key/value pairs. The set of required/valid keys is dynamic per plugin type - check Rundeck's SCM plugin setup page in the UI, or the plugin's documentation, for the exact keys it expects. Reference external secret storage for credential-like values (e.g. SSH key paths, not raw key material) rather than embedding secrets directly.
+
+## Attributes Reference
+
+* `id` - The ID of this resource, in the form `"project:type"`.
+* `enabled` - Whether the plugin is currently enabled for the project.
+
+## Import
+
+```
+terraform import rundeck_scm_import.example my-project:git-import
+```
+
+## Notes
+
+- There is no dedicated "delete" operation for SCM plugin configuration - destroying this resource disables the plugin (`ApiProjectDisable`), which is the closest available operation. The configuration may still persist server-side in a disabled state; there's no API to fully remove it.
+- Rundeck has no validation/dry-run endpoint for SCM plugin config - invalid configuration is only caught at apply time, surfaced as a Rundeck-reported validation error.
+- This resource only configures the import plugin; it does not trigger an import action (pulling jobs from the repository). Triggering SCM actions (e.g. import/commit/synch) is not currently supported by this provider.

--- a/website/docs/r/scm_import.html.md
+++ b/website/docs/r/scm_import.html.md
@@ -10,7 +10,7 @@ description: |-
 
 Configures and enables a project's SCM **import** plugin (e.g. `git-import`, `svn-import`) - job definitions pulled into Rundeck from a version control repository.
 
-**Requirements:** API v15+ (bundled with core Rundeck, not Enterprise-gated - git/svn SCM plugins ship with OSS Rundeck).
+**Requirements:** none beyond the provider's own minimum. The SCM API endpoints this resource uses have shipped with core Rundeck (not Enterprise-gated) since API v15, well below the provider's documented overall minimum of v46 (Rundeck 5.0.0+), so there's no separate version constraint to configure for.
 
 ## Example Usage
 

--- a/website/rundeck.erb
+++ b/website/rundeck.erb
@@ -43,6 +43,12 @@
             <li<%= sidebar_current("docs-rundeck-resource-public-key") %>>
               <a href="/docs/providers/rundeck/r/public_key.html">rundeck_public_key</a>
             </li>
+            <li<%= sidebar_current("docs-rundeck-resource-scm-export") %>>
+              <a href="/docs/providers/rundeck/r/scm_export.html">rundeck_scm_export</a>
+            </li>
+            <li<%= sidebar_current("docs-rundeck-resource-scm-import") %>>
+              <a href="/docs/providers/rundeck/r/scm_import.html">rundeck_scm_import</a>
+            </li>
             <li<%= sidebar_current("docs-rundeck-resource-system-runner") %>>
               <a href="/docs/providers/rundeck/r/system_runner.html">rundeck_system_runner</a>
             </li>


### PR DESCRIPTION
## Summary
- Adds `rundeck_scm_import` and `rundeck_scm_export`, sharing one implementation parameterized by the fixed "import"/"export" integration value. Closes #76.
- `config` is a generic `map(string)` since the valid/required keys are dynamic per plugin type (`git-export`, `svn-export`, etc.), discoverable via Rundeck's own plugin-input-schema endpoint (`GET /project/{project}/scm/{integration}/plugin/{type}/input`) rather than modeled client-side.
- Gated at API v15+ only - these endpoints are bundled with core Rundeck, not Enterprise-only.
- Also includes an unrelated, pre-existing fix to `rundeck_project` (explicit `resource_model_source { config = {} }` was being collapsed to `null` on read) - needed for this PR's own test fixtures, and also independently found/fixed in #<runner-data-sources PR> for the same reason. Whichever of the two merges first will absorb it for the other.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` all clean
- [x] `TestAccRundeckScmExport_basic` passes end-to-end against a real Rundeck instance and a real git remote (Gitea), including SSH key auth via `rundeck_private_key`, custom checkout directory, and branch-creation semantics
- [x] README documents the additional setup needed to run this locally (a git remote reachable from the Rundeck server + SSH deploy key, via `RUNDECK_SCM_TEST_GIT_URL`/`RUNDECK_SCM_TEST_SSH_KEY_PATH`)
- [x] Live testing surfaced and fixed several real requirements now documented in `website/docs/r/scm_export.html.md`: the setup request body must wrap plugin properties under a `config` key, `sshPrivateKeyPath` needs the full `keys/` storage path prefix, `dir` is required in addition to `url`, and `createBranch` needs the remote to already have at least one commit to base a new branch on

🤖 Generated with [Claude Code](https://claude.com/claude-code)