### PR TITLE
chore: update TODO.md reference after master -> main rename

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 Forward-looking tasks for the Rundeck Terraform Provider.
 
-**Current Status**: 1.4.0 merged to `master` (not yet tagged) - local roles, system execution mode, runner data sources, plus job and system runner fixes. See `CHANGELOG.md` for full details.  
+**Current Status**: 1.4.0 merged to `main` (not yet tagged) - local roles, system execution mode, runner data sources, plus job and system runner fixes. See `CHANGELOG.md` for full details.  
 **Last Updated**: 2026-08-27 (1.4.0 merged)
 
 ---


### PR DESCRIPTION
Follow-up to the default branch rename (master -> main). Checked the whole repo for hardcoded branch references:

- Workflows (`test.yml`, `release.yml`, `prepare-community-pr.yml`) - none filter on branch name, unaffected.
- `.goreleaser.yml` - tag-triggered only, unaffected.
- Active ruleset (id 9458535) - already targets `~DEFAULT_BRANCH` dynamically, now resolves to `main` automatically.
- Dependabot config - no pinned target-branch, follows the default branch automatically.
- No `blob/master`/`tree/master` links anywhere in docs.

`TODO.md` was the only remaining literal reference to `master`. This fixes it.