### PR TITLE
docs: correct README's Go version requirement and enterprise test list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This provider is **community-supported**. While Rundeck/PagerDuty staff review a
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
-- [Go](https://golang.org/doc/install) >= 1.24
+- [Go](https://golang.org/doc/install) >= 1.25.8
 - [Rundeck](https://www.rundeck.com/) >= 5.0.0 (API v46+)
 
 > Note: Some features will require newer or Enterprise versions of Rundeck.
@@ -78,6 +78,8 @@ Some tests require **Rundeck Enterprise** features and will fail on Rundeck Comm
 
 **Enterprise-only features tested:**
 - **Runner resources** - System runners and project runners (5 tests)
+- **Runner data sources** - `rundeck_runner`, `rundeck_runners`, `rundeck_runner_tags`
+- **Local roles** - `rundeck_local_role` CRUD and membership (see the dedicated setup section below)
 - **Project schedules** - Job scheduling via project-level schedules (3 tests)
 - **Execution lifecycle plugins**
 
@@ -144,7 +146,7 @@ env:
 
 #### Test Requirements
 
-- **Go 1.24+** - Required for modern Terraform Plugin Framework
+- **Go 1.25.8+** - Required by `terraform-plugin-sdk/v2`
 - **Rundeck 5.0.0+** - Minimum supported version (API v46)
 - **Docker** - For local testing environment (optional but recommended)
 - **Rundeck Enterprise** - Only if running Enterprise feature tests

--- a/test/README.md
+++ b/test/README.md
@@ -134,13 +134,13 @@ Use the test configurations in this directory for manual validation:
 
 ### For OSS Testing
 - Docker and Docker Compose
-- Go 1.24+ (for building provider)
+- Go 1.25.8+ (for building provider)
 - jq (for JSON parsing in test scripts)
 
 ### For Enterprise Testing
 - Running Rundeck Enterprise instance (5.17.0+)
 - Valid API token with appropriate permissions
-- Go 1.24+ (for building provider)
+- Go 1.25.8+ (for building provider)
 - jq (for JSON parsing)
 
 ## Contributing
@@ -169,7 +169,7 @@ When adding new tests:
 - Review test logs in `/tmp/enterprise_test.log`
 
 **Provider build failures:**
-- Ensure Go 1.24+ is installed
+- Ensure Go 1.25.8+ is installed
 - Run `go mod tidy`
 - Clear Go cache: `go clean -cache`
 

--- a/test/enterprise/README.md
+++ b/test/enterprise/README.md
@@ -15,7 +15,7 @@ This directory contains comprehensive test configurations for Rundeck Enterprise
 ### Required
 - Running Rundeck Enterprise instance (5.17.0 or later)
 - Valid API token with admin/sufficient permissions
-- Go 1.24+ installed
+- Go 1.25.8+ installed
 - jq installed (`brew install jq` on macOS)
 
 ### Enterprise Features Tested
@@ -178,7 +178,7 @@ If build fails:
 # Ensure you're in the repo root
 cd /path/to/terraform-provider-rundeck
 
-# Check Go version (requires 1.24+)
+# Check Go version (requires 1.25.8+)
 go version
 
 # Try manual build


### PR DESCRIPTION
Checked whether README.md was current after #293. Found two real gaps:

- **Go version stale**: README says `Go >= 1.24` (both the top-level Requirements section and Test Requirements), but `go.mod`'s actual minimum is `1.25.8`, required transitively by `terraform-plugin-sdk/v2 v2.40.1`. Confirmed by temporarily lowering the `go` directive and rebuilding - it fails with `go: github.com/hashicorp/terraform-plugin-sdk/v2@v2.40.1 requires go >= 1.25.8`. A contributor with exactly Go 1.24 installed would hit a build failure the README doesn't warn about.
- **Enterprise test list incomplete**: added runner data sources and local roles to the "Enterprise-only features tested" list - both new in 1.4.0, both gated on `RUNDECK_ENTERPRISE_TESTS`, neither previously mentioned in that summary (local roles do have their own detailed setup section further down, this just makes the summary list match).