### PR TITLE
fix(job): move the job instead of replacing it when group_name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Unreleased
 
+**Enhancements**
+
+### Job Resource
+
+- **Changing `group_name` now moves the job instead of replacing it** - `group_name` carried `RequiresReplace`, so reorganising jobs into different groups destroyed and recreated each one, losing its UUID and its execution history along the way.
+
+  That constraint dated from when the update resolved the job by name + group + project: moving a job broke the resolution, and replacing it was the defensive answer. Since the update targets the job by the UUID held in state, the group takes no part in identifying it — `findByUuidAndProject` looks the job up by uuid and project alone — and the group in the payload is simply applied. `name` was already in this position and renames have worked in place since then; the group is the same case.
+
+  `project_name` keeps `RequiresReplace`: that lookup *is* scoped to a project, so moving a job across projects still has to recreate it.
+
+  Removing `group_name` from a configuration moves the job back to the project root. The payload omits the field, and Rundeck reads it back as `se.groupPath = data['group'] ? data['group'] : null` (`ScheduledExecution.fromMap`), so an absent group clears it.
+
+  **Behaviour change:** a plan that previously showed a job being destroyed and recreated now shows an in-place update. Jobs keep their UUID, so `jobref` references by UUID and documentation links survive a reorganisation, as does the execution history.
+
 ## 1.4.0
 
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
   Removing `group_name` from a configuration moves the job back to the project root. The payload omits the field, and Rundeck reads it back as `se.groupPath = data['group'] ? data['group'] : null` (`ScheduledExecution.fromMap`), so an absent group clears it.
 
-  **Behaviour change:** a plan that previously showed a job being destroyed and recreated now shows an in-place update. Jobs keep their UUID, so `jobref` references by UUID and documentation links survive a reorganisation, as does the execution history.
+  The read-back was changed to match: `group_name` now reads as null when the API returns no group, so a job moved to the project root outside Terraform shows as drift instead of leaving the old group in state forever. `group_name = ""` is rejected at plan time rather than silently behaving as "no group". And an update whose import comes back under a different id — which is what resolution by name rather than by uuid looks like — is now an error naming both jobs, instead of silently pointing state at the duplicate.
+
+  **Behaviour change:** a plan that previously showed a job being destroyed and recreated now shows an in-place update. Jobs keep their UUID, so `jobref` references by UUID, `rundeck_webhook.job_id`, and documentation links survive a reorganisation, as does the execution history. Job references written by *name* carry the group they expect and do not follow a move — see the upgrade guide.
 
 ## 1.4.0
 

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -22,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -175,7 +177,10 @@ func (r *jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			// project_name still replaces, its lookup being scoped to a project.
 			"group_name": schema.StringAttribute{
 				Optional:    true,
-				Description: "Job group name. Changing it moves the job; leave it unset for the project root.",
+				Description: "Job group name. Changing it moves the job; omit it for the project root.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"project_name": schema.StringAttribute{
 				Required:    true,
@@ -926,6 +931,16 @@ func (r *jobResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	// Read the job back from API to ensure state matches what's actually stored
 	// This is important for fields like notifications which are sorted by the API
 	jobID := importResult.Succeeded[0].ID
+	if jobID != plan.ID.ValueString() {
+		resp.Diagnostics.AddError(
+			"Update created a second job instead of updating the existing one",
+			fmt.Sprintf("The update targeted job %q but Rundeck answered with %q, which means it resolved the import by name rather than by uuid and created a new job.\n\n"+
+				"Job %q is still in Rundeck, holding the execution history, and is no longer referenced by Terraform. Remove one of the two by hand before applying again.",
+				plan.ID.ValueString(), jobID, plan.ID.ValueString()),
+		)
+		return
+	}
+
 	apiJobData, err := GetJobJSON(r.client.V1, jobID)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -1396,7 +1411,9 @@ func (r *jobResource) jobJSONAPIToState(ctx context.Context, job *JobJSON, state
 	state.ID = types.StringValue(job.ID)
 	state.Name = types.StringValue(job.Name)
 
-	// Only set group_name if API returns a non-empty value
+	// toMap emits "group" exactly when the job has one, so an absent group means
+	// the job sits at the project root and must read back as null.
+	state.GroupName = types.StringNull()
 	if job.Group != "" {
 		state.GroupName = types.StringValue(job.Group)
 	}

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -170,12 +170,12 @@ func (r *jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Required:    true,
 				Description: "Job name",
 			},
+			// No RequiresReplace: the update resolves the job by uuid, so the group
+			// no longer takes part in identifying it and Rundeck moves the job.
+			// project_name still replaces, its lookup being scoped to a project.
 			"group_name": schema.StringAttribute{
 				Optional:    true,
-				Description: "Job group name",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
+				Description: "Job group name. Changing it moves the job; leave it unset for the project root.",
 			},
 			"project_name": schema.StringAttribute{
 				Required:    true,

--- a/rundeck/resource_job_group_move_test.go
+++ b/rundeck/resource_job_group_move_test.go
@@ -1,0 +1,292 @@
+package rundeck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// A configured group must reach the payload, which is what moves the job.
+func TestPlanToJobJSON_carriesGroupName(t *testing.T) {
+	r := &jobResource{}
+	job, err := r.planToJobJSON(context.Background(), &jobResourceModel{
+		Name:        types.StringValue("test-job"),
+		ProjectName: types.StringValue("test-project"),
+		Command:     testSingleShellCommandList(t),
+		GroupName:   types.StringValue("reorg/after"),
+	})
+	if err != nil {
+		t.Fatalf("planToJobJSON: %v", err)
+	}
+
+	if job.Group != "reorg/after" {
+		t.Errorf("group = %q, want %q", job.Group, "reorg/after")
+	}
+}
+
+// A null group must leave "group" out of the payload entirely. That omission is
+// what clears the group: Rundeck reads it back as
+// se.groupPath = data['group'] ? data['group'] : null (ScheduledExecution.fromMap),
+// so an absent key moves the job to the project root. Sending an empty string
+// would be indistinguishable here, but only because omitempty drops it — this
+// test pins that, since the module configures null rather than "".
+func TestPlanToJobJSON_omitsNullGroupNameSoTheJobMovesToTheRoot(t *testing.T) {
+	r := &jobResource{}
+	job, err := r.planToJobJSON(context.Background(), &jobResourceModel{
+		Name:        types.StringValue("test-job"),
+		ProjectName: types.StringValue("test-project"),
+		Command:     testSingleShellCommandList(t),
+	})
+	if err != nil {
+		t.Fatalf("planToJobJSON: %v", err)
+	}
+
+	raw, err := json.Marshal(job)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if v, exists := decoded["group"]; exists {
+		t.Errorf("group = %v, want it omitted so Rundeck moves the job to the project root", v)
+	}
+}
+
+// TestAccJob_groupNameMovesInPlace is the behavioural test. Changing group_name
+// must move the job rather than replace it: same UUID, same execution history,
+// and the group actually changed server-side. The last step clears the group,
+// which is how the job returns to the project root.
+func TestAccJob_groupNameMovesInPlace(t *testing.T) {
+	var (
+		jobUUID          string
+		executionsBefore []string
+	)
+
+	captureAndGiveItHistory := func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["rundeck_job.test"]
+		if !ok {
+			return fmt.Errorf("rundeck_job.test not found in state")
+		}
+		jobUUID = rs.Primary.ID
+
+		clients, err := getTestClients()
+		if err != nil {
+			return fmt.Errorf("error getting test client: %s", err)
+		}
+		if _, err := runJob(clients, jobUUID); err != nil {
+			return fmt.Errorf("could not run the job to give it an execution history: %s", err)
+		}
+		executionsBefore, err = jobExecutionIDs(clients, jobUUID)
+		if err != nil {
+			return fmt.Errorf("could not list executions: %s", err)
+		}
+		if len(executionsBefore) == 0 {
+			return fmt.Errorf("job has no execution after being run, so the history check below would prove nothing")
+		}
+		return nil
+	}
+
+	requireMovedInPlace := func(wantGroup string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			rs, ok := s.RootModule().Resources["rundeck_job.test"]
+			if !ok {
+				return fmt.Errorf("rundeck_job.test not found in state")
+			}
+			if rs.Primary.ID != jobUUID {
+				return fmt.Errorf("job id changed across the move: %s -> %s (the job was replaced instead of moved)",
+					jobUUID, rs.Primary.ID)
+			}
+
+			clients, err := getTestClients()
+			if err != nil {
+				return fmt.Errorf("error getting test client: %s", err)
+			}
+
+			job, err := GetJobJSON(clients.V1, jobUUID)
+			if err != nil {
+				return fmt.Errorf("could not read job back: %s", err)
+			}
+			if job.Group != wantGroup {
+				return fmt.Errorf("group server-side = %q, want %q (the job did not move)", job.Group, wantGroup)
+			}
+
+			after, err := jobExecutionIDs(clients, jobUUID)
+			if err != nil {
+				return fmt.Errorf("could not list executions: %s", err)
+			}
+			kept := make(map[string]bool, len(after))
+			for _, id := range after {
+				kept[id] = true
+			}
+			for _, id := range executionsBefore {
+				if !kept[id] {
+					return fmt.Errorf("execution %s is gone after the move: the job was recreated and its history lost", id)
+				}
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccJobCheckDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_groupBefore,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rundeck_job.test", "group_name", "reorg/before"),
+					captureAndGiveItHistory,
+				),
+			},
+			{
+				Config: testAccJobConfig_groupAfter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rundeck_job.test", "group_name", "reorg/after"),
+					requireMovedInPlace("reorg/after"),
+				),
+			},
+			{
+				// group_name absent from the configuration: the job goes back to
+				// the project root, still without being replaced.
+				Config: testAccJobConfig_groupCleared,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("rundeck_job.test", "group_name"),
+					requireMovedInPlace(""),
+				),
+			},
+			{
+				Config:   testAccJobConfig_groupCleared,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// runJob starts the job and returns the id of the execution Rundeck recorded.
+func runJob(clients *RundeckClients, jobID string) (string, error) {
+	url := fmt.Sprintf("%s/api/%s/job/%s/run", clients.BaseURL, clients.APIVersion, jobID)
+
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Rundeck-Auth-Token", clients.Token)
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var execution struct {
+		ID int `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&execution); err != nil {
+		return "", fmt.Errorf("decoding run response (status %d): %w", resp.StatusCode, err)
+	}
+	if resp.StatusCode != http.StatusOK || execution.ID == 0 {
+		return "", fmt.Errorf("run returned status %d with execution id %d", resp.StatusCode, execution.ID)
+	}
+	return strconv.Itoa(execution.ID), nil
+}
+
+// jobExecutionIDs lists every execution Rundeck holds for the job.
+func jobExecutionIDs(clients *RundeckClients, jobID string) ([]string, error) {
+	url := fmt.Sprintf("%s/api/%s/job/%s/executions", clients.BaseURL, clients.APIVersion, jobID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Rundeck-Auth-Token", clients.Token)
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var body struct {
+		Executions []struct {
+			ID int `json:"id"`
+		} `json:"executions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decoding executions response (status %d): %w", resp.StatusCode, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("listing executions returned status %d", resp.StatusCode)
+	}
+
+	ids := make([]string, 0, len(body.Executions))
+	for _, e := range body.Executions {
+		ids = append(ids, strconv.Itoa(e.ID))
+	}
+	return ids, nil
+}
+
+const testAccJobConfig_groupProject = `
+resource "rundeck_project" "test" {
+  name        = "terraform-acc-test-job-group-move"
+  description = "Test project for moving a job between groups"
+  resource_model_source {
+    type = "file"
+    config = {
+      format = "resourceyaml"
+      file   = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+`
+
+const testAccJobConfig_groupBefore = testAccJobConfig_groupProject + `
+resource "rundeck_job" "test" {
+  project_name      = rundeck_project.test.name
+  name              = "job-to-move"
+  group_name        = "reorg/before"
+  description       = "Job that will be moved between groups"
+  execution_enabled = true
+  command {
+    shell_command = "echo hello"
+  }
+}
+`
+
+const testAccJobConfig_groupAfter = testAccJobConfig_groupProject + `
+resource "rundeck_job" "test" {
+  project_name      = rundeck_project.test.name
+  name              = "job-to-move"
+  group_name        = "reorg/after"
+  description       = "Job that will be moved between groups"
+  execution_enabled = true
+  command {
+    shell_command = "echo hello"
+  }
+}
+`
+
+const testAccJobConfig_groupCleared = testAccJobConfig_groupProject + `
+resource "rundeck_job" "test" {
+  project_name      = rundeck_project.test.name
+  name              = "job-to-move"
+  description       = "Job that will be moved between groups"
+  execution_enabled = true
+  command {
+    shell_command = "echo hello"
+  }
+}
+`

--- a/rundeck/resource_job_group_move_test.go
+++ b/rundeck/resource_job_group_move_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -84,16 +85,12 @@ func TestAccJob_groupNameMovesInPlace(t *testing.T) {
 		if err != nil {
 			return fmt.Errorf("error getting test client: %s", err)
 		}
-		if _, err := runJob(clients, jobUUID); err != nil {
-			return fmt.Errorf("could not run the job to give it an execution history: %s", err)
-		}
-		executionsBefore, err = jobExecutionIDs(clients, jobUUID)
+		executionID, err := testRunJob(clients, jobUUID)
 		if err != nil {
-			return fmt.Errorf("could not list executions: %s", err)
+			return fmt.Errorf("could not run the job to give it an execution history: %s "+
+				"(a server left in passive execution mode refuses to run jobs)", err)
 		}
-		if len(executionsBefore) == 0 {
-			return fmt.Errorf("job has no execution after being run, so the history check below would prove nothing")
-		}
+		executionsBefore = []string{executionID}
 		return nil
 	}
 
@@ -102,6 +99,9 @@ func TestAccJob_groupNameMovesInPlace(t *testing.T) {
 			rs, ok := s.RootModule().Resources["rundeck_job.test"]
 			if !ok {
 				return fmt.Errorf("rundeck_job.test not found in state")
+			}
+			if jobUUID == "" {
+				return fmt.Errorf("no job captured: this check needs a prior step to record the job and its executions")
 			}
 			if rs.Primary.ID != jobUUID {
 				return fmt.Errorf("job id changed across the move: %s -> %s (the job was replaced instead of moved)",
@@ -118,10 +118,13 @@ func TestAccJob_groupNameMovesInPlace(t *testing.T) {
 				return fmt.Errorf("could not read job back: %s", err)
 			}
 			if job.Group != wantGroup {
-				return fmt.Errorf("group server-side = %q, want %q (the job did not move)", job.Group, wantGroup)
+				return fmt.Errorf("group server-side = %q, want %q", job.Group, wantGroup)
 			}
 
-			after, err := jobExecutionIDs(clients, jobUUID)
+			if len(executionsBefore) == 0 {
+				return fmt.Errorf("no executions recorded before the move, so the history check would prove nothing")
+			}
+			after, err := testJobExecutionIDs(clients, jobUUID)
 			if err != nil {
 				return fmt.Errorf("could not list executions: %s", err)
 			}
@@ -144,102 +147,100 @@ func TestAccJob_groupNameMovesInPlace(t *testing.T) {
 		CheckDestroy:             testAccJobCheckDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_groupBefore,
+				Config: testAccJobConfig_group(`group_name        = "reorg/before"`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("rundeck_job.test", "group_name", "reorg/before"),
 					captureAndGiveItHistory,
+					requireMovedInPlace("reorg/before"),
 				),
 			},
 			{
-				Config: testAccJobConfig_groupAfter,
+				Config: testAccJobConfig_group(`group_name        = "reorg/after"`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("rundeck_job.test", "group_name", "reorg/after"),
 					requireMovedInPlace("reorg/after"),
 				),
 			},
 			{
+				Config:   testAccJobConfig_group(`group_name        = "reorg/after"`),
+				PlanOnly: true,
+			},
+			{
 				// group_name absent from the configuration: the job goes back to
 				// the project root, still without being replaced.
-				Config: testAccJobConfig_groupCleared,
+				Config: testAccJobConfig_group(""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("rundeck_job.test", "group_name"),
 					requireMovedInPlace(""),
 				),
 			},
 			{
-				Config:   testAccJobConfig_groupCleared,
+				Config:   testAccJobConfig_group(""),
 				PlanOnly: true,
 			},
 		},
 	})
 }
 
-// runJob starts the job and returns the id of the execution Rundeck recorded.
-func runJob(clients *RundeckClients, jobID string) (string, error) {
-	url := fmt.Sprintf("%s/api/%s/job/%s/run", clients.BaseURL, clients.APIVersion, jobID)
-
-	req, err := http.NewRequest("POST", url, nil)
-	if err != nil {
-		return "", err
+// testRunJob starts the job and returns the id of the execution Rundeck recorded.
+func testRunJob(clients *RundeckClients, jobID string) (string, error) {
+	resp, err := clients.V2.JobsAPI.ApiJobRun(clients.ctx, jobID).Execute()
+	if resp != nil {
+		defer resp.Body.Close()
 	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Rundeck-Auth-Token", clients.Token)
-
-	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("running job %s: %w", jobID, err)
 	}
-	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("running job %s returned status %d: %s", jobID, resp.StatusCode, testTruncate(body))
+	}
+	if readErr != nil {
+		return "", fmt.Errorf("reading run response: %w", readErr)
+	}
 
 	var execution struct {
 		ID int `json:"id"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&execution); err != nil {
-		return "", fmt.Errorf("decoding run response (status %d): %w", resp.StatusCode, err)
+	if err := json.Unmarshal(body, &execution); err != nil {
+		return "", fmt.Errorf("decoding run response %s: %w", testTruncate(body), err)
 	}
-	if resp.StatusCode != http.StatusOK || execution.ID == 0 {
-		return "", fmt.Errorf("run returned status %d with execution id %d", resp.StatusCode, execution.ID)
+	if execution.ID == 0 {
+		return "", fmt.Errorf("run response carried no execution id: %s", testTruncate(body))
 	}
 	return strconv.Itoa(execution.ID), nil
 }
 
-// jobExecutionIDs lists every execution Rundeck holds for the job.
-func jobExecutionIDs(clients *RundeckClients, jobID string) ([]string, error) {
-	url := fmt.Sprintf("%s/api/%s/job/%s/executions", clients.BaseURL, clients.APIVersion, jobID)
-
-	req, err := http.NewRequest("GET", url, nil)
+// testJobExecutionIDs lists every execution Rundeck holds for the job.
+func testJobExecutionIDs(clients *RundeckClients, jobID string) ([]string, error) {
+	list, err := clients.V1.JobExecutionList(clients.ctx, jobID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing executions of job %s: %w", jobID, err)
 	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("X-Rundeck-Auth-Token", clients.Token)
-
-	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	var body struct {
-		Executions []struct {
-			ID int `json:"id"`
-		} `json:"executions"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return nil, fmt.Errorf("decoding executions response (status %d): %w", resp.StatusCode, err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("listing executions returned status %d", resp.StatusCode)
+	if list.Executions == nil {
+		return nil, nil
 	}
 
-	ids := make([]string, 0, len(body.Executions))
-	for _, e := range body.Executions {
-		ids = append(ids, strconv.Itoa(e.ID))
+	ids := make([]string, 0, len(*list.Executions))
+	for _, e := range *list.Executions {
+		if e.ID != nil {
+			ids = append(ids, strconv.Itoa(int(*e.ID)))
+		}
 	}
 	return ids, nil
 }
 
-const testAccJobConfig_groupProject = `
+func testTruncate(body []byte) string {
+	const max = 512
+	if len(body) > max {
+		return string(body[:max]) + "…"
+	}
+	return string(body)
+}
+
+func testAccJobConfig_group(groupLine string) string {
+	return fmt.Sprintf(`
 resource "rundeck_project" "test" {
   name        = "terraform-acc-test-job-group-move"
   description = "Test project for moving a job between groups"
@@ -251,42 +252,16 @@ resource "rundeck_project" "test" {
     }
   }
 }
-`
 
-const testAccJobConfig_groupBefore = testAccJobConfig_groupProject + `
 resource "rundeck_job" "test" {
   project_name      = rundeck_project.test.name
   name              = "job-to-move"
-  group_name        = "reorg/before"
+  %s
   description       = "Job that will be moved between groups"
   execution_enabled = true
   command {
     shell_command = "echo hello"
   }
 }
-`
-
-const testAccJobConfig_groupAfter = testAccJobConfig_groupProject + `
-resource "rundeck_job" "test" {
-  project_name      = rundeck_project.test.name
-  name              = "job-to-move"
-  group_name        = "reorg/after"
-  description       = "Job that will be moved between groups"
-  execution_enabled = true
-  command {
-    shell_command = "echo hello"
-  }
+`, groupLine)
 }
-`
-
-const testAccJobConfig_groupCleared = testAccJobConfig_groupProject + `
-resource "rundeck_job" "test" {
-  project_name      = rundeck_project.test.name
-  name              = "job-to-move"
-  description       = "Job that will be moved between groups"
-  execution_enabled = true
-  command {
-    shell_command = "echo hello"
-  }
-}
-`

--- a/website/docs/guides/upgrading.html.md
+++ b/website/docs/guides/upgrading.html.md
@@ -299,3 +299,34 @@ If you encounter issues during upgrade:
 - No breaking changes from v1.1.x
 - Adds webhook resource
 - Bug fixes for import and option enforcement
+
+### Changing a job's group is now an in-place move
+
+Changing `group_name` on a `rundeck_job` used to destroy and recreate the job. It now moves it:
+the job keeps its UUID and its execution history.
+
+**What changes in your plans.** A line that read `# rundeck_job.x must be replaced` now reads
+`~ update in-place`. Nothing in your configuration has to change, but a reorganisation that you
+previously treated as destructive is no longer one — and conversely, a plan you would have
+reviewed carefully because it said "replace" now looks routine while still moving a live job.
+
+**What to check before applying.** Job references written by name carry the group they expect:
+
+```hcl
+command {
+  job {
+    name       = "cleanup-temp-files"
+    group_name = "ops/maintenance"
+  }
+}
+```
+
+Moving `cleanup-temp-files` leaves that reference pointing at a group the job has left. The
+referring job plans and applies cleanly — none of its own attributes changed — and only fails
+the next time it executes. Terraform has no dependency edge that would catch this. Update those
+references in the same change, or reference the target by `uuid`, which does follow the move.
+
+References by `uuid`, `rundeck_webhook.job_id`, documentation links and bookmarks all survive a
+move, where previously the replacement broke every one of them.
+
+`project_name` is unaffected: moving a job to another project still destroys and recreates it.

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -290,6 +290,10 @@ The following arguments are supported:
   place the job at the project root — removing it from an existing configuration moves the
   job back there. Note that `project_name` behaves differently: moving a job to another
   project still destroys and recreates it.
+  **Job references by name do not follow a move.** A `jobref` written as
+  `job { name = "…" group_name = "…" }` names the group it expects, and Terraform has no
+  dependency edge to catch it: the referring job plans and applies clean, then fails the next
+  time it runs. Update those references in the same change, or reference by `uuid` instead.
   Setting this creates collapsable subcategories within the Rundeck UI's project job index.
 
 * `log_level` - (Optional) The log level that Rundeck should use for this job. Defaults to "INFO".

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -285,6 +285,11 @@ The following arguments are supported:
 * `default_tab` - (Optional) The default tab to show during job execution. Set to 'output' to follow the execution log. Must be set to `output`, `html`, or `nodes`
 
 * `group_name` - (Optional) The name of a group within the project in which to place the job.
+  Changing it moves the job in place: the job keeps its UUID and its execution history, so
+  `jobref` references by UUID and documentation links survive a reorganisation. Omit it to
+  place the job at the project root — removing it from an existing configuration moves the
+  job back there. Note that `project_name` behaves differently: moving a job to another
+  project still destroys and recreates it.
   Setting this creates collapsable subcategories within the Rundeck UI's project job index.
 
 * `log_level` - (Optional) The log level that Rundeck should use for this job. Defaults to "INFO".


### PR DESCRIPTION
## What

`group_name` carries `RequiresReplace`, so reorganising jobs into different groups destroys and recreates each one — losing its UUID and its execution history along the way.

This removes that plan modifier, so a group change becomes an in-place update and Rundeck simply moves the job, and closes the two halves of the resource that could not observe the result.

## Why the constraint is obsolete

It dated from when `Update` resolved the job by name + group + project. Moving a job broke that resolution, and replacing it was the defensive answer.

Since [#286](https://github.com/rundeck/terraform-provider-rundeck/pull/286) (shipped in 1.4.0), the update carries the job's UUID and Rundeck takes its UUID-first path: `findByUuidAndProject(jobdata.uuid, jobdata.project)` in `ScheduledExecutionService.loadImportedJobs`. The group no longer takes part in identifying the job, and the group carried in the payload is applied by `_doupdateJob`.

`name` was already in exactly this position, and renames have worked in place since #286. The group is the same case.

**`project_name` deliberately keeps `RequiresReplace`.** That lookup *is* scoped to a project, so moving a job across projects still has to recreate it. The two constraints look symmetrical; they are not.

## The halves that had to change with it

Making the group mutable exposed two paths that could not observe the result:

- **`jobJSONAPIToState` guarded the group with `if job.Group != ""`,** so a cleared group could never reach state. A job moved to the project root outside Terraform showed no drift and the configured group was never restored. `toMap` emits `group` exactly when the job has one, so an absent group now reads back as null — restoring the TO/FROM symmetry the write side already had.

- **`Update` took the id the import answered with without checking it was the job it targeted.** Resolution by name rather than by uuid is newly reachable for a group change, since the group is precisely what stops matching; it would create a second job, and state would follow it silently, orphaning the original and the history this change exists to preserve. It is now an error naming both jobs.

Also, `group_name = ""` was indistinguishable from omitting it — `omitempty` dropped the key, Rundeck moved the job to the root, and state kept `""` with no diff. It is rejected at plan time.

## Clearing the group

Removing `group_name` moves the job back to the project root. `planToJobJSON` already sends `Group: plan.GroupName.ValueString()` with `json:"group,omitempty"`, so a null group is omitted — and Rundeck reads it back as:

```groovy
se.groupPath = data['group'] ? data['group'] : null   // ScheduledExecution.fromMap
```

An absent group therefore clears it. The unit test pins that omission, since it is the omission rather than any value that drives the behaviour.

## Testing

`TestAccJob_groupNameMovesInPlace` runs against a real Rundeck. It gives the job an execution history first — running it through the API and recording the execution — then verifies the starting group **server-side** before moving, so the test cannot pass for a job that was only ever *set* rather than moved. After the move it asserts all three together:

- the UUID is unchanged, so the job was moved rather than replaced;
- the execution recorded beforehand is still attached;
- the group actually changed server-side, read back via `GET /job/{id}`.

A further step removes `group_name` and checks the return to the project root, and both the move and the cleared state get a `PlanOnly` round-trip.

Verified green in CI against Rundeck 5.x (`--- PASS: TestAccJob_groupNameMovesInPlace (4.59s)`), alongside the full unit suite, `go build`, `gofmt` and `go vet`.

## Behaviour change

A plan that previously showed a job being destroyed and recreated now shows an in-place update. Jobs keep their UUID across a reorganisation, so `jobref` references by UUID, `rundeck_webhook.job_id`, documentation links and bookmarks survive it — as does the execution history.

Job references written by **name** carry the group they expect and do not follow a move: the referring job plans and applies cleanly, then fails the next time it executes, with no dependency edge to catch it. Both the resource page and a new entry in `website/docs/guides/upgrading.html.md` say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwXPD3tGmAmSdkRa9AxqaZ