### PR TITLE
docs: correct rundeck_local_role api_version guidance

### DIFF
--- a/website/docs/r/local_role.html.md
+++ b/website/docs/r/local_role.html.md
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Rundeck Enterprise local role, including its member usernames. Local roles are referenced by name (`authority`) from ACL policies (`rundeck_acl_policy`) to determine what a role is authorized to do; this resource manages the role and its membership, not what it's authorized to do.
 
-**Requirements:** Requires Rundeck Enterprise with the **local user store** authentication realm enabled, and API v44+. Configure the provider with `api_version = "44"` or higher. If your instance authenticates users via LDAP/SSO/PAM instead of the local user store, this resource will not work — Rundeck has no REST-manageable role concept for those realms.
+**Requirements:** Requires Rundeck Enterprise with the **local user store** authentication realm enabled. This resource's own requirement is `api_version` 44 or higher, but in practice this is already covered by the provider's overall minimum of 46 (Rundeck 5.0.0+), so it isn't a separate constraint you need to configure for. If your instance authenticates users via LDAP/SSO/PAM instead of the local user store, this resource will not work — Rundeck has no REST-manageable role concept for those realms.
 
 **Note:** This resource manages roles and role membership only. It does not create local user accounts — see the note below on `rundeck_local_user`.
 
@@ -20,7 +20,7 @@ Manages a Rundeck Enterprise local role, including its member usernames. Local r
 provider "rundeck" {
   url         = "http://localhost:4440"
   auth_token  = "your-token"
-  api_version = "44"
+  api_version = "46"
 }
 
 resource "rundeck_local_role" "operators" {


### PR DESCRIPTION
Copilot's review on #293 flagged that the CHANGELOG's "API v44+" note for `rundeck_local_role` implied support below the provider's stated minimum (Rundeck 5.0.0 / API v46+, per README.md and the upgrading guide). The actual bug is in `local_role.html.md` itself, which the CHANGELOG entry was echoing: it told users to configure `api_version = "44"`, below the provider's own documented floor.

Fixed the doc's Requirements line and example to match the phrasing already used by `system_execution_mode.html.md` for the same situation (a resource's own minimum sitting below the provider's overall floor) — state the resource's real requirement, note it's already covered, and don't instruct a value below the provider's minimum.