### PR TITLE
docs: add rundeck_system_execution_mode to website sidebar nav

### DIFF
--- a/website/rundeck.erb
+++ b/website/rundeck.erb
@@ -46,6 +46,9 @@
             <li<%= sidebar_current("docs-rundeck-resource-public-key") %>>
               <a href="/docs/providers/rundeck/r/public_key.html">rundeck_public_key</a>
             </li>
+            <li<%= sidebar_current("docs-rundeck-resource-system-execution-mode") %>>
+              <a href="/docs/providers/rundeck/r/system_execution_mode.html">rundeck_system_execution_mode</a>
+            </li>
             <li<%= sidebar_current("docs-rundeck-resource-system-runner") %>>
               <a href="/docs/providers/rundeck/r/system_runner.html">rundeck_system_runner</a>
             </li>


### PR DESCRIPTION
The doc page for `rundeck_system_execution_mode` (added in #287) has the correct `sidebar_current` front-matter key but was never linked from `website/rundeck.erb`'s Resources nav, so it wasn't reachable by browsing the docs site. Found while auditing docs completeness for the 1.4.0 release.