### PR TITLE
docs: finalize CHANGELOG for 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.4.0 (2026-08-27)
+
 **Bug Fixes**
 
 ### Job Resource
@@ -17,6 +19,36 @@
   The plan being perfectly valid, this only ever surfaced at apply time — and the job was left in Rundeck without its handler, so a workflow meant to stop on a condition simply ran on. Both directions now carry `type`, `configuration` and `nodeStep`, the latter distinguishing a workflow step from a node step (Rundeck answers it as a bool or as the string `"true"`, both accepted).
 
   Note that Rundeck itself refuses a workflow-step handler on a node-oriented workflow (*"Error Handlers for Node Steps must also be Node Steps"*), so a job guarded this way needs `strategy = "sequential"`.
+
+### Project Resource
+
+- **Fixed an explicit `resource_model_source { config = {} }` collapsing to `null` on read** - Rundeck accepts an empty `config` map on a resource model source plugin, but the read-back treated an empty map the same as an absent one and returned `null`, causing `Provider produced inconsistent result after apply` for any project declaring the block with no plugin-specific properties.
+
+### System Runner Resource
+
+- **Fixed a project not being fully detached from a runner on update** - Removing a project from `assigned_projects`/`assigned_projects_config` relied on `SaveRunner`'s overwrite semantics to clear that project's other per-project dispatch settings (`runner_as_node_enabled`, `remote_node_dispatch`, `runner_node_filter`) server-side, which wasn't guaranteed. `Update` now explicitly calls `RemoveProjectAssociation` for every project dropped from either attribute.
+
+**Enhancements**
+
+### Job Resource
+
+- **Added `node_intersect` to a job reference's `node_filters` `dispatch` block** - Rundeck's "Match Node Filter Intersection" setting (`jobref.nodefilters.dispatch.nodeIntersect`) had no equivalent in the provider, so a referenced job configured this way always ran on its own node set instead of the intersection with the calling job's. The setting is now settable and round-trips on read. Note that Rundeck honors `nodeIntersect` even when the reference sets no `filter` — it is the only `dispatch` field read independently of one — so a `dispatch` block carrying nothing but `node_intersect` is a valid configuration.
+
+- **Added `values_list_delimiter` to job options** - Rundeck stores an option's predefined choices as a single delimited string plus the delimiter used to split it (`Option.toMap` always emits `valuesListDelimiter` alongside `values`, defaulting it to a comma). The provider had no way to set it, so a choice containing a comma could not be represented — the option silently split into the wrong values. Distinct from the existing `multi_value_delimiter`, which separates the values a user selects rather than the ones offered.
+
+- **Added `notify_avg_duration_threshold` to `rundeck_job`** - The threshold that decides when the `on_avg_duration` notification fires (a duration, a percentage of the job's average duration, or an increment over it). Without it Rundeck reads the threshold as zero and the guard `jobAverageDurationFinal > 0` never passes, so an `on_avg_duration` notification was configured but could never fire.
+
+### System Execution Mode Resource
+
+- **Added `rundeck_system_execution_mode`** - Controls whether a server executes jobs (`active` / `passive`), the switch used during migrations and maintenance windows. Rundeck exposes this over the API (`system/executions/{status,enable,disable}`) but the provider had no way to reach it, so the mode could only be set through the `rundeck.executionMode` property — which is read at startup only, meaning a change required a restart and any manual switch went unnoticed until the next one. Managing it as a resource makes the intended mode explicit and surfaces out-of-band changes as drift. Removing the resource leaves the server untouched rather than flipping its mode.
+
+### Runner Data Sources
+
+- **Added `rundeck_runner`, `rundeck_runners`, and `rundeck_runner_tags`** - Data sources for looking up and enumerating Enterprise runners without managing them, closing the long-standing `data.rundeck_runner` TODO item.
+
+### Local Role Resource
+
+- **Added `rundeck_local_role`** - Create/read/update/delete for Rundeck Enterprise local user store roles (requires the local user store auth realm, API v44+), including membership management. There's no API endpoint to list a role's members directly, so membership is resolved by listing all local users and diffing against each one's roles. `rundeck_local_user` is intentionally not implemented: the vendored SDK has no request-body support for the user create/edit endpoints, a gap in Rundeck's own published OpenAPI spec.
 
 
 ## 1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 1.4.0 (2026-08-27)
+## 1.4.0
 
 **Bug Fixes**
 
@@ -48,7 +48,7 @@
 
 ### Local Role Resource
 
-- **Added `rundeck_local_role`** - Create/read/update/delete for Rundeck Enterprise local user store roles (requires the local user store auth realm, API v44+), including membership management. There's no API endpoint to list a role's members directly, so membership is resolved by listing all local users and diffing against each one's roles. `rundeck_local_user` is intentionally not implemented: the vendored SDK has no request-body support for the user create/edit endpoints, a gap in Rundeck's own published OpenAPI spec.
+- **Added `rundeck_local_role`** - Create/read/update/delete for Rundeck Enterprise local user store roles (requires the local user store auth realm; the resource's own API v44+ requirement is already covered by the provider's overall minimum of v46+), including membership management. There's no API endpoint to list a role's members directly, so membership is resolved by listing all local users and diffing against each one's roles. `rundeck_local_user` is intentionally not implemented: the vendored SDK has no request-body support for the user create/edit endpoints, a gap in Rundeck's own published OpenAPI spec.
 
 
 ## 1.3.1

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,19 @@
 
 Forward-looking tasks for the Rundeck Terraform Provider.
 
-**Current Status**: v1.2.0 released with webhooks, bug fixes, and max_concurrent_executions!  
-**Last Updated**: 2026-02-25 (v1.2.0 released)
+**Current Status**: 1.4.0 merged to `master` (not yet tagged) - local roles, system execution mode, runner data sources, plus job and system runner fixes. See `CHANGELOG.md` for full details.  
+**Last Updated**: 2026-08-27 (1.4.0 merged)
+
+---
+
+## ✅ Completed in 1.4.0
+
+- **`rundeck_local_role`** - Create/read/update/delete for Enterprise local user store roles, including membership management ([#291](https://github.com/rundeck/terraform-provider-rundeck/pull/291)). `rundeck_local_user` remains blocked - see the note under "New Resources (Other)" below.
+- **`rundeck_system_execution_mode`** - Controls whether a server executes jobs (`active`/`passive`) ([#287](https://github.com/rundeck/terraform-provider-rundeck/pull/287)).
+- **Runner data sources** - `rundeck_runner`, `rundeck_runners`, `rundeck_runner_tags`, closing the long-standing `data.rundeck_runner` item below ([#290](https://github.com/rundeck/terraform-provider-rundeck/pull/290)).
+- **`rundeck_system_runner` project detachment fix** - `Update` now explicitly clears per-project dispatch settings when a project is removed, instead of relying on unreliable overwrite semantics ([#290](https://github.com/rundeck/terraform-provider-rundeck/pull/290)).
+- **Job resource enhancements** - `node_intersect` on job reference dispatch blocks, `values_list_delimiter` for option choices, `notify_avg_duration_threshold` for `on_avg_duration` notifications ([#284](https://github.com/rundeck/terraform-provider-rundeck/pull/284), [#285](https://github.com/rundeck/terraform-provider-rundeck/pull/285)).
+- **SCM resources implemented, held from this release** - `rundeck_scm_import`/`rundeck_scm_export` are built and reviewed ([#292](https://github.com/rundeck/terraform-provider-rundeck/pull/292)) but not merged: acceptance testing surfaced a GitHub/SSHJ SSH handshake incompatibility that's on Rundeck's server side, not the provider. Held pending a Rundeck 6.2.0 fix; see the "SCM Integration Support" entry below for details.
 
 ---
 
@@ -37,7 +48,10 @@ Forward-looking tasks for the Rundeck Terraform Provider.
 **Effort**: Medium (1 week)  
 **Why Important**: Enables referencing existing Rundeck resources without managing them, common pattern in Terraform.
 
-**Priority Order**:
+**Completed in v1.4.0**:
+- ✅ `data.rundeck_runner`, `data.rundeck_runners`, `data.rundeck_runner_tags` - Look up and enumerate Enterprise runners
+
+**Remaining, priority order**:
 - `data.rundeck_project` - Look up project details, most requested
 - `data.rundeck_job` - Reference existing jobs by name/UUID
 - `data.rundeck_node` - Query nodes (lower priority)
@@ -194,28 +208,18 @@ After:  Error creating job "my-job" in project "prod": Rundeck returned validati
 ---
 
 ### SCM Integration Support
-**Effort**: Large (1-2 weeks)  
+**Effort**: Large (1-2 weeks) - **implemented, held from release**  
 **Why Important**: Users want to manage SCM configurations via Terraform.  
-**GitHub Issue**: [#76](https://github.com/rundeck/terraform-provider-rundeck/issues/76)
+**GitHub Issue**: [#76](https://github.com/rundeck/terraform-provider-rundeck/issues/76)  
+**PR**: [#292](https://github.com/rundeck/terraform-provider-rundeck/pull/292)
 
-**Feature Request**:
-Add support for Rundeck's Source Control Management (SCM) integration, allowing Terraform to configure Git import/export for projects.
+**Status**: `rundeck_scm_import` and `rundeck_scm_export` are implemented, reviewed, and passed acceptance testing for the resource logic itself. They're held out of 1.4.0 because that same acceptance testing (a Git-export config against a real GitHub remote) hit a GitHub/SSHJ SSH handshake incompatibility - confirmed via server logs to be on Rundeck's side (the SSHJ client disconnects before authentication completes), not a provider or SDK bug. A fix is going into Rundeck 6.2.0. Once that ships, re-run the SCM acceptance test against a real GitHub remote and merge.
 
-**Proposed Resources**:
-- `rundeck_scm_import` - Configure Git import for a project
-- `rundeck_scm_export` - Configure Git export for a project
-
-**API Support**:
-- Rundeck API v14+ supports SCM endpoints
-- Complex configuration schema varies by plugin
-- Authentication methods (SSH keys, tokens)
-
-**Priority Justification**:
-- Low demand (only 1 GitHub issue in 3 years)
-- Complex implementation
-- Workaround exists (manual SCM setup in Rundeck UI)
-
-**Recommendation**: Consider for future release if user demand increases
+**Resources** (as implemented):
+- `rundeck_scm_import` - Configure Git/SVN import for a project
+- `rundeck_scm_export` - Configure Git/SVN export for a project
+- `config` is a generic string map since valid keys are plugin-specific and discovered at runtime
+- Gated at API v15+ (ships with core Rundeck, not Enterprise-only)
 
 ---
 
@@ -234,6 +238,9 @@ Add support for Rundeck's Source Control Management (SCM) integration, allowing 
   upstream or the requests are hand-built, bypassing the generated client
   for those two calls.
 - `rundeck_execution` - Trigger/manage executions (questionable use case)
+
+**Completed in v1.4.0**:
+- ✅ `rundeck_local_role` - Enterprise local user store role CRUD + membership management
 
 **Completed in v1.2.0**:
 - ✅ `rundeck_webhook` - Webhook event handlers (fully implemented with all 8 plugin types)

--- a/website/docs/r/local_role.html.md
+++ b/website/docs/r/local_role.html.md
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Rundeck Enterprise local role, including its member usernames. Local roles are referenced by name (`authority`) from ACL policies (`rundeck_acl_policy`) to determine what a role is authorized to do; this resource manages the role and its membership, not what it's authorized to do.
 
-**Requirements:** Requires Rundeck Enterprise with the **local user store** authentication realm enabled, and API v44+. Configure the provider with `api_version = "44"` or higher. If your instance authenticates users via LDAP/SSO/PAM instead of the local user store, this resource will not work — Rundeck has no REST-manageable role concept for those realms.
+**Requirements:** Requires Rundeck Enterprise with the **local user store** authentication realm enabled. This resource's own requirement is `api_version` 44 or higher, but in practice this is already covered by the provider's overall minimum of 46 (Rundeck 5.0.0+), so it isn't a separate constraint you need to configure for. If your instance authenticates users via LDAP/SSO/PAM instead of the local user store, this resource will not work — Rundeck has no REST-manageable role concept for those realms.
 
 **Note:** This resource manages roles and role membership only. It does not create local user accounts — see the note below on `rundeck_local_user`.
 
@@ -20,7 +20,7 @@ Manages a Rundeck Enterprise local role, including its member usernames. Local r
 provider "rundeck" {
   url         = "http://localhost:4440"
   auth_token  = "your-token"
-  api_version = "44"
+  api_version = "46"
 }
 
 resource "rundeck_local_role" "operators" {


### PR DESCRIPTION
## What

Finalizes the `Unreleased` section of `CHANGELOG.md` into a `1.4.0` release entry, consolidating fixes/features from this release cycle:

- #284 - `node_intersect` on job reference `node_filters.dispatch`
- #285 - `values_list_delimiter` and `notify_avg_duration_threshold` for job options/notifications
- #287 - `rundeck_system_execution_mode` resource
- #290 - runner data sources (`rundeck_runner`, `rundeck_runners`, `rundeck_runner_tags`) + a real `system_runner` project-detach bug fix found during live acceptance testing
- #291 - `rundeck_local_role` resource

An empty `Unreleased` section is restored above `1.4.0` for subsequent work.

Also includes a refreshed `TODO.md` reflecting everything shipped in this release (previously still dated for v1.2.0).

## What's intentionally left out

#292 (`rundeck_scm_import`/`rundeck_scm_export`) is **not** included. It's deferred pending a Rundeck 6.2.0 fix for a GitHub/SSHJ SSH handshake incompatibility (confirmed to be a Rundeck server-side issue, not the provider - see the comment thread on that PR). It'll get its own changelog entry once it lands.

## Notes

- Docs-only change - `CHANGELOG.md` and `TODO.md`.
- Addressed Copilot review feedback: dropped the one-off release date on the `1.4.0` heading (inconsistent with recent convention) and corrected the `rundeck_local_role` entry's API version note (v44+ is the resource's own floor; the provider's documented minimum is v46+).
- The website nav fix and local_role api_version doc fix (previously #294/#295) are already merged directly to master and are reflected here via merge, not duplicated.