### PR TITLE
feat(job): let a job's UUID come from the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 
   `uuid` is `Optional` + `Computed`: left unset it is read back from the server exactly as before, so existing configurations are unaffected and no state migration is needed. Set, it must be a canonical lowercase UUID and travels in the payload's `uuid` field — the one Rundeck reads back on import (`ScheduledExecution.fromMap`) and the one `uuidOption=preserve` acts on.
 
-  Setting `uuid` to the value a job already has plans as no change, so an existing estate can be pinned in place without recreating anything. Changing a `uuid` that is already set replaces the job, since Rundeck cannot renumber one in place; the plan shows the replacement and the provider warns, because the references that break live outside Terraform's state. Removing `uuid` from a configuration is not a change — the job keeps the UUID it has.
+  Setting `uuid` to the value a job already has plans as no change, so an existing estate can be pinned in place without recreating anything — including on state written before this attribute existed, where the job's UUID is recorded under `id` alone and is compared against that. Changing a `uuid` that is already set replaces the job, since Rundeck cannot renumber one in place; the plan shows the replacement and the provider warns alongside it, because the references that break live outside Terraform's state. Removing `uuid` from a configuration is not a change — the job keeps the UUID it has.
 
-  Two consequences worth noting. Rundeck constrains job UUIDs to be unique across the whole instance rather than per project (`ScheduledExecution.uuid(unique: true)`), so a colliding apply fails instead of creating a duplicate. And because `Create` sends `dupeOption=create`, re-applying against a job that already carries a pinned UUID now errors rather than silently creating a second job with a new UUID, as it did when the state was lost.
+  Rundeck constrains job UUIDs to be unique across the whole instance rather than per project (`ScheduledExecution.uuid(unique: true)`), and `Create` sends `dupeOption=create`, so creating a job whose pinned UUID is already taken fails instead of silently creating a duplicate under a fresh UUID. That can happen after a lost state file, or under `create_before_destroy` while the job being replaced still holds the UUID; the error now says so and points at `terraform import`.
+
+  A pinned UUID that Rundeck does not honour is reported as such rather than surfacing as `Provider produced inconsistent result after apply`, and the job is still recorded in state so it is not orphaned.
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+**Enhancements**
+
+### Job Resource
+
+- **Added a settable `uuid` to `rundeck_job`** - A job's UUID is its identity in Rundeck, and the provider had no way to supply one: the create payload carried no `uuid`, so the server minted a fresh one every time. Rebuilding an instance from the same Terraform therefore produced different UUIDs than the instance it replaced, breaking everything that refers to a job by UUID from outside Terraform — `jobref` blocks, documentation and runbook links, bookmarks. The create path already sent `uuidOption=preserve`, so there was simply nothing in the payload for it to preserve.
+
+  `uuid` is `Optional` + `Computed`: left unset it is read back from the server exactly as before, so existing configurations are unaffected and no state migration is needed. Set, it must be a canonical lowercase UUID and travels in the payload's `uuid` field — the one Rundeck reads back on import (`ScheduledExecution.fromMap`) and the one `uuidOption=preserve` acts on.
+
+  Setting `uuid` to the value a job already has plans as no change, so an existing estate can be pinned in place without recreating anything. Changing a `uuid` that is already set replaces the job, since Rundeck cannot renumber one in place; the plan shows the replacement and the provider warns, because the references that break live outside Terraform's state. Removing `uuid` from a configuration is not a change — the job keeps the UUID it has.
+
+  Two consequences worth noting. Rundeck constrains job UUIDs to be unique across the whole instance rather than per project (`ScheduledExecution.uuid(unique: true)`), so a colliding apply fails instead of creating a duplicate. And because `Create` sends `dupeOption=create`, re-applying against a job that already carries a pinned UUID now errors rather than silently creating a second job with a new UUID, as it did when the state was lost.
+
 ## 1.4.0
 
 **Bug Fixes**

--- a/rundeck/job.go
+++ b/rundeck/job.go
@@ -57,6 +57,7 @@ import (
 // - Matches Rundeck API v46+ JSON response format
 type JobJSON struct {
 	ID                         string                   `json:"id"`
+	UUID                       string                   `json:"uuid,omitempty"`
 	Name                       string                   `json:"name"`
 	Group                      string                   `json:"group,omitempty"`
 	Project                    string                   `json:"project"`

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -22,8 +24,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// Rundeck itself only constrains a job uuid to VALID_RESOURCE_NAME_REGEX, but its
+// UI, job references and documentation links all assume a UUID.
+var canonicalUUIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 type jobResource struct {
 	client *RundeckClients
@@ -32,6 +39,7 @@ type jobResource struct {
 // jobResourceModel represents the Terraform resource model
 type jobResourceModel struct {
 	ID                          types.String `tfsdk:"id"`
+	UUID                        types.String `tfsdk:"uuid"`
 	Name                        types.String `tfsdk:"name"`
 	GroupName                   types.String `tfsdk:"group_name"`
 	ProjectName                 types.String `tfsdk:"project_name"`
@@ -164,6 +172,25 @@ func (r *jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			// Set, the job's identity comes from the configuration, so the same
+			// Terraform rebuilds an instance with the same job UUIDs. Unset, it is
+			// computed from the server as before.
+			"uuid": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Job UUID. Set it to pin the job's identity across rebuilds of a Rundeck instance; leave it unset to let Rundeck generate one. Changing a configured value replaces the job.",
+				PlanModifiers: []planmodifier.String{
+					// The attribute being computed, only a configured change may replace.
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						canonicalUUIDPattern,
+						"must be a canonical lowercase UUID (8-4-4-4-12 hexadecimal digits), e.g. \"11111111-2222-3333-4444-555555555555\"",
+					),
 				},
 			},
 			"name": schema.StringAttribute{
@@ -571,6 +598,40 @@ func (r *jobResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 			}
 		}
 	}
+}
+
+// ModifyPlan warns when a configured uuid change is about to replace the job.
+// The replacement itself is visible in the plan; what it costs is not, since a
+// job's UUID is referenced from outside this state file.
+func (r *jobResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Nothing to compare while creating or destroying.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var stateUUID, configUUID types.String
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("uuid"), &stateUUID)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("uuid"), &configUUID)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Unconfigured, the uuid keeps whatever the server assigned: not a change.
+	if configUUID.IsNull() || configUUID.IsUnknown() || stateUUID.IsNull() {
+		return
+	}
+	if configUUID.Equal(stateUUID) {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeWarning(
+		path.Root("uuid"),
+		"Job UUID change replaces the job",
+		fmt.Sprintf("Changing uuid from %q to %q destroys this job and creates a new one under the new UUID.\n\n"+
+			"A job's UUID is how it is referenced outside Terraform: jobref blocks pointing at it by UUID (including in jobs this configuration does not manage), documentation and runbook links, and bookmarks all name the old UUID and will not follow the change. The job's execution history stays with the job being destroyed.\n\n"+
+			"If the intent is to pin this job's current identity rather than change it, set uuid to %q — that plans as no change.",
+			stateUUID.ValueString(), configUUID.ValueString(), stateUUID.ValueString()),
+	)
 }
 
 func (r *jobResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -1034,6 +1095,12 @@ func (r *jobResource) planToJobJSON(ctx context.Context, plan *jobResourceModel)
 		ScheduleEnabled:        plan.ScheduleEnabled.ValueBool(),
 	}
 
+	// "uuid" is the field the import reads back and that uuidOption=preserve acts
+	// on; omitted, the server mints one.
+	if !plan.UUID.IsNull() && !plan.UUID.IsUnknown() {
+		job.UUID = plan.UUID.ValueString()
+	}
+
 	if !plan.AllowConcurrentExecutions.IsNull() {
 		job.MultipleExecutions = plan.AllowConcurrentExecutions.ValueBool()
 	}
@@ -1238,6 +1305,7 @@ func (r *jobResource) planToJobJSON(ctx context.Context, plan *jobResourceModel)
 // jobJSONToState converts Rundeck job JSON to Terraform state
 func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *jobResourceModel) error {
 	state.ID = types.StringValue(job.ID)
+	state.UUID = types.StringValue(job.ID)
 	state.Name = types.StringValue(job.Name)
 	state.GroupName = types.StringValue(job.Group)
 	// Project name is not returned by JobGet API, preserve from current state
@@ -1394,6 +1462,7 @@ func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *j
 func (r *jobResource) jobJSONAPIToState(ctx context.Context, job *JobJSON, state *jobResourceModel) error {
 	// Map JSON fields directly to Terraform state
 	state.ID = types.StringValue(job.ID)
+	state.UUID = types.StringValue(job.ID)
 	state.Name = types.StringValue(job.Name)
 
 	// Only set group_name if API returns a non-empty value

--- a/rundeck/resource_job_framework.go
+++ b/rundeck/resource_job_framework.go
@@ -32,6 +32,67 @@ import (
 // UI, job references and documentation links all assume a UUID.
 var canonicalUUIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
+// jobIdentity picks the job's UUID from a response that may carry it under
+// either key: Rundeck's toMap writes it to both "uuid" and "id".
+func jobIdentity(uuid, id string) string {
+	if uuid != "" {
+		return uuid
+	}
+	return id
+}
+
+// requiresReplaceOnUUIDChange decides the replacement and warns about it in one
+// place, so the two can never disagree.
+func requiresReplaceOnUUIDChange() planmodifier.String {
+	const description = "If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource."
+
+	return stringplanmodifier.RequiresReplaceIf(
+		func(ctx context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+			if req.ConfigValue.IsNull() {
+				return
+			}
+
+			prior := req.StateValue
+			if prior.IsNull() {
+				// State written before this attribute existed records the job's
+				// UUID under id alone.
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &prior)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+			}
+
+			if req.ConfigValue.Equal(prior) {
+				return
+			}
+
+			resp.RequiresReplace = true
+
+			if req.ConfigValue.IsUnknown() {
+				resp.Diagnostics.AddAttributeWarning(
+					req.Path,
+					"Job UUID is not known until apply, so the job will be replaced",
+					"uuid resolves to a value that is only known at apply time, so Terraform cannot tell whether it differs from the job's current UUID and plans a replacement either way.\n\n"+
+						"Destroying the job takes its execution history with it and breaks every reference to it that lives outside Terraform. Pin uuid to a literal value to avoid this.",
+				)
+				return
+			}
+
+			resp.Diagnostics.AddAttributeWarning(
+				req.Path,
+				"Job UUID change replaces the job",
+				fmt.Sprintf("Changing uuid from %q to %q destroys this job and creates a new one under the new UUID.\n\n"+
+					"A job's UUID is how it is referenced outside Terraform: jobref blocks pointing at it by UUID (including in jobs this configuration does not manage), documentation and runbook links, and bookmarks all name the old UUID and will not follow the change. The job's execution history stays with the job being destroyed.\n\n"+
+					"Rundeck requires job UUIDs to be unique across the whole instance, so if %[2]q already belongs to another job the apply fails after this one has been destroyed.\n\n"+
+					"If the intent is to pin this job's current identity rather than change it, set uuid to %[1]q — that plans as no change.",
+					prior.ValueString(), req.ConfigValue.ValueString()),
+			)
+		},
+		description,
+		description,
+	)
+}
+
 type jobResource struct {
 	client *RundeckClients
 }
@@ -174,17 +235,13 @@ func (r *jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			// Set, the job's identity comes from the configuration, so the same
-			// Terraform rebuilds an instance with the same job UUIDs. Unset, it is
-			// computed from the server as before.
 			"uuid": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
 				Description: "Job UUID. Set it to pin the job's identity across rebuilds of a Rundeck instance; leave it unset to let Rundeck generate one. Changing a configured value replaces the job.",
 				PlanModifiers: []planmodifier.String{
-					// The attribute being computed, only a configured change may replace.
-					stringplanmodifier.RequiresReplaceIfConfigured(),
-					stringplanmodifier.UseStateForUnknown(),
+					requiresReplaceOnUUIDChange(),
+					stringplanmodifier.UseNonNullStateForUnknown(),
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
@@ -600,40 +657,6 @@ func (r *jobResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 	}
 }
 
-// ModifyPlan warns when a configured uuid change is about to replace the job.
-// The replacement itself is visible in the plan; what it costs is not, since a
-// job's UUID is referenced from outside this state file.
-func (r *jobResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Nothing to compare while creating or destroying.
-	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
-		return
-	}
-
-	var stateUUID, configUUID types.String
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("uuid"), &stateUUID)...)
-	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("uuid"), &configUUID)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Unconfigured, the uuid keeps whatever the server assigned: not a change.
-	if configUUID.IsNull() || configUUID.IsUnknown() || stateUUID.IsNull() {
-		return
-	}
-	if configUUID.Equal(stateUUID) {
-		return
-	}
-
-	resp.Diagnostics.AddAttributeWarning(
-		path.Root("uuid"),
-		"Job UUID change replaces the job",
-		fmt.Sprintf("Changing uuid from %q to %q destroys this job and creates a new one under the new UUID.\n\n"+
-			"A job's UUID is how it is referenced outside Terraform: jobref blocks pointing at it by UUID (including in jobs this configuration does not manage), documentation and runbook links, and bookmarks all name the old UUID and will not follow the change. The job's execution history stays with the job being destroyed.\n\n"+
-			"If the intent is to pin this job's current identity rather than change it, set uuid to %q — that plans as no change.",
-			stateUUID.ValueString(), configUUID.ValueString(), stateUUID.ValueString()),
-	)
-}
-
 func (r *jobResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan jobResourceModel
 
@@ -641,6 +664,8 @@ func (r *jobResource) Create(ctx context.Context, req resource.CreateRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	requestedUUID := plan.UUID
 
 	// Convert Terraform model to Rundeck JSON format
 	jobData, err := r.planToJobJSON(ctx, &plan)
@@ -752,10 +777,11 @@ func (r *jobResource) Create(ctx context.Context, req resource.CreateRequest, re
 		if errorMsg == "" {
 			errorMsg = importResult.Failed[0].Message
 		}
-		resp.Diagnostics.AddError(
-			"Error creating job",
-			fmt.Sprintf("Job import failed: %s\nFull response: %s", errorMsg, string(responseBody)),
-		)
+		detail := fmt.Sprintf("Job import failed: %s\nFull response: %s", errorMsg, string(responseBody))
+		if pinned := requestedUUID.ValueString(); pinned != "" {
+			detail += fmt.Sprintf("\n\nThis job pins uuid %q, and Rundeck requires job UUIDs to be unique across the whole instance. If a job already holds it — left behind by a lost state file, or still alive under create_before_destroy — adopt it with `terraform import` instead of creating it.", pinned)
+		}
+		resp.Diagnostics.AddError("Error creating job", detail)
 		return
 	}
 
@@ -802,7 +828,17 @@ func (r *jobResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	// State is written either way: the job exists in Rundeck, and leaving it out
+	// of state would orphan it.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+
+	if pinned := requestedUUID.ValueString(); pinned != "" && plan.ID.ValueString() != pinned {
+		resp.Diagnostics.AddError(
+			"Rundeck did not preserve the configured job UUID",
+			fmt.Sprintf("The configuration pinned uuid %q, but Rundeck created the job as %q.\n\n"+
+				"The job exists under the UUID Rundeck chose and has been recorded in state under it. Import requires API v46+ with uuidOption=preserve, which this provider sends; a server that ignores it cannot pin job UUIDs.", pinned, plan.ID.ValueString()),
+		)
+	}
 }
 
 func (r *jobResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -859,14 +895,6 @@ func (r *jobResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		)
 		return
 	}
-
-	// Target the existing job by its UUID. Rundeck resolves the job to update
-	// from "uuid" first and only falls back to name + group + project, and that
-	// fallback needs the name to match exactly one job — so without the UUID a
-	// rename creates a second job and leaves the original orphaned, and two
-	// jobs sharing a name can never be updated at all.
-	jobData.ID = plan.ID.ValueString()
-	jobData.UUID = plan.ID.ValueString()
 
 	// Marshal to JSON
 	jobJSON, err := json.Marshal([]interface{}{jobData})
@@ -1095,10 +1123,11 @@ func (r *jobResource) planToJobJSON(ctx context.Context, plan *jobResourceModel)
 		ScheduleEnabled:        plan.ScheduleEnabled.ValueBool(),
 	}
 
-	// "uuid" is the field the import reads back and that uuidOption=preserve acts
-	// on; omitted, the server mints one.
-	if !plan.UUID.IsNull() && !plan.UUID.IsUnknown() {
-		job.UUID = plan.UUID.ValueString()
+	// "uuid" is the only identifier the import reads back, so it both targets an
+	// existing job and pins a new one. Empty on create, where Rundeck mints one.
+	job.UUID = plan.UUID.ValueString()
+	if plan.UUID.IsNull() || plan.UUID.IsUnknown() {
+		job.UUID = plan.ID.ValueString()
 	}
 
 	if !plan.AllowConcurrentExecutions.IsNull() {
@@ -1305,7 +1334,7 @@ func (r *jobResource) planToJobJSON(ctx context.Context, plan *jobResourceModel)
 // jobJSONToState converts Rundeck job JSON to Terraform state
 func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *jobResourceModel) error {
 	state.ID = types.StringValue(job.ID)
-	state.UUID = types.StringValue(job.ID)
+	state.UUID = types.StringValue(jobIdentity(job.UUID, job.ID))
 	state.Name = types.StringValue(job.Name)
 	state.GroupName = types.StringValue(job.Group)
 	// Project name is not returned by JobGet API, preserve from current state
@@ -1461,8 +1490,11 @@ func (r *jobResource) jobJSONToState(ctx context.Context, job *jobJSON, state *j
 // jobJSONAPIToState converts API JSON response to Terraform state
 func (r *jobResource) jobJSONAPIToState(ctx context.Context, job *JobJSON, state *jobResourceModel) error {
 	// Map JSON fields directly to Terraform state
-	state.ID = types.StringValue(job.ID)
-	state.UUID = types.StringValue(job.ID)
+	identity := jobIdentity(job.UUID, job.ID)
+	if identity != "" {
+		state.ID = types.StringValue(identity)
+		state.UUID = types.StringValue(identity)
+	}
 	state.Name = types.StringValue(job.Name)
 
 	// Only set group_name if API returns a non-empty value

--- a/rundeck/resource_job_settable_uuid_test.go
+++ b/rundeck/resource_job_settable_uuid_test.go
@@ -1,0 +1,135 @@
+package rundeck
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// A configured uuid must reach the payload's "uuid" field: that is the one the
+// import reads back, and the one uuidOption=preserve acts on.
+func TestPlanToJobJSON_carriesConfiguredUUID(t *testing.T) {
+	const want = "11111111-2222-3333-4444-555555555555"
+
+	r := &jobResource{}
+	job, err := r.planToJobJSON(context.Background(), &jobResourceModel{
+		Name:        types.StringValue("test-job"),
+		ProjectName: types.StringValue("test-project"),
+		Command:     testSingleShellCommandList(t),
+		UUID:        types.StringValue(want),
+	})
+	if err != nil {
+		t.Fatalf("planToJobJSON: %v", err)
+	}
+
+	if job.UUID != want {
+		t.Errorf("uuid = %q, want %q", job.UUID, want)
+	}
+}
+
+// Unset, the uuid must stay out of the payload so Rundeck keeps assigning one.
+func TestPlanToJobJSON_omitsUnsetUUID(t *testing.T) {
+	r := &jobResource{}
+	job, err := r.planToJobJSON(context.Background(), &jobResourceModel{
+		Name:        types.StringValue("test-job"),
+		ProjectName: types.StringValue("test-project"),
+		Command:     testSingleShellCommandList(t),
+	})
+	if err != nil {
+		t.Fatalf("planToJobJSON: %v", err)
+	}
+
+	if job.UUID != "" {
+		t.Errorf("uuid = %q, want it empty so the field is omitted", job.UUID)
+	}
+}
+
+func TestCanonicalUUIDPattern(t *testing.T) {
+	cases := []struct {
+		value string
+		valid bool
+	}{
+		{"11111111-2222-3333-4444-555555555555", true},
+		{"6bf08fc5-835e-4dea-a83f-56953879b497", true},
+		{"6BF08FC5-835E-4DEA-A83F-56953879B497", false},
+		{"6bf08fc5835e4dea a83f56953879b497", false},
+		{"6bf08fc5-835e-4dea-a83f", false},
+		// Rundeck's own constraint would accept this; the provider does not.
+		{"deploy-prod-app1", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		if got := canonicalUUIDPattern.MatchString(tc.value); got != tc.valid {
+			t.Errorf("MatchString(%q) = %v, want %v", tc.value, got, tc.valid)
+		}
+	}
+}
+
+// The behavioural test: a configured uuid must be the job's actual UUID in
+// Rundeck, and stay so across a re-apply.
+func TestAccJob_configuredUUIDIsPreserved(t *testing.T) {
+	const want = "8c1d4e2a-7b93-4f61-95c8-2e0a6d3f7b14"
+
+	requireJobID := func(want string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			rs, ok := s.RootModule().Resources["rundeck_job.test"]
+			if !ok {
+				return fmt.Errorf("rundeck_job.test not found in state")
+			}
+			if rs.Primary.ID != want {
+				return fmt.Errorf("job id = %s, want %s (Rundeck did not preserve the configured uuid)",
+					rs.Primary.ID, want)
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccJobCheckDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobConfig_settableUUID,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rundeck_job.test", "uuid", want),
+					requireJobID(want),
+				),
+			},
+			{
+				Config:   testAccJobConfig_settableUUID,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+const testAccJobConfig_settableUUID = `
+resource "rundeck_project" "test" {
+  name        = "terraform-acc-test-job-uuid"
+  description = "Test project for settable job uuid"
+  resource_model_source {
+    type = "file"
+    config = {
+      format = "resourceyaml"
+      file   = "/tmp/terraform-acc-tests.yaml"
+    }
+  }
+}
+
+resource "rundeck_job" "test" {
+  project_name      = rundeck_project.test.name
+  uuid              = "8c1d4e2a-7b93-4f61-95c8-2e0a6d3f7b14"
+  name              = "job-with-pinned-uuid"
+  description       = "Job whose identity comes from the configuration"
+  execution_enabled = true
+  command {
+    shell_command = "echo hello"
+  }
+}
+`

--- a/rundeck/resource_job_settable_uuid_test.go
+++ b/rundeck/resource_job_settable_uuid_test.go
@@ -2,6 +2,7 @@ package rundeck
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"testing"
 
@@ -70,20 +71,33 @@ func TestCanonicalUUIDPattern(t *testing.T) {
 	}
 }
 
-// The behavioural test: a configured uuid must be the job's actual UUID in
-// Rundeck, and stay so across a re-apply.
+// TestAccJob_configuredUUIDIsPreserved covers the three things a pinned uuid
+// promises: Rundeck honours it on create, an update keeps the job under it, and
+// changing it replaces the job.
 func TestAccJob_configuredUUIDIsPreserved(t *testing.T) {
-	const want = "8c1d4e2a-7b93-4f61-95c8-2e0a6d3f7b14"
+	pinned, replacement := randomJobUUID(t), randomJobUUID(t)
 
-	requireJobID := func(want string) resource.TestCheckFunc {
+	requireJobID := func(want *string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
 			rs, ok := s.RootModule().Resources["rundeck_job.test"]
 			if !ok {
 				return fmt.Errorf("rundeck_job.test not found in state")
 			}
-			if rs.Primary.ID != want {
-				return fmt.Errorf("job id = %s, want %s (Rundeck did not preserve the configured uuid)",
-					rs.Primary.ID, want)
+			if rs.Primary.ID != *want {
+				return fmt.Errorf("job id = %s, want %s (Rundeck did not honour the configured uuid)",
+					rs.Primary.ID, *want)
+			}
+
+			clients, err := getTestClients()
+			if err != nil {
+				return fmt.Errorf("error getting test client: %s", err)
+			}
+			job, err := GetJobJSON(clients.V1, *want)
+			if err != nil {
+				return fmt.Errorf("job %s could not be read back from Rundeck: %s", *want, err)
+			}
+			if got := jobIdentity(job.UUID, job.ID); got != *want {
+				return fmt.Errorf("uuid in Rundeck = %s, want %s", got, *want)
 			}
 			return nil
 		}
@@ -95,21 +109,55 @@ func TestAccJob_configuredUUIDIsPreserved(t *testing.T) {
 		CheckDestroy:             testAccJobCheckDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobConfig_settableUUID,
+				Config: testAccJobConfig_settableUUID(pinned, "Job whose identity comes from the configuration"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("rundeck_job.test", "uuid", want),
-					requireJobID(want),
+					resource.TestCheckResourceAttr("rundeck_job.test", "uuid", pinned),
+					requireJobID(&pinned),
 				),
 			},
 			{
-				Config:   testAccJobConfig_settableUUID,
+				Config:   testAccJobConfig_settableUUID(pinned, "Job whose identity comes from the configuration"),
 				PlanOnly: true,
+			},
+			{
+				// Update with the uuid still pinned: the job must stay under it.
+				Config: testAccJobConfig_settableUUID(pinned, "Description changed while the uuid stays pinned"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rundeck_job.test", "description", "Description changed while the uuid stays pinned"),
+					resource.TestCheckResourceAttr("rundeck_job.test", "uuid", pinned),
+					requireJobID(&pinned),
+				),
+			},
+			{
+				// Changing the uuid replaces the job under the new one.
+				Config: testAccJobConfig_settableUUID(replacement, "Description changed while the uuid stays pinned"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rundeck_job.test", "uuid", replacement),
+					requireJobID(&replacement),
+				),
 			},
 		},
 	})
 }
 
-const testAccJobConfig_settableUUID = `
+// randomJobUUID keeps each run on its own UUID: Rundeck enforces uniqueness
+// instance-wide, so a literal would strand the next run behind any job a killed
+// run left behind.
+func randomJobUUID(t *testing.T) string {
+	t.Helper()
+
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("generating a uuid: %v", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+func testAccJobConfig_settableUUID(uuid, description string) string {
+	return fmt.Sprintf(`
 resource "rundeck_project" "test" {
   name        = "terraform-acc-test-job-uuid"
   description = "Test project for settable job uuid"
@@ -124,12 +172,13 @@ resource "rundeck_project" "test" {
 
 resource "rundeck_job" "test" {
   project_name      = rundeck_project.test.name
-  uuid              = "8c1d4e2a-7b93-4f61-95c8-2e0a6d3f7b14"
+  uuid              = %q
   name              = "job-with-pinned-uuid"
-  description       = "Job whose identity comes from the configuration"
+  description       = %q
   execution_enabled = true
   command {
     shell_command = "echo hello"
   }
 }
-`
+`, uuid, description)
+}

--- a/rundeck/resource_job_uuid_planmodifier_test.go
+++ b/rundeck/resource_job_uuid_planmodifier_test.go
@@ -1,0 +1,79 @@
+package rundeck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// State written before the uuid attribute existed records the job's UUID under
+// id alone. Pinning such a job to the UUID it already has must plan as no
+// change: treating the absent attribute as a difference would replace every job
+// in the estate, taking their execution history with them.
+func TestRequiresReplaceOnUUIDChange_priorStateWithoutUUID(t *testing.T) {
+	const jobUUID = "6bf08fc5-835e-4dea-a83f-56953879b497"
+
+	cases := []struct {
+		name            string
+		configured      string
+		wantReplace     bool
+		wantDiagnostics int
+	}{
+		{"pinned to the id already in state", jobUUID, false, 0},
+		{"pinned to a different uuid", "11111111-2222-3333-4444-555555555555", true, 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := planmodifier.StringRequest{
+				Path:        path.Root("uuid"),
+				ConfigValue: types.StringValue(tc.configured),
+				PlanValue:   types.StringValue(tc.configured),
+				StateValue:  types.StringNull(),
+				State:       testUUIDState(jobUUID, nil),
+				Plan:        tfsdk.Plan(testUUIDState(jobUUID, &tc.configured)),
+			}
+			resp := &planmodifier.StringResponse{}
+
+			requiresReplaceOnUUIDChange().PlanModifyString(context.Background(), req, resp)
+
+			if resp.RequiresReplace != tc.wantReplace {
+				t.Errorf("RequiresReplace = %v, want %v", resp.RequiresReplace, tc.wantReplace)
+			}
+			if got := len(resp.Diagnostics.Warnings()); got != tc.wantDiagnostics {
+				t.Errorf("warnings = %d, want %d — a replacement must always come with one", got, tc.wantDiagnostics)
+			}
+		})
+	}
+}
+
+func testUUIDState(id string, uuid *string) tfsdk.State {
+	objectType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"id":   tftypes.String,
+		"uuid": tftypes.String,
+	}}
+
+	uuidValue := tftypes.NewValue(tftypes.String, nil)
+	if uuid != nil {
+		uuidValue = tftypes.NewValue(tftypes.String, *uuid)
+	}
+
+	return tfsdk.State{
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"id":   schema.StringAttribute{Computed: true},
+				"uuid": schema.StringAttribute{Optional: true, Computed: true},
+			},
+		},
+		Raw: tftypes.NewValue(objectType, map[string]tftypes.Value{
+			"id":   tftypes.NewValue(tftypes.String, id),
+			"uuid": uuidValue,
+		}),
+	}
+}

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -69,7 +69,7 @@ resource "rundeck_job" "deploy_with_cleanup" {
   
   command {
     job {
-      uuid = rundeck_job.cleanup.id  # References by UUID - won't break if cleanup job renamed
+      uuid = rundeck_job.cleanup.uuid  # References by UUID - won't break if cleanup job renamed
     }
     description = "Run cleanup after deployment"
   }
@@ -219,7 +219,7 @@ resource "rundeck_job" "sequential_task" {
       }
     command {
       job {
-        uuid              = rundeck_job.git_pull.id  # uuid reference recommended
+        uuid              = rundeck_job.git_pull.uuid  # uuid reference recommended
         args              = "-environment_numbers $${data.environment_numbers}"
       }
     }
@@ -538,7 +538,7 @@ A command's `job` block has the following structure:
 
 **Job Identification (either uuid or name must be specified):**
 
-* `uuid`: (Optional) The UUID of the job to execute. **Recommended** for production use as UUIDs are immutable and will not break if the referenced job is renamed. You can reference another `rundeck_job` resource's `id` attribute (e.g., `uuid = rundeck_job.target.id`).
+* `uuid`: (Optional) The UUID of the job to execute. **Recommended** for production use as UUIDs are immutable and will not break if the referenced job is renamed. Reference another `rundeck_job` resource's `uuid` attribute (e.g., `uuid = rundeck_job.target.uuid`); its `id` holds the same value but is computed only, so it reads as `(known after apply)` while the referenced job is being created.
 
 * `name`: (Optional) The name of the job to execute. If no specific `project_name` was given the target job should be in the same project as the current job. Note that name-based references can break if the target job is renamed.
 
@@ -653,10 +653,14 @@ refers to a job by UUID — `jobref` blocks, documentation and runbook links, bo
 points at a job that no longer exists. Setting `uuid` moves that identity into the
 configuration, so a rebuild reproduces it:
 
+Generate your own UUID for each job — `uuidgen`, or a `random_uuid` resource — and commit it.
+Rundeck requires job UUIDs to be unique across the whole instance, so a value copied from this
+page collides with every other job that copied it.
+
 ```hcl
 resource "rundeck_job" "deploy" {
   project_name = rundeck_project.main.name
-  uuid         = "8c1d4e2a-7b93-4f61-95c8-2e0a6d3f7b14"
+  uuid         = "REPLACE-WITH-YOUR-OWN-UUID"
   name         = "deploy-application"
   description  = "Deploy the application"
 
@@ -674,12 +678,25 @@ it into the configuration:
 
 ```bash
 terraform show -json \
-  | jq -r '.values.root_module.resources[]
+  | jq -r '[.values.root_module | recurse(.child_modules[]?) | .resources[]?]
+           | .[]
            | select(.type == "rundeck_job")
-           | "\(.address)\t\(.values.id)"'
+           | "\(.address)\t\(.values.uuid)"'
 ```
 
+The `recurse` is what reaches jobs declared inside modules; a filter rooted at
+`.values.root_module.resources` alone would silently skip them and pin only part of the estate.
+
 Then re-run `terraform plan` and confirm it reports no changes before applying.
+
+Jobs whose UUID is not a canonical lowercase UUID cannot be pinned: Rundeck accepts a wider
+set of identifiers than this provider validates. Such a job keeps working — `uuid` is read back
+into state either way — it simply cannot be written into the configuration.
+
+Note also that `terraform plan -generate-config-out` emits a `uuid` line for every job it
+generates, since the attribute always has a value in state. Those jobs are then pinned, and
+each generated `uuid` is governed by the replacement rule below. Delete the lines you did not
+mean to pin.
 
 ### Changing a UUID
 
@@ -693,12 +710,20 @@ Removing `uuid` from the configuration is not a change — the job keeps the UUI
 
 Rundeck requires job UUIDs to be unique across the whole instance, not per project, so an
 apply that would collide with an existing job's UUID fails rather than creating a duplicate.
+Under `create_before_destroy`, or after a lost state file, that collision can be with the job
+being replaced or with one this configuration no longer tracks; adopt it with
+`terraform import` rather than letting the create retry.
 
 ## Attributes Reference
 
-The following attribute is exported:
+The following attributes are exported:
 
-* `id` - A unique identifier for the job. Always equal to `uuid`.
+* `uuid` - The job's UUID. Readable whether or not it was configured, and known at plan time
+  when it was — prefer it over `id` when referencing the job from another resource.
+
+* `id` - The same value as `uuid`. Computed only, so on creation it is `(known after apply)`
+  even when `uuid` is pinned: a `jobref` written as `rundeck_job.x.id` therefore makes the
+  referring job's plan unknown, where `rundeck_job.x.uuid` stays known.
 
 ## Import
 

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -280,6 +280,12 @@ The following arguments are supported:
 
 * `project_name` - (Required) The name of the project that this job should belong to.
 
+* `uuid` - (Optional) The job's UUID, which is its identity in Rundeck. Left unset, Rundeck
+  generates one on create and it is recorded in state — the default, and unchanged behaviour.
+  Set it to a canonical lowercase UUID to make the identity come from the configuration
+  instead, so that rebuilding a Rundeck instance from the same Terraform reproduces the same
+  job UUIDs. See [Pinning a job's UUID](#pinning-a-jobs-uuid) below.
+
 * `execution_enabled` - (Optional) If you want job execution to be enabled or disabled. Defaults to `true`.
 
 * `default_tab` - (Optional) The default tab to show during job execution. Set to 'output' to follow the execution log. Must be set to `output`, `html`, or `nodes`
@@ -638,11 +644,61 @@ A notification's `plugin` list element has the following structure:
 * `type` - (Required) The name of the execution lifecycle plugin to use. Must match an installed plugin type in Rundeck.
 
 * `config` - (Optional) Map of arbitrary configuration properties for the selected plugin. The available configuration options depend on the specific plugin being used.
+
+## Pinning a job's UUID
+
+By default Rundeck assigns a job's UUID when the job is created, so rebuilding an instance
+from the same Terraform produces different UUIDs than the instance it replaces. Anything that
+refers to a job by UUID — `jobref` blocks, documentation and runbook links, bookmarks — then
+points at a job that no longer exists. Setting `uuid` moves that identity into the
+configuration, so a rebuild reproduces it:
+
+```hcl
+resource "rundeck_job" "deploy" {
+  project_name = rundeck_project.main.name
+  uuid         = "8c1d4e2a-7b93-4f61-95c8-2e0a6d3f7b14"
+  name         = "deploy-application"
+  description  = "Deploy the application"
+
+  command {
+    shell_command = "deploy.sh"
+  }
+}
+```
+
+### Pinning jobs that already exist
+
+Setting `uuid` to the value a job already has plans as no change, so an existing estate can be
+pinned in place without recreating anything. Read each job's current UUID from state and write
+it into the configuration:
+
+```bash
+terraform show -json \
+  | jq -r '.values.root_module.resources[]
+           | select(.type == "rundeck_job")
+           | "\(.address)\t\(.values.id)"'
+```
+
+Then re-run `terraform plan` and confirm it reports no changes before applying.
+
+### Changing a UUID
+
+Changing a `uuid` that is already set replaces the job: Rundeck has no way to renumber a job
+in place, so the existing one is destroyed and a new one created under the new UUID. The plan
+shows the replacement and the provider emits a warning, because the references that break are
+outside Terraform's state and it cannot show them. The job's execution history stays with the
+destroyed job.
+
+Removing `uuid` from the configuration is not a change — the job keeps the UUID it has.
+
+Rundeck requires job UUIDs to be unique across the whole instance, not per project, so an
+apply that would collide with an existing job's UUID fails rather than creating a duplicate.
+
 ## Attributes Reference
 
 The following attribute is exported:
 
-* `id` - A unique identifier for the job.
+* `id` - A unique identifier for the job. Always equal to `uuid`.
 
 ## Import
 


### PR DESCRIPTION
## The problem

Rebuild a Rundeck instance from the same Terraform and every job comes back under a different UUID. Everything that names a job by UUID from outside Terraform then points at a job that no longer exists: `jobref` blocks in jobs this configuration does not manage, `rundeck_webhook.job_id`, runbook and documentation links, bookmarks, saved searches.

For anyone who treats a Rundeck instance as reproducible — DR rehearsals, promoting a tested definition from staging to production, rebuilding after an incident — the definitions restore correctly and every reference to them breaks. There is no way to express "this job, the same one, on the rebuilt instance".

The provider had no way to supply a UUID: the create payload carried none, so the server minted one every time. The create path already sent `uuidOption=preserve`, so there was simply nothing in the payload for it to preserve.

## What this adds

`uuid` on `rundeck_job`, `Optional` + `Computed`:

- **Left unset** it is read back from the server exactly as before. Existing configurations are unaffected and no state migration is needed.
- **Set**, it must be a canonical lowercase UUID and travels in the payload's `uuid` field — the one Rundeck reads back on import (`ScheduledExecution.fromMap`) and the one `uuidOption=preserve` acts on.

## Adoption is a no-op

This is the part that matters for an existing estate. Setting `uuid` to the value a job **already has** plans as no change, so a whole estate can be pinned in place without recreating anything:

```bash
terraform show -json \
  | jq -r '[.values.root_module | recurse(.child_modules[]?) | .resources[]?]
           | .[] | select(.type == "rundeck_job") | "\(.address)\t\(.values.uuid)"'
```

Write those values into the configuration, confirm `terraform plan` reports no changes, and from then on a rebuild reproduces the same UUIDs.

That holds for state written before this attribute existed too, where the job's UUID is recorded under `id` alone: the plan modifier compares against `id` when `uuid` is absent from state, so the first plan after upgrading is not a mass replacement. `TestRequiresReplaceOnUUIDChange_priorStateWithoutUUID` covers both halves of that — removing the fallback fails it.

## Changing a pinned UUID

Changing a `uuid` that is already set replaces the job, since Rundeck cannot renumber one in place. The decision and its warning come from the same plan modifier (`RequiresReplaceIfFuncResponse` carries `Diagnostics`), so a replacement can never be planned without the warning that explains what it costs — including that instance-wide uniqueness means the apply can fail *after* the original has been destroyed if the new UUID is taken.

Removing `uuid` from a configuration is not a change: the job keeps the UUID it has.

## Failure modes made explicit

- Rundeck constrains job UUIDs to be unique across the whole instance, not per project (`ScheduledExecution.uuid(unique: true)`). A create whose pinned UUID is taken fails instead of silently producing a duplicate under a fresh UUID — after a lost state file, or under `create_before_destroy` while the job being replaced still holds it. The error says so and points at `terraform import`.
- A server that does not honour the pinned UUID is reported as such rather than surfacing as `Provider produced inconsistent result after apply`, and the job is still recorded in state so it is not orphaned.

## Testing

`TestAccJob_configuredUUIDIsPreserved` runs against a real Rundeck and covers create, update with the UUID still pinned, and replacement on change — the repository checklist's "both create and update scenarios". It generates its UUID per run, since a literal would strand every later run behind whatever a killed run left in the instance.

Unit tests cover the payload mapping, the omission when unset, the format validator, and the prior-state fallback above.

Verified green in CI against Rundeck 5.x, alongside `go build`, `gofmt` and `go vet`.

## Note on prior art

[#261](https://github.com/rundeck/terraform-provider-rundeck/pull/261) proposed a settable `uuid` in June 2026 and was closed with "we are moving away from supporting this functionality in future versions". I could not find what that refers to — nothing in the TODO, the changelog or the docs describes an alternative, and the v2 OpenAPI client still reaches jobs only through `/project/{project}/jobs/import` with `uuidOption`.

If there is a direction that makes this unnecessary, I would genuinely rather hear it than carry a patch: the need is reproducible job identity across a rebuilt instance, and I am not attached to this particular shape of it. If the objection was to exposing the UUID as configuration specifically, note that #286 already established the UUID as the job's identity on the wire — this only lets that identity be declared rather than discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwXPD3tGmAmSdkRa9AxqaZ